### PR TITLE
Change Kotlin stdlib-jre8 to Kotlin stdlib-jdk8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
   <dependencies>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
-      <artifactId>kotlin-stdlib-jre8</artifactId>
+      <artifactId>kotlin-stdlib-jdk8</artifactId>
       <version>${kotlin.version}</version>
     </dependency>
     <dependency>


### PR DESCRIPTION
Since Kotlin 1.2 for full support for Java 9, Kotlin now introduces `kotlin-stdlib-jdk8` to replace `kotlin-stdlib-jre8`.

See http://kotlinlang.org/docs/reference/whatsnew12.html#kotlin-standard-library-artifacts-and-split-packages