### PR TITLE
Bump Kotlin version. Fix deprecated stdlib dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <kotlin.version>1.2.20</kotlin.version>
+    <kotlin.version>1.2.41</kotlin.version>
     <kotlin.coroutines.version>0.21.2</kotlin.coroutines.version>
     <junit.version>4.12</junit.version>
     <stack.version>3.5.2-SNAPSHOT</stack.version>
@@ -41,7 +41,7 @@
   <dependencies>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
-      <artifactId>kotlin-stdlib-jre8</artifactId>
+      <artifactId>kotlin-stdlib-jdk8</artifactId>
       <version>${kotlin.version}</version>
     </dependency>
     <dependency>

--- a/vertx-lang-kotlin-coroutines/pom.xml
+++ b/vertx-lang-kotlin-coroutines/pom.xml
@@ -15,7 +15,7 @@
   <dependencies>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
-      <artifactId>kotlin-stdlib-jre8</artifactId>
+      <artifactId>kotlin-stdlib-jdk8</artifactId>
       <version>${kotlin.version}</version>
     </dependency>
     <dependency>


### PR DESCRIPTION
The Kotlin version has been bumped from 1.2.20 to 1.2.41

The dependency on kotlin-stdlib-jre-8 has been changed to
kotlin-stdlib-jdk-8. The previous dependency was deprecated and was
changed in all other pom.xml files except for in the
vertx-lang-kotlin-coroutines directory.

The hardcoded dependency on 1.2.20 in vertx-lang-kotlin has been
changed to use the `kotlin.version` variable set in the root pom.xml
This is consistent with the pom.xml files in the other subdirectories