### PR TITLE
Bump Kotlin version. Fix deprecated stdlib dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <kotlin.version>1.2.20</kotlin.version>
+    <kotlin.version>1.2.41</kotlin.version>
     <kotlin.coroutines.version>0.21.2</kotlin.coroutines.version>
     <junit.version>4.12</junit.version>
     <stack.version>3.6.0-SNAPSHOT</stack.version>

--- a/vertx-lang-kotlin-coroutines/pom.xml
+++ b/vertx-lang-kotlin-coroutines/pom.xml
@@ -15,7 +15,7 @@
   <dependencies>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
-      <artifactId>kotlin-stdlib-jre8</artifactId>
+      <artifactId>kotlin-stdlib-jdk8</artifactId>
       <version>${kotlin.version}</version>
     </dependency>
     <dependency>

--- a/vertx-lang-kotlin/pom.xml
+++ b/vertx-lang-kotlin/pom.xml
@@ -22,7 +22,7 @@
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib-jdk8</artifactId>
-      <version>1.2.20</version>
+      <version>${kotlin.version}</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
@@ -39,7 +39,7 @@
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-test-junit</artifactId>
-      <version>1.2.20</version>
+      <version>${kotlin.version}</version>
       <scope>test</scope>
     </dependency>
 
@@ -91,7 +91,7 @@
       <plugin>
         <artifactId>kotlin-maven-plugin</artifactId>
         <groupId>org.jetbrains.kotlin</groupId>
-        <version>1.2.20</version>
+        <version>${kotlin.version}</version>
         <configuration>
           <jvmTarget>1.8</jvmTarget>
         </configuration>


### PR DESCRIPTION
I wasn't able to test this since everything points at 3.6.0

I did test this in #56 when targeting 3.5.2