### PR TITLE
Fix to allow instants and byte[] to be used via kotlin extension

### DIFF
--- a/vertx-lang-kotlin/src/main/java/io/vertx/kotlin/core/json/json.kt
+++ b/vertx-lang-kotlin/src/main/java/io/vertx/kotlin/core/json/json.kt
@@ -1,12 +1,29 @@
 package io.vertx.kotlin.core.json
 
 import io.vertx.core.json.*
+import java.time.Instant
+import java.time.format.DateTimeFormatter
+import java.util.*
 
 object Json
 
 // JsonObject creation
 
-fun JsonObject(vararg fields: Pair<String, Any?>): JsonObject = JsonObject(linkedMapOf(*fields))
+fun JsonObject(vararg fields: Pair<String, Any?>): JsonObject {
+    val processedCases = fields.map {
+        when {
+            // @See io.vertx.core.json.JsonObject.put(java.lang.String, java.time.Instant)
+            it.second is Instant -> return@map (Pair(it.first, DateTimeFormatter.ISO_INSTANT.format(it.second as Instant)))
+            // @See   io.vertx.core.json.JsonObject.put(java.lang.String, byte[])
+            it.second is ByteArray -> return@map(Pair(it.first, Base64.getEncoder().encodeToString(it.second as ByteArray)))
+            else -> return@map it
+        }
+
+    }.toTypedArray()
+
+    return JsonObject(linkedMapOf(*processedCases))
+}
+
 fun Json.obj(vararg fields: Pair<String, Any?>): JsonObject = JsonObject(*fields)
 fun Json.obj(fields: Iterable<Pair<String, Any?>>): JsonObject = JsonObject(*fields.toList().toTypedArray())
 fun Json.obj(fields: Map<String, Any?>): JsonObject = JsonObject(fields)

--- a/vertx-lang-kotlin/src/test/kotlin/io/vertx/lang/kotlin/test/JsonTest.kt
+++ b/vertx-lang-kotlin/src/test/kotlin/io/vertx/lang/kotlin/test/JsonTest.kt
@@ -8,6 +8,7 @@ import io.vertx.kotlin.core.json.*
 import io.vertx.kotlin.core.streams.*
 import io.vertx.kotlin.core.buffer.*
 import org.junit.Test
+import java.time.Instant
 import java.util.*
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.test.*
@@ -17,15 +18,15 @@ class JsonTest {
   fun smoke() {
     val result = json {
       obj(
-          "a" to array(1, 2, 3),
-          "obj" to obj("b1" to 1, "b2" to "2"),
-          "imperative-loop" to obj {
-            for (i in 1..3) {
-              put("k_$i", i)
-            }
-          },
-          "map" to obj((1..3).map { "k_$it" to it }),
-          "d" to "d"
+        "a" to array(1, 2, 3),
+        "obj" to obj("b1" to 1, "b2" to "2"),
+        "imperative-loop" to obj {
+          for (i in 1..3) {
+            put("k_$i", i)
+          }
+        },
+        "map" to obj((1..3).map { "k_$it" to it }),
+        "d" to "d"
       )
     }
 
@@ -47,14 +48,14 @@ class JsonTest {
   fun testArrays() {
     val result = json {
       array(
-          array(1, 2, 3),
-          array(listOf(4, 5, 6)),
-          array(setOf(7)),
-          array {
-            for (i in 8..10) {
-              add(i)
-            }
+        array(1, 2, 3),
+        array(listOf(4, 5, 6)),
+        array(setOf(7)),
+        array {
+          for (i in 8..10) {
+            add(i)
           }
+        }
       )
     }
 
@@ -87,7 +88,7 @@ class JsonTest {
       obj("k" to "v")
     }
     assertEquals("{\"k\":\"v\"}", b.toString(Charsets.UTF_8))
-    val c = Buffer.buffer().appendJson{ User("Julien", "Viet") }
+    val c = Buffer.buffer().appendJson { User("Julien", "Viet") }
     assertEquals("{\"firstName\":\"Julien\",\"lastName\":\"Viet\"}", c.toString(Charsets.UTF_8))
     val d = Buffer.buffer().appendJson(true, { User("Julien", "Viet") })
     assertEquals("{\n  \"firstName\" : \"Julien\",\n  \"lastName\" : \"Viet\"\n}", d.toString(Charsets.UTF_8))
@@ -147,7 +148,7 @@ class JsonTest {
   fun testInferenceObj() {
     val arr = json {
       array(obj(
-          "foo" to "foo_value"
+        "foo" to "foo_value"
       ))
     }
 
@@ -167,4 +168,38 @@ class JsonTest {
     assertEquals(1, subArray.getInteger(0))
   }
 
+  @Test
+  fun testInstantProcessing() {
+    val expected = Instant.now()
+    val json = JsonObject("time" to expected)
+
+    val actual = json.getInstant("time")
+
+    assertEquals(expected, actual)
+  }
+
+  @Test
+  fun testByteArrayProcessing() {
+    val expected = ByteArray(3)
+    expected.set(0, 0)
+    expected.set(1, 1)
+    expected.set(2, 2)
+    val json = JsonObject("bytes" to expected)
+
+    val actual = json.getBinary("bytes")
+
+    assertEquals(expected[0], actual[0])
+    assertEquals(expected[1], actual[1])
+    assertEquals(expected[2], actual[2])
+  }
+
+  @Test
+  fun testNormalProcessing() {
+    val expected = "A Value"
+    val json = JsonObject("key" to expected)
+
+    val actual = json.getString("key")
+
+    assertEquals(expected, actual)
+  }
 }


### PR DESCRIPTION
Hello all,

I found a bug in the extension for JsonObject a while ago and I wanted to provide the fix for anyone else who might be using this library. 

The bug is caused by not performing the same type conversions that put method does for the types Instant and byte[].  Which prevents you from retrieving the data when trying to access it from the getter.

I have provided four units that cover the section of code that I modified so you can see that it works!

Let me know if I need to update anything or if you have any feedback!
Best Regards,
Tim