### PR TITLE
 Backport #60 to 3.5.3 

### DIFF
--- a/vertx-lang-kotlin/src/main/java/io/vertx/kotlin/core/json/json.kt
+++ b/vertx-lang-kotlin/src/main/java/io/vertx/kotlin/core/json/json.kt
@@ -1,12 +1,27 @@
 package io.vertx.kotlin.core.json
 
 import io.vertx.core.json.*
+import java.time.Instant
+import java.time.format.DateTimeFormatter
+import java.util.*
 
 object Json
 
 // JsonObject creation
+fun JsonObject(vararg fields: Pair<String, Any?>): JsonObject {
+  val processedCases = fields.map {
+    when {
+    // @See io.vertx.core.json.JsonObject.put(java.lang.String, java.time.Instant)
+      it.second is Instant -> return@map (Pair(it.first, DateTimeFormatter.ISO_INSTANT.format(it.second as Instant)))
+    // @See   io.vertx.core.json.JsonObject.put(java.lang.String, byte[])
+      it.second is ByteArray -> return@map(Pair(it.first, Base64.getEncoder().encodeToString(it.second as ByteArray)))
+      else -> return@map it
+    }
 
-fun JsonObject(vararg fields: Pair<String, Any?>): JsonObject = JsonObject(linkedMapOf(*fields))
+  }.toTypedArray()
+
+  return JsonObject(linkedMapOf(*processedCases))
+}
 fun Json.obj(vararg fields: Pair<String, Any?>): JsonObject = JsonObject(*fields)
 fun Json.obj(fields: Iterable<Pair<String, Any?>>): JsonObject = JsonObject(*fields.toList().toTypedArray())
 fun Json.obj(fields: Map<String, Any?>): JsonObject = JsonObject(fields)

--- a/vertx-lang-kotlin/src/test/kotlin/io/vertx/lang/kotlin/test/JsonTest.kt
+++ b/vertx-lang-kotlin/src/test/kotlin/io/vertx/lang/kotlin/test/JsonTest.kt
@@ -8,6 +8,7 @@ import io.vertx.kotlin.core.json.*
 import io.vertx.kotlin.core.streams.*
 import io.vertx.kotlin.core.buffer.*
 import org.junit.Test
+import java.time.Instant
 import java.util.*
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.test.*
@@ -32,7 +33,40 @@ class JsonTest {
     assertTrue { result is JsonObject }
     assertEquals("""{"a":[1,2,3],"obj":{"b1":1,"b2":"2"},"imperative-loop":{"k_1":1,"k_2":2,"k_3":3},"map":{"k_1":1,"k_2":2,"k_3":3},"d":"d"}""", result.toString())
   }
+  @Test
+  fun testInstantProcessing() {
+    val expected = Instant.now()
+    val json = JsonObject("time" to expected)
 
+    val actual = json.getInstant("time")
+
+    assertEquals(expected, actual)
+  }
+
+  @Test
+  fun testByteArrayProcessing() {
+    val expected = ByteArray(3)
+    expected.set(0, 0)
+    expected.set(1, 1)
+    expected.set(2, 2)
+    val json = JsonObject("bytes" to expected)
+
+    val actual = json.getBinary("bytes")
+
+    assertEquals(expected[0], actual[0])
+    assertEquals(expected[1], actual[1])
+    assertEquals(expected[2], actual[2])
+  }
+
+  @Test
+  fun testNormalProcessing() {
+    val expected = "A Value"
+    val json = JsonObject("key" to expected)
+
+    val actual = json.getString("key")
+
+    assertEquals(expected, actual)
+  }
   @Test
   fun testMapToObj() {
     val result = json {


### PR DESCRIPTION
Previous pull request.
> Hello all,
> 
> I found a bug in the extension for JsonObject a while ago and I wanted to provide the fix for anyone else who might be using this library.
> 
> The bug is caused by not performing the same type conversions that put method does for the types Instant and byte[]. Which prevents you from retrieving the data when trying to access it from the getter.
> 
> I have provided four units that cover the section of code that I modified so you can see that it works!
> 
> Let me know if I need to update anything or if you have any feedback!
> Best Regards,
> Tim