### PR TITLE
Updated coroutines to 0.30.0 and removed (most of) deprecated code

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,8 +22,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <kotlin.coroutines.version>0.30.0</kotlin.coroutines.version>
-    <!-- latest version compatiable with coroutines lib -->
-    <kotlin.version>1.2.71</kotlin.version>
+    <!-- latest version compatible with coroutines lib -->
+    <kotlin.version>1.2.70</kotlin.version>
     <junit.version>4.12</junit.version>
     <stack.version>3.6.0-SNAPSHOT</stack.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <kotlin.coroutines.version>0.30.0</kotlin.coroutines.version>
     <!-- latest version compatiable with coroutines lib -->
-    <kotlin.version>1.2.70</kotlin.version>
+    <kotlin.version>1.2.71</kotlin.version>
     <junit.version>4.12</junit.version>
     <stack.version>3.6.0-SNAPSHOT</stack.version>
   </properties>

--- a/vertx-lang-kotlin-coroutines/src/main/asciidoc/index.adoc
+++ b/vertx-lang-kotlin-coroutines/src/main/asciidoc/index.adoc
@@ -24,12 +24,13 @@ its current kernel thread so that another coroutine can process events.
 
 `vertx-lang-kotlin-coroutines` uses https://github.com/Kotlin/kotlinx.coroutines[kotlinx.coroutines] to implement the Coroutines.
 
-NOTE: `vertx-lang-kotlin-coroutines` currently only works with Kotlin and is an https://kotlinlang.org/docs/reference/coroutines.html#experimental-status-of-coroutines[experimental] feature of Kotlin 1.1
+NOTE: `vertx-lang-kotlin-coroutines` currently only works with Kotlin and will be out of the https://kotlinlang.org/docs/reference/coroutines.html#experimental-status-of-coroutines[experimental] status
+in Kotlin 1.3
 
 == Running a coroutine from a Vert.x context
 
-Having imported `io.vertx.kotlin.coroutines.VertxCoroutine`, the `launch` (a coroutine builder) method allows running a block of code
-as a coroutine that can be suspended:
+Having imported `io.vertx.kotlin.coroutines.VertxCoroutine`, the `GlobalScope.launch` method allows to run a block of code as a
+coroutine in the "Global" application scope (bounded on the lifetime of the application):
 
 [source,kotlin,indent=0]
 ----
@@ -46,12 +47,17 @@ More details are given in the next sections on handlers, events and stream of ev
 == Extending CoroutineVerticle
 
 You can deploy your code as instances of `io.vertx.kotlin.coroutines.CoroutineVerticle`, a specialized type of verticle
-for Kotlin coroutines. You should override the `start()` and (optionally) the `stop()` methods of the verticle:
+for Kotlin coroutines. The `CoroutineVerticle` class implements the `kotlinx.coroutines.experimental.CoroutineScope` interface,
+making all coroutines builder methods bounded by default to the verticle context. You should override the suspending `start()`
+and (optionally) the suspending `stop()` methods of the verticle:
 
 [source,kotlin,indent=0]
 ----
 include::Example.kt[tags=CoroutineVerticle]
 ----
+
+All code examples below assume to be run inside a `CoroutineVerticle` implementation, but you can replace all `<builder> { .. }`
+calls with `GlobalScope.<builder> { .. }` to use the application scope instead.
 
 == Getting one-shot asynchronous results
 
@@ -180,21 +186,7 @@ Using a channel to send data is quite straightforward:
 
 [source,kotlin,indent=0]
 ----
-suspend fun sendChannel() {
-  val stream = vertx.eventBus().publisher<Double>("temperature")
-  val channel = stream.toChannel(vertx)
-
-  while (true) {
-    val temperature = readTemperatureSensor()
-
-    // Broadcast the temperature
-    // Non-blocking but could be suspended
-    channel.send(temperature)
-
-    // Wait for one second
-    awaitEvent<Long> { vertx.setTimer(1000, it)  }
-  }
-}
+include::Example.kt[tags=sendChannel]
 ----
 
 Both `SendChannel#send` and `WriteStream#write` are non blocking operations, however unlike `SendChannel#send`
@@ -232,12 +224,12 @@ include::Example.kt[tags=withTimeout]
 
 == Coroutine builders
 
-Vert.x works will all coroutine builders: `launch`, `async` and `runBlocking` . The `runBlocking` builder
-must not be used from a Vert.x event loop thread.
+Vert.x works will all coroutine builders, as long as an instance of `CoroutineScope` is available: `launch`, `async` and `runBlocking`.
+The `runBlocking` builder must not be used from a Vert.x event loop thread.
 
 == Coroutine interoperability
 
-Vertx integration has been designed to be fully interroperable with Kotlin coroutines
+Vertx integration has been designed to be fully interoperable with Kotlin coroutines
 
 * `kotlinx.coroutines.experimental.sync.Mutex` are executed on the event loop thread when using the vertx dispatcher
 

--- a/vertx-lang-kotlin-coroutines/src/main/java/examples/Example.kt
+++ b/vertx-lang-kotlin-coroutines/src/main/java/examples/Example.kt
@@ -1,3 +1,5 @@
+@file:Suppress("UNUSED")
+
 package examples
 
 import io.vertx.core.CompositeFuture
@@ -20,6 +22,7 @@ import io.vertx.kotlin.coroutines.receiveChannelHandler
 import io.vertx.kotlin.coroutines.toChannel
 import kotlinx.coroutines.experimental.TimeoutCancellationException
 import kotlinx.coroutines.experimental.channels.ReceiveChannel
+import kotlinx.coroutines.experimental.coroutineScope
 import kotlinx.coroutines.experimental.delay
 import kotlinx.coroutines.experimental.launch
 import kotlinx.coroutines.experimental.withTimeout
@@ -27,9 +30,10 @@ import kotlinx.coroutines.experimental.withTimeout
 fun launchCoroutineExample() {
   // tag::launchCoroutine[]
   val vertx = Vertx.vertx()
-  vertx.deployVerticle(ExampleVerticle())
+  val exampleVerticle = ExampleVerticle()
+  vertx.deployVerticle(exampleVerticle)
 
-  launch(vertx.dispatcher()) {
+  exampleVerticle.launch {
     val timerId = awaitEvent<Long> { handler ->
       vertx.setTimer(1000, handler)
     }
@@ -43,16 +47,23 @@ class MyVerticle : CoroutineVerticle() {
   override suspend fun start() {
     // ...
   }
+
+  override suspend fun stop() {
+    // ...
+  }
 }
 // end::CoroutineVerticle[]
 
 class ExampleVerticle : CoroutineVerticle() {
+
   override suspend fun start() {
-    awaitEventExample()
-    awaitResultExample()
-    streamExample()
-    handlerAndCoroutineExample()
-    awaitingFuture()
+    coroutineScope {
+      awaitEventExample()
+      awaitResultExample()
+      streamExample()
+      handlerAndCoroutineExample()
+      awaitingFuture()
+    }
   }
 
   // tag::awaitEvent[]
@@ -88,7 +99,7 @@ class ExampleVerticle : CoroutineVerticle() {
 
     // Send a message and wait for a reply
     try {
-      val reply = awaitResult<Message<String>> { h ->
+      awaitResult<Message<String>> { h ->
         vertx.eventBus().send("a.b.c", "ping", h)
       }
     } catch (e: ReplyException) {
@@ -145,7 +156,7 @@ class ExampleVerticle : CoroutineVerticle() {
   fun handlerAndCoroutineExample() {
     // tag::handlerAndCoroutine[]
     vertx.createHttpServer().requestHandler { req ->
-      launch(context.dispatcher()) {
+      launch {
         val timerID = awaitEvent<Long> { h -> vertx.setTimer(2000, h) }
         req.response().end("Hello, this is timerID $timerID after 2 seconds!")
       }
@@ -175,7 +186,7 @@ class ExampleVerticle : CoroutineVerticle() {
 
   private fun channel1() {
     // tag::channel1[]
-    val server = vertx.createNetServer().connectHandler { socket ->
+    vertx.createNetServer().connectHandler { socket ->
 
       // The record parser provides a stream of buffers delimited by \r\n
       val stream = RecordParser.newDelimited("\r\n", socket)
@@ -184,7 +195,7 @@ class ExampleVerticle : CoroutineVerticle() {
       val channel = stream.toChannel(vertx)
 
       // Run the coroutine
-      launch(vertx.dispatcher()) {
+      launch {
 
         // Receive the request-line
         // Non-blocking

--- a/vertx-lang-kotlin-coroutines/src/main/java/io/vertx/kotlin/coroutines/CoroutineVerticle.kt
+++ b/vertx-lang-kotlin-coroutines/src/main/java/io/vertx/kotlin/coroutines/CoroutineVerticle.kt
@@ -19,8 +19,8 @@ abstract class CoroutineVerticle : Verticle, CoroutineScope {
 
   private lateinit var vertxInstance: Vertx
   protected lateinit var context: Context
-  override val coroutineContext: CoroutineContext
-    get() = context.dispatcher()
+
+  override val coroutineContext: CoroutineContext by lazy { context.dispatcher() }
 
   override fun init(vertx: Vertx, context: Context) {
     this.vertxInstance = vertx

--- a/vertx-lang-kotlin-coroutines/src/main/java/io/vertx/kotlin/coroutines/CoroutineVerticle.kt
+++ b/vertx-lang-kotlin-coroutines/src/main/java/io/vertx/kotlin/coroutines/CoroutineVerticle.kt
@@ -10,10 +10,13 @@ import kotlinx.coroutines.experimental.launch
 import kotlin.coroutines.experimental.CoroutineContext
 
 /**
- * A Verticle which run its start and stop methods in coroutine.
- * You should subclass this class instead of AbstractVerticle to create any verticles that use vertx-kotlin-coroutine.
+ * A Verticle which run its start and stop methods in coroutine. By default, all child coroutines will have the
+ * verticle's [CoroutineScope] as the parent scope.
+ * You should subclass this class instead of AbstractVerticle to create any verticles that use
+ * vertx-kotlin-coroutine.
  *
  * @author <a href="http://www.streamis.me">Stream Liu</a>
+ * @author [Guido Pio Mariotti](https://github.com/gmariotti)
  */
 abstract class CoroutineVerticle : Verticle, CoroutineScope {
 

--- a/vertx-lang-kotlin-coroutines/src/main/java/io/vertx/kotlin/coroutines/CoroutineVerticle.kt
+++ b/vertx-lang-kotlin-coroutines/src/main/java/io/vertx/kotlin/coroutines/CoroutineVerticle.kt
@@ -5,7 +5,9 @@ import io.vertx.core.Future
 import io.vertx.core.Verticle
 import io.vertx.core.Vertx
 import io.vertx.core.json.JsonObject
+import kotlinx.coroutines.experimental.CoroutineScope
 import kotlinx.coroutines.experimental.launch
+import kotlin.coroutines.experimental.CoroutineContext
 
 /**
  * A Verticle which run its start and stop methods in coroutine.
@@ -13,10 +15,12 @@ import kotlinx.coroutines.experimental.launch
  *
  * @author <a href="http://www.streamis.me">Stream Liu</a>
  */
-abstract class CoroutineVerticle : Verticle {
+abstract class CoroutineVerticle : Verticle, CoroutineScope {
 
   private lateinit var vertxInstance: Vertx
   protected lateinit var context: Context
+  override val coroutineContext: CoroutineContext
+    get() = context.dispatcher()
 
   override fun init(vertx: Vertx, context: Context) {
     this.vertxInstance = vertx
@@ -26,7 +30,7 @@ abstract class CoroutineVerticle : Verticle {
   override fun getVertx(): Vertx = vertxInstance
 
   override fun start(startFuture: Future<Void>?) {
-    launch(context.dispatcher()) {
+    launch {
       try {
         start()
         startFuture?.complete()
@@ -37,7 +41,7 @@ abstract class CoroutineVerticle : Verticle {
   }
 
   override fun stop(stopFuture: Future<Void>?) {
-    launch(context.dispatcher()) {
+    launch {
       try {
         stop()
         stopFuture?.complete()
@@ -62,7 +66,7 @@ abstract class CoroutineVerticle : Verticle {
    * This can be specified when the verticle is deployed.
    * @return the configuration
    */
-  protected val config : JsonObject by lazy {
+  protected val config: JsonObject by lazy {
     context.config()
   }
 
@@ -70,7 +74,7 @@ abstract class CoroutineVerticle : Verticle {
    * Get the arguments used when deploying the Vert.x process.
    * @return the list of arguments
    */
-  protected val processArgs : List<String> by lazy {
+  protected val processArgs: List<String> by lazy {
     context.processArgs()
   }
 

--- a/vertx-lang-kotlin-coroutines/src/main/java/io/vertx/kotlin/coroutines/VertxCoroutine.kt
+++ b/vertx-lang-kotlin-coroutines/src/main/java/io/vertx/kotlin/coroutines/VertxCoroutine.kt
@@ -199,7 +199,11 @@ class ReceiveChannelHandler<T> constructor(context: Context) : ReceiveChannel<T>
   }
 
   override fun cancel(cause: Throwable?): Boolean {
-    TODO("not implemented")
+    return channel.cancel(cause)
+  }
+
+  override fun cancel(): Boolean {
+    return this.cancel(null)
   }
 }
 

--- a/vertx-lang-kotlin-coroutines/src/main/java/io/vertx/kotlin/coroutines/VertxCoroutine.kt
+++ b/vertx-lang-kotlin-coroutines/src/main/java/io/vertx/kotlin/coroutines/VertxCoroutine.kt
@@ -194,10 +194,6 @@ class ReceiveChannelHandler<T> constructor(context: Context) : ReceiveChannel<T>
     handler?.handle(event)
   }
 
-  override fun cancel(): Boolean {
-    TODO("not implemented")
-  }
-
   override fun cancel(cause: Throwable?): Boolean {
     return channel.cancel(cause)
   }

--- a/vertx-lang-kotlin-coroutines/src/test/kotlin/io/vertx/kotlin/coroutines/RxTest.kt
+++ b/vertx-lang-kotlin-coroutines/src/test/kotlin/io/vertx/kotlin/coroutines/RxTest.kt
@@ -3,6 +3,7 @@ package io.vertx.kotlin.coroutines
 import io.vertx.ext.unit.TestContext
 import io.vertx.ext.unit.junit.VertxUnitRunner
 import io.vertx.reactivex.core.Vertx
+import kotlinx.coroutines.experimental.GlobalScope
 import kotlinx.coroutines.experimental.launch
 import kotlinx.coroutines.experimental.reactive.openSubscription
 import kotlinx.coroutines.experimental.rx2.await
@@ -30,11 +31,12 @@ class RxTest {
   }
 
   @Test
-  fun testFlowable(testContext: TestContext) {
+  fun `test flowable`(testContext: TestContext) {
     val async = testContext.async()
     val source = vertx.eventBus().consumer<Long>("the-address").toFlowable()
     val latch = testContext.async()
-    launch(vertx.delegate.dispatcher()) {
+
+    GlobalScope.launch(vertx.delegate.dispatcher()) {
       val channel = source.openSubscription()
       latch.complete()
       var cnt = 0
@@ -53,10 +55,13 @@ class RxTest {
   }
 
   @Test
-  fun testAwait(testContext: TestContext) {
+  fun `test await`(testContext: TestContext) {
     val async = testContext.async()
-    val single = vertx.createHttpServer().requestHandler({ req -> req.response().end("hello") }).rxListen(8080)
-    launch(vertx.delegate.dispatcher()) {
+    val single = vertx.createHttpServer()
+      .requestHandler { req -> req.response().end("hello") }
+      .rxListen(8080)
+
+    GlobalScope.launch(vertx.delegate.dispatcher()) {
       val server = single.await()
       server.rxClose().await()
       async.complete()


### PR DESCRIPTION
- `CoroutineVerticle` implements now `CoroutineScope` based on https://github.com/Kotlin/kotlinx.coroutines/issues/410
- Used `GlobalScope.launch` over `launch` when a verticle doesn't exist.
- Renamed tests for improving readability.
- Reverted to coroutines `0.30.0` to avoid warnings from `atomicfu-common:0.11.10` that uses `kotlin-stdlib-common:1.3.0-rc-131`.

Next steps:
- Adjust documentation for coroutines module. (how should I update the examples in `index.adoc`?)
- Remove deprecated `ArrayChannel` in `ReceiveChannelHandler`.
- Make project depend on Kotlin `1.3.x` and support the latest coroutines version.