### PR TITLE
Fixed tests for Worker verticles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <kotlin.coroutines.version>0.30.0</kotlin.coroutines.version>
+    <kotlin.coroutines.version>0.30.2</kotlin.coroutines.version>
     <!-- latest version compatible with coroutines lib -->
     <kotlin.version>1.2.70</kotlin.version>
     <junit.version>4.12</junit.version>


### PR DESCRIPTION
- Updated coroutines to the latest version.
- Use `CoroutineVerticle` in tests and verify that, by default, coroutines on Worker verticles don't run on the event loop.