### PR TITLE
Removed deprecated usage of internal class ArrayChannel

### DIFF
--- a/vertx-lang-kotlin-coroutines/pom.xml
+++ b/vertx-lang-kotlin-coroutines/pom.xml
@@ -13,6 +13,7 @@
   <properties>
     <!-- Files are copied there as it contains the examples -->
     <asciidoc.dir>${project.build.directory}/asciidoc</asciidoc.dir>
+    <atomicfu.version>0.11.9</atomicfu.version>
   </properties>
 
   <artifactId>vertx-lang-kotlin-coroutines</artifactId>
@@ -22,6 +23,12 @@
       <groupId>org.jetbrains.kotlinx</groupId>
       <artifactId>kotlinx-coroutines-core</artifactId>
       <version>${kotlin.coroutines.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains.kotlinx</groupId>
+      <artifactId>atomicfu</artifactId>
+      <version>${atomicfu.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
@@ -81,6 +88,7 @@
         </executions>
       </plugin>
 
+      <!-- compile Kotlin files to staging directory -->
       <plugin>
         <groupId>org.jetbrains.kotlin</groupId>
         <artifactId>kotlin-maven-plugin</artifactId>
@@ -94,6 +102,11 @@
             <goals>
               <goal>compile</goal>
             </goals>
+            <configuration>
+              <output>${project.build.directory}/classes-pre-atomicfu</output>
+              <!-- "VH" to use Java 9 VarHandle, "BOTH" to produce multi-version code -->
+              <variant>FU</variant>
+            </configuration>
           </execution>
           <execution>
             <id>test-compile</id>
@@ -101,6 +114,23 @@
             <goals>
               <goal>test-compile</goal>
             </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <!-- transform classes with AtomicFU plugin -->
+      <plugin>
+        <groupId>org.jetbrains.kotlinx</groupId>
+        <artifactId>atomicfu-maven-plugin</artifactId>
+        <version>${atomicfu.version}</version>
+        <executions>
+          <execution>
+            <phase>compile</phase>
+            <goals>
+              <goal>transform</goal>
+            </goals>
+            <configuration>
+              <input>${project.build.directory}/classes-pre-atomicfu</input>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/vertx-lang-kotlin-coroutines/src/main/java/io/vertx/kotlin/coroutines/ReceiveChannelHandler.kt
+++ b/vertx-lang-kotlin-coroutines/src/main/java/io/vertx/kotlin/coroutines/ReceiveChannelHandler.kt
@@ -1,0 +1,282 @@
+package io.vertx.kotlin.coroutines
+
+import io.vertx.core.Context
+import io.vertx.core.Handler
+import io.vertx.core.Vertx
+import io.vertx.core.streams.ReadStream
+import io.vertx.core.streams.WriteStream
+import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.experimental.CoroutineScope
+import kotlinx.coroutines.experimental.channels.Channel
+import kotlinx.coroutines.experimental.channels.ChannelIterator
+import kotlinx.coroutines.experimental.channels.ReceiveChannel
+import kotlinx.coroutines.experimental.channels.SendChannel
+import kotlinx.coroutines.experimental.launch
+import kotlinx.coroutines.experimental.selects.SelectClause1
+import kotlin.coroutines.experimental.CoroutineContext
+
+/**
+ * @author <a href="http://www.streamis.me">Stream Liu</a>
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ * @author [Julien Ponge](https://julien.ponge.org/)
+ * @author [Guido Pio Mariotti](https://github.com/gmariotti)
+ */
+
+/**
+ * An adapter that converts a stream of events from the [Handler] into a [ReceiveChannel] which allows the events
+ * to be received synchronously.
+ */
+class ReceiveChannelHandler<T>(context: Context) : ReceiveChannel<T>, Handler<T>, CoroutineScope {
+
+  constructor(vertx: Vertx) : this(vertx.getOrCreateContext())
+
+  override val coroutineContext: CoroutineContext = context.dispatcher()
+  private val channel: Channel<T> = Channel(MAX_CAPACITY)
+
+  override val isClosedForReceive: Boolean
+    get() = channel.isClosedForReceive
+
+  override val isEmpty: Boolean
+    get() = channel.isEmpty
+
+  override fun iterator(): ChannelIterator<T> {
+    return channel.iterator()
+  }
+
+  override fun poll(): T? {
+    return channel.poll()
+  }
+
+  override suspend fun receive(): T {
+    return channel.receive()
+  }
+
+  override suspend fun receiveOrNull(): T? {
+    return channel.receiveOrNull()
+  }
+
+  override val onReceive: SelectClause1<T>
+    get() = channel.onReceive
+
+  override val onReceiveOrNull: SelectClause1<T?>
+    get() = channel.onReceiveOrNull
+
+  override fun handle(event: T) {
+    launch { channel.send(event) }
+  }
+
+  override fun cancel(cause: Throwable?): Boolean {
+    return channel.cancel(cause)
+  }
+
+  override fun cancel(): Boolean {
+    return this.cancel(null)
+  }
+}
+
+/**
+ * Create a [ReceiveChannelHandler] of some type `T`.
+ */
+fun <T> Vertx.receiveChannelHandler(): ReceiveChannelHandler<T> = ReceiveChannelHandler(this)
+
+/**
+ * Adapts the current read stream to Kotlin [ReceiveChannel].
+ *
+ * The channel can be used to receive the read stream items, the stream is paused when the channel
+ * is full and resumed when the channel is half empty.
+ *
+ * @param vertx the related vertx instance
+ * @param capacity the channel buffering capacity
+ */
+fun <T> ReadStream<T>.toChannel(vertx: Vertx, capacity: Int = MAX_CAPACITY): ReceiveChannel<T> {
+  return toChannel(vertx.getOrCreateContext(), capacity)
+}
+
+/**
+ * Adapts the current read stream to Kotlin [ReceiveChannel].
+ *
+ * The channel can be used to receive the read stream items, the stream is paused when the channel
+ * is full and resumed when the channel is half empty.
+ *
+ * @param context the vertx context
+ * @param capacity the channel buffering capacity
+ */
+fun <T> ReadStream<T>.toChannel(context: Context, capacity: Int = MAX_CAPACITY): ReceiveChannel<T> {
+  val ret = ChannelReadStream(
+    stream = this,
+    channel = Channel(capacity),
+    capacity = capacity,
+    context = context
+  )
+  ret.subscribe()
+  return ret
+}
+
+private class ChannelReadStream<T>(val stream: ReadStream<T>,
+                                   val channel: Channel<T>,
+                                   val capacity: Int,
+                                   context: Context) : Channel<T> by channel, CoroutineScope {
+
+  private val size = atomic(0)
+
+  override val coroutineContext: CoroutineContext = context.dispatcher()
+
+  fun subscribe() {
+    stream.endHandler { _ ->
+      close()
+    }
+    stream.exceptionHandler { err ->
+      close(err)
+    }
+    stream.handler { event ->
+      launch {
+        send(event)
+      }
+    }
+  }
+
+  override suspend fun send(element: T) {
+    channel.send(element)
+    pauseStreamIfFull()
+  }
+
+  override fun offer(element: T): Boolean {
+    val isOffered = channel.offer(element)
+    if (isOffered) {
+      pauseStreamIfFull()
+    }
+    return isOffered
+  }
+
+  private fun pauseStreamIfFull() {
+    size += 1
+    if (isFull) {
+      stream.pause()
+    }
+  }
+
+  override suspend fun receive(): T {
+    val ret = channel.receive()
+    resumeStream()
+    return ret
+  }
+
+  override suspend fun receiveOrNull(): T? {
+    val ret = channel.receiveOrNull()
+    ret?.let {
+      resumeStream()
+    }
+    return ret
+  }
+
+  override fun poll(): T? {
+    val ret = channel.poll()
+    ret?.let {
+      resumeStream()
+    }
+    return ret
+  }
+
+  private fun resumeStream() {
+    if (size.decrementAndGet() < capacity / 2) {
+      stream.resume()
+    }
+  }
+
+  override fun iterator(): ChannelIterator<T> {
+    return object : ChannelIterator<T> {
+      private val iterator = channel.iterator()
+      override suspend fun hasNext(): Boolean {
+        return iterator.hasNext()
+      }
+
+      override suspend fun next(): T {
+        val ret = iterator.next()
+        resumeStream()
+        return ret
+      }
+    }
+  }
+
+}
+
+/**
+ * Adapts the current write stream to Kotlin [SendChannel].
+ *
+ * The channel can be used to write items, the coroutine is suspended when the stream is full
+ * and resumed when the stream is drained.
+ *
+ * @param vertx the related vertx instance
+ * @param capacity the channel buffering capacity
+ */
+fun <T> WriteStream<T>.toChannel(vertx: Vertx, capacity: Int = MAX_CAPACITY): SendChannel<T> {
+  return toChannel(vertx.getOrCreateContext(), capacity)
+}
+
+/**
+ * Adapts the current write stream to Kotlin [SendChannel].
+ *
+ * The channel can be used to write items, the coroutine is suspended when the stream is full
+ * and resumed when the stream is drained.
+ *
+ * @param context the vertx context
+ * @param capacity the channel buffering capacity
+ */
+fun <T> WriteStream<T>.toChannel(context: Context, capacity: Int = MAX_CAPACITY): SendChannel<T> {
+  val ret = ChannelWriteStream(
+    stream = this,
+    channel = Channel(capacity),
+    context = context
+  )
+  ret.subscribe()
+  return ret
+}
+
+private class ChannelWriteStream<T>(val stream: WriteStream<T>,
+                                    val channel: Channel<T>,
+                                    context: Context) : Channel<T> by channel, CoroutineScope {
+
+  override val coroutineContext: CoroutineContext = context.dispatcher()
+
+  fun subscribe() {
+    stream.exceptionHandler {
+      channel.close(it)
+    }
+
+    launch {
+      while (true) {
+        val elt = channel.receiveOrNull()
+        if (stream.writeQueueFull()) {
+          stream.drainHandler { _ ->
+            if (dispatch(elt)) {
+              subscribe()
+            }
+          }
+          break
+        } else {
+          if (!dispatch(elt)) {
+            break
+          }
+        }
+      }
+    }
+  }
+
+  fun dispatch(elt: T?): Boolean {
+    return if (elt != null) {
+      stream.write(elt)
+      true
+    } else {
+      close()
+      false
+    }
+  }
+
+  override fun close(cause: Throwable?): Boolean {
+    val ret = channel.close(cause)
+    if (ret) stream.end()
+    return ret
+  }
+}
+
+private const val MAX_CAPACITY = 256

--- a/vertx-lang-kotlin-coroutines/src/main/java/io/vertx/kotlin/coroutines/VertxCoroutine.kt
+++ b/vertx-lang-kotlin-coroutines/src/main/java/io/vertx/kotlin/coroutines/VertxCoroutine.kt
@@ -5,19 +5,10 @@ import io.vertx.core.Context
 import io.vertx.core.Future
 import io.vertx.core.Handler
 import io.vertx.core.Vertx
-import io.vertx.core.streams.ReadStream
-import io.vertx.core.streams.WriteStream
 import kotlinx.coroutines.experimental.CancellableContinuation
 import kotlinx.coroutines.experimental.CoroutineDispatcher
 import kotlinx.coroutines.experimental.Runnable
 import kotlinx.coroutines.experimental.asCoroutineDispatcher
-import kotlinx.coroutines.experimental.channels.ArrayChannel
-import kotlinx.coroutines.experimental.channels.ChannelIterator
-import kotlinx.coroutines.experimental.channels.Closed
-import kotlinx.coroutines.experimental.channels.ReceiveChannel
-import kotlinx.coroutines.experimental.channels.SendChannel
-import kotlinx.coroutines.experimental.launch
-import kotlinx.coroutines.experimental.selects.SelectClause1
 import kotlinx.coroutines.experimental.suspendCancellableCoroutine
 import java.util.concurrent.AbstractExecutorService
 import java.util.concurrent.Callable
@@ -32,11 +23,6 @@ import java.util.concurrent.atomic.AtomicReference
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  * @author [Julien Ponge](https://julien.ponge.org/)
  */
-
-/**
- * Create a [ReceiveChannelHandler] of some type `T`.
- */
-fun <T> Vertx.receiveChannelHandler(): ReceiveChannelHandler<T> = ReceiveChannelHandler(this)
 
 /**
  * Runs an asynchronous [block] and awaits its completion.
@@ -135,206 +121,6 @@ suspend fun <T> Future<T>.await(): T = when {
     setHandler { asyncResult ->
       if (asyncResult.succeeded()) cont.resume(asyncResult.result() as T)
       else cont.resumeWithException(asyncResult.cause())
-    }
-  }
-}
-
-/**
- * An adapter that converts a stream of events from the [Handler] into a [ReceiveChannel] which allows the events
- * to be received synchronously.
- */
-class ReceiveChannelHandler<T> constructor(context: Context) : ReceiveChannel<T>, Handler<T> {
-
-  constructor(vertx: Vertx) : this(vertx.getOrCreateContext())
-
-  private val stream: ReadStream<T> = object : ReadStream<T> {
-    override fun pause(): ReadStream<T> = this
-    override fun exceptionHandler(handler: Handler<Throwable>?): ReadStream<T> = this
-    override fun endHandler(endHandler: Handler<Void>?): ReadStream<T> = this
-    override fun resume(): ReadStream<T> = this
-    override fun fetch(amount: Long): ReadStream<T> = this
-    override fun handler(h: Handler<T>?): ReadStream<T> {
-      handler = h
-      return this
-    }
-  }
-
-  private val channel: ReceiveChannel<T> = stream.toChannel(context)
-  private var handler: Handler<T>? = null
-
-  override val isClosedForReceive: Boolean
-    get() = channel.isClosedForReceive
-
-  override val isEmpty: Boolean
-    get() = channel.isEmpty
-
-  override fun iterator(): ChannelIterator<T> {
-    return channel.iterator()
-  }
-
-  override fun poll(): T? {
-    return channel.poll()
-  }
-
-  override suspend fun receive(): T {
-    return channel.receive()
-  }
-
-  override suspend fun receiveOrNull(): T? {
-    return channel.receiveOrNull()
-  }
-
-  override val onReceive: SelectClause1<T>
-    get() = channel.onReceive
-
-  override val onReceiveOrNull: SelectClause1<T?>
-    get() = channel.onReceiveOrNull
-
-  override fun handle(event: T) {
-    handler?.handle(event)
-  }
-
-  override fun cancel(cause: Throwable?): Boolean {
-    return channel.cancel(cause)
-  }
-
-  override fun cancel(): Boolean {
-    return this.cancel(null)
-  }
-}
-
-/**
- * Adapts the current read stream to Kotlin [ReceiveChannel].
- *
- * The channel can be used to receive the read stream items, the stream is paused when the channel
- * is full and resumed when the channel is half empty.
- *
- * @param vertx the related vertx instance
- * @param capacity the channel buffering capacity
- */
-fun <T> ReadStream<T>.toChannel(vertx: Vertx, capacity: Int = 256): ReceiveChannel<T> {
-  return toChannel(vertx.getOrCreateContext(), capacity)
-}
-
-/**
- * Adapts the current read stream to Kotlin [ReceiveChannel].
- *
- * The channel can be used to receive the read stream items, the stream is paused when the channel
- * is full and resumed when the channel is half empty.
- *
- * @param context the vertx context
- * @param capacity the channel buffering capacity
- */
-fun <T> ReadStream<T>.toChannel(context: Context, capacity: Int = 256): ReceiveChannel<T> {
-  val ret = ChannelReadStream(context, this, capacity)
-  ret.subscribe()
-  return ret
-}
-
-private class ChannelReadStream<T>(val context: Context,
-                                   val stream: ReadStream<T>,
-                                   capacity: Int) : ArrayChannel<T>(capacity) {
-
-  @Volatile
-  private var size = 0
-
-  fun subscribe() {
-    stream.endHandler { _ ->
-      close()
-    }
-    stream.exceptionHandler { err ->
-      close(err)
-    }
-    stream.handler { event ->
-      launch(context.dispatcher()) {
-        send(event)
-      }
-    }
-  }
-
-  override fun offerInternal(element: T): Any {
-    val ret = super.offerInternal(element)
-    // Not great - fix this
-    if (ret.toString() == "OFFER_SUCCESS") {
-      size++
-      if (isFull) {
-        stream.pause()
-      }
-    }
-    return ret
-  }
-
-  override fun pollInternal(): Any? {
-    val ret = super.pollInternal()
-    // Not great - fix this
-    if (ret.toString() != "POLL_FAILED" && ret !is Closed<*>) {
-      if (--size < capacity / 2) {
-        stream.resume()
-      }
-    }
-    return ret
-  }
-}
-
-/**
- * Adapts the current write stream to Kotlin [SendChannel].
- *
- * The channel can be used to write items, the coroutine is suspended when the stream is full
- * and resumed when the stream is drained.
- *
- * @param vertx the related vertx instance
- * @param capacity the channel buffering capacity
- */
-fun <T> WriteStream<T>.toChannel(vertx: Vertx, capacity: Int = 256): SendChannel<T> {
-  return toChannel(vertx.getOrCreateContext(), capacity)
-}
-
-/**
- * Adapts the current write stream to Kotlin [SendChannel].
- *
- * The channel can be used to write items, the coroutine is suspended when the stream is full
- * and resumed when the stream is drained.
- *
- * @param context the vertx context
- * @param capacity the channel buffering capacity
- */
-fun <T> WriteStream<T>.toChannel(context: Context, capacity: Int = 256): SendChannel<T> {
-  val ret = ChannelWriteStream(context, this, capacity)
-  ret.subscribe()
-  return ret
-}
-
-private class ChannelWriteStream<T>(val context: Context,
-                                    val stream: WriteStream<T>,
-                                    capacity: Int) : ArrayChannel<T>(capacity) {
-
-  fun subscribe() {
-    launch(context.dispatcher()) {
-      while (true) {
-        val elt = receiveOrNull()
-        if (stream.writeQueueFull()) {
-          stream.drainHandler { _ ->
-            if (dispatch(elt)) {
-              subscribe()
-            }
-          }
-          break
-        } else {
-          if (!dispatch(elt)) {
-            break
-          }
-        }
-      }
-    }
-  }
-
-  fun dispatch(elt: T?): Boolean {
-    return if (elt != null) {
-      stream.write(elt)
-      true
-    } else {
-      stream.end()
-      false
     }
   }
 }

--- a/vertx-lang-kotlin-coroutines/src/test/kotlin/io/vertx/kotlin/coroutines/ReceiveChannelHandlerTest.kt
+++ b/vertx-lang-kotlin-coroutines/src/test/kotlin/io/vertx/kotlin/coroutines/ReceiveChannelHandlerTest.kt
@@ -1,0 +1,185 @@
+package io.vertx.kotlin.coroutines
+
+import io.vertx.core.Vertx
+import io.vertx.core.eventbus.Message
+import io.vertx.core.streams.ReadStream
+import io.vertx.core.streams.WriteStream
+import io.vertx.ext.unit.TestContext
+import io.vertx.ext.unit.junit.RunTestOnContext
+import io.vertx.ext.unit.junit.VertxUnitRunner
+import kotlinx.coroutines.experimental.CancellationException
+import kotlinx.coroutines.experimental.GlobalScope
+import kotlinx.coroutines.experimental.launch
+import kotlinx.coroutines.experimental.withTimeout
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.test.assertFalse
+
+/**
+ * @author <a href="http://www.streamis.me">Stream Liu</a>
+ */
+@RunWith(VertxUnitRunner::class)
+class ReceiveChannelHandlerTest {
+  companion object {
+    private const val ADDRESS1 = "address1"
+    private const val ADDRESS2 = "address2"
+    private const val ADDRESS3 = "address3"
+  }
+
+  @Rule
+  @JvmField
+  val rule = RunTestOnContext()
+
+  private lateinit var vertx: Vertx
+  private lateinit var ai: AsyncInterface
+
+  @Before
+  fun before() {
+    vertx = rule.vertx()
+    ai = AsyncInterfaceImpl(vertx)
+  }
+
+  @Test
+  fun `test readStream to channel`(testContext: TestContext) {
+    val stream = TestStream<Int>()
+    val capacity = 3
+    val expected = List(capacity) { it }
+    val channel = (stream as ReadStream<Int>).toChannel(vertx, capacity)
+
+    expected.forEach {
+      testContext.assertFalse(stream.writeQueueFull())
+      stream.write(it)
+    }
+    Assert.assertTrue(stream.writeQueueFull())
+    val list = mutableListOf<Int>()
+    GlobalScope.launch(vertx.dispatcher()) {
+      for (item in channel) {
+        list.add(item)
+        val isQueueFull = (capacity - list.size) >= capacity / 2
+        testContext.assertEquals(
+          isQueueFull,
+          stream.writeQueueFull(),
+          "Excepted stream to ${if (!isQueueFull) "not " else ""}have queue full"
+        )
+        if (list.size == expected.size) {
+          break
+        }
+      }
+    }
+    Assert.assertEquals(expected, list)
+    stream.write(-1)
+    stream.write(-2)
+    stream.end()
+    val ended = AtomicBoolean()
+    GlobalScope.launch(vertx.dispatcher()) {
+      var count = -1
+      for (item in channel) {
+        Assert.assertEquals(count--, item)
+      }
+      testContext.assertEquals(-3, count)
+      ended.set(true)
+    }
+    testContext.assertTrue(ended.get())
+  }
+
+  @Test
+  fun `test writeStream to channel`(testContext: TestContext) {
+    val stream = TestStream<Int>()
+    val capacity = 3
+    val expected = List(capacity) { it }
+    val channel = (stream as WriteStream<Int>).toChannel(vertx, capacity)
+    val received = mutableListOf<Int>()
+
+    stream.handler { elt -> received.add(elt) }
+    GlobalScope.launch(vertx.dispatcher()) {
+      for (elt in expected) {
+        channel.send(elt)
+        assertFalse(channel.isFull)
+      }
+    }
+    testContext.assertEquals(expected, received)
+    received.clear()
+    stream.pause()
+
+    val async = testContext.async()
+    var foo = false
+    GlobalScope.launch(vertx.dispatcher()) {
+      for (elt in expected) {
+        channel.send(elt)
+        testContext.assertFalse(channel.isFull)
+      }
+      channel.send(capacity) // Need an extra element for the inflight
+      testContext.assertTrue(channel.isFull)
+      channel.send(capacity + 1) // Shall be suspended until resume
+      foo = true
+    }
+    testContext.assertFalse(foo)
+    testContext.assertEquals(emptyList<Int>(), received)
+    stream.resume()
+    testContext.assertTrue(foo)
+    testContext.assertEquals(listOf(0, 1, 2, 3, 4), received)
+    GlobalScope.launch(vertx.dispatcher()) {
+      channel.send(5)
+    }
+    testContext.assertEquals(listOf(0, 1, 2, 3, 4, 5), received)
+    testContext.assertFalse(stream.isEnded)
+    channel.close()
+    testContext.assertTrue(stream.isEnded)
+    async.complete()
+  }
+
+  @Test
+  fun `test handler adaptor`(testContext: TestContext) {
+    val async = testContext.async()
+    val eb = vertx.eventBus()
+    // Create a couple of consumers on different addresses
+    // The adaptor allows handler to be used as a Channel
+    val adaptor1 = vertx.receiveChannelHandler<Message<String>>()
+    eb.consumer<String>(ADDRESS1).handler(adaptor1)
+
+    val adaptor2 = vertx.receiveChannelHandler<Message<String>>()
+    eb.consumer<String>(ADDRESS2).handler(adaptor2)
+
+    // Set up a periodic timer to send messages to these addresses
+    val start = System.currentTimeMillis()
+    vertx.setPeriodic(10) { _ ->
+      eb.send(ADDRESS1, "wibble")
+      eb.send(ADDRESS2, "flibble")
+    }
+    GlobalScope.launch(vertx.dispatcher()) {
+      for (i in 0..9) {
+        val received1 = adaptor1.receive()
+        Assert.assertEquals("wibble", received1.body())
+        val received2 = adaptor2.receive()
+        Assert.assertEquals("flibble", received2.body())
+      }
+
+      val end = System.currentTimeMillis()
+      Assert.assertTrue(end - start >= 100)
+
+      // Try a receive with timeout
+      var received1: Message<String>? = null
+      try {
+        received1 = withTimeout(1000) { adaptor1.receive() }
+      } catch (e: CancellationException) {
+      }
+
+      if (received1 is Message<*>) Assert.assertEquals("wibble", received1.body())
+      else Assert.fail("received1 cast type failed.")
+
+      // And timing out
+      val adaptor3 = vertx.receiveChannelHandler<Message<String>>()
+      eb.consumer<String>(ADDRESS3).handler(adaptor3)
+      try {
+        withTimeout(100) { adaptor3.receive() }
+        testContext.fail()
+      } catch (e: CancellationException) {
+        async.complete()
+      }
+    }
+  }
+}

--- a/vertx-lang-kotlin-coroutines/src/test/kotlin/io/vertx/kotlin/coroutines/VertxCoroutineTest.kt
+++ b/vertx-lang-kotlin-coroutines/src/test/kotlin/io/vertx/kotlin/coroutines/VertxCoroutineTest.kt
@@ -3,11 +3,8 @@ package io.vertx.kotlin.coroutines
 import io.vertx.core.Context
 import io.vertx.core.Future
 import io.vertx.core.Vertx
-import io.vertx.core.eventbus.Message
 import io.vertx.core.http.HttpClientOptions
 import io.vertx.core.http.HttpServerOptions
-import io.vertx.core.streams.ReadStream
-import io.vertx.core.streams.WriteStream
 import io.vertx.ext.unit.TestContext
 import io.vertx.ext.unit.junit.RunTestOnContext
 import io.vertx.ext.unit.junit.VertxUnitRunner
@@ -25,22 +22,14 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import java.util.LinkedList
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
-import kotlin.test.assertFalse
 
 /**
  * @author <a href="http://www.streamis.me">Stream Liu</a>
  */
 @RunWith(VertxUnitRunner::class)
 class VertxCoroutineTest {
-
-  companion object {
-    private const val ADDRESS1 = "address1"
-    private const val ADDRESS2 = "address2"
-    private const val ADDRESS3 = "address3"
-  }
 
   @Rule
   @JvmField
@@ -328,146 +317,6 @@ class VertxCoroutineTest {
       }
       testContext.assertEquals("one", v)
       async.countDown()
-    }
-  }
-
-  @Test
-  fun `test readStream to channel`(testContext: TestContext) {
-    val stream = TestStream<Int>()
-    val capacity = 3
-    val expected = LinkedList<Int>()
-    for (i in 0 until capacity) {
-      expected.add(i)
-    }
-    val readStream: ReadStream<Int> = stream
-    val channel = readStream.toChannel(vertx, capacity)
-    for (i in expected) {
-      testContext.assertFalse(stream.writeQueueFull())
-      stream.write(i)
-    }
-    assertTrue(stream.writeQueueFull())
-    val list = LinkedList<Int>()
-    GlobalScope.launch(vertx.dispatcher()) {
-      for (item in channel) {
-        list.add(item)
-        testContext.assertEquals((capacity - list.size) >= capacity / 2, stream.writeQueueFull())
-        if (list.size == expected.size) {
-          break
-        }
-      }
-    }
-    assertEquals(expected, list)
-    stream.write(-1)
-    stream.write(-2)
-    stream.end()
-    val ended = AtomicBoolean()
-    GlobalScope.launch(vertx.dispatcher()) {
-      var count = -1
-      for (item in channel) {
-        assertEquals(count--, item)
-      }
-      testContext.assertEquals(-3, count)
-      ended.set(true)
-    }
-    testContext.assertTrue(ended.get())
-  }
-
-  @Test
-  fun `test writeStream to channel`(testContext: TestContext) {
-    val stream = TestStream<Int>()
-    val capacity = 3
-    val expected = LinkedList<Int>()
-    for (i in 0 until capacity) {
-      expected.add(i)
-    }
-    val writeStream: WriteStream<Int> = stream
-    val channel = writeStream.toChannel(vertx, capacity)
-    val received = LinkedList<Int>()
-    stream.handler { elt -> received.add(elt) }
-    GlobalScope.launch(vertx.dispatcher()) {
-      for (elt in expected) {
-        channel.send(elt)
-        assertFalse(channel.isFull)
-      }
-    }
-    testContext.assertEquals(expected, received)
-    received.clear()
-    stream.pause()
-    val async = testContext.async()
-    var foo = false
-    GlobalScope.launch(vertx.dispatcher()) {
-      for (elt in expected) {
-        channel.send(elt)
-        testContext.assertFalse(channel.isFull)
-      }
-      channel.send(capacity) // Need an extra element for the inflight
-      testContext.assertTrue(channel.isFull)
-      channel.send(capacity + 1) // Shall be suspended until resume
-      foo = true
-    }
-    testContext.assertFalse(foo)
-    testContext.assertEquals(emptyList<Int>(), received)
-    stream.resume()
-    testContext.assertTrue(foo)
-    testContext.assertEquals(listOf(0, 1, 2, 3, 4), received)
-    GlobalScope.launch(vertx.dispatcher()) {
-      channel.send(5)
-    }
-    testContext.assertEquals(listOf(0, 1, 2, 3, 4, 5), received)
-    testContext.assertFalse(stream.isEnded)
-    channel.close()
-    testContext.assertTrue(stream.isEnded)
-    async.complete()
-  }
-
-  @Test
-  fun `test handler adaptor`(testContext: TestContext) {
-    val async = testContext.async()
-    val eb = vertx.eventBus()
-    // Create a couple of consumers on different addresses
-    // The adaptor allows handler to be used as a Channel
-    val adaptor1 = vertx.receiveChannelHandler<Message<String>>()
-    eb.consumer<String>(ADDRESS1).handler(adaptor1)
-
-    val adaptor2 = vertx.receiveChannelHandler<Message<String>>()
-    eb.consumer<String>(ADDRESS2).handler(adaptor2)
-
-    // Set up a periodic timer to send messages to these addresses
-    val start = System.currentTimeMillis()
-    vertx.setPeriodic(10) { _ ->
-      eb.send(ADDRESS1, "wibble")
-      eb.send(ADDRESS2, "flibble")
-    }
-    GlobalScope.launch(vertx.dispatcher()) {
-      for (i in 0..9) {
-        val received1 = adaptor1.receive()
-        assertEquals("wibble", received1.body())
-        val received2 = adaptor2.receive()
-        assertEquals("flibble", received2.body())
-      }
-
-      val end = System.currentTimeMillis()
-      assertTrue(end - start >= 100)
-
-      // Try a receive with timeout
-      var received1: Message<String>? = null
-      try {
-        received1 = withTimeout(1000) { adaptor1.receive() }
-      } catch (e: CancellationException) {
-      }
-
-      if (received1 is Message<*>) assertEquals("wibble", received1.body())
-      else fail("received1 cast type failed.")
-
-      // And timing out
-      val adaptor3 = vertx.receiveChannelHandler<Message<String>>()
-      eb.consumer<String>(ADDRESS3).handler(adaptor3)
-      try {
-        withTimeout(100) { adaptor3.receive() }
-        testContext.fail()
-      } catch (e: CancellationException) {
-        async.complete()
-      }
     }
   }
 


### PR DESCRIPTION
Description:
- Prefer using `AtomicInt` over `@Volatile` and adjusted the pom accordingly (the version used matches Kotlin 1.2.70).
- Use an internal channel instead of a `ReadStream` to implement the `ReceiveChannelHandler`.
- Removed usage of internal `ArrayChannel`.