### PR TITLE
`kotlinx.coroutines` to 1.0.1

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,11 +1,16 @@
 = Vert.x for Kotlin
 
 image:https://travis-ci.org/vert-x3/vertx-lang-kotlin.svg?branch=master["Build Status",link="https://travis-ci.org/vert-x3/vertx-lang-kotlin"]
+image:https://img.shields.io/badge/license-Apache%20License%202.0-blue.svg?style=flat["GitHub license",link="http://www.apache.org/licenses/LICENSE-2.0"]
+image:https://img.shields.io/badge/kotlin-1.3.0-blue.svg["Kotlin version badge",link="https://kotlinlang.org/docs/reference/whatsnew13.html"]
+image:https://img.shields.io/badge/kotlinx.coroutines-1.0.1-blue.svg["Coroutines version badge",link="https://github.com/Kotlin/kotlinx.coroutines#kotlinxcoroutines"]
 
-http://kotlinlang.org[Kotlin] language support for vert.x3
+This is the repository for http://kotlinlang.org[Kotlin] language support for http://vertx.io/docs[Vert.x 3].
 
-* http://vertx.io/docs[Documentation]
-* http://vertx.io/docs/vertx-lang-kotlin-coroutines/kotlin/[Coroutines]
+The following modules are available in this project:
+
+* `vertx-lang-kotlin` contains extension functions for the majority of Vert.x libraries.
+* `vertx-lang-kotlin-coroutines` contains coroutines support for https://vertx.io/docs/vertx-lang-kotlin-coroutines/kotlin/[Vert.x].
 
 == Contributing
 
@@ -18,5 +23,11 @@ For instance `vertx-core` extensions are in the `io.vertx.kotlin.core` package, 
 Extensions needs to be tested and link:vertx-lang-kotlin/src/main/asciidoc/index.adoc[documented].
 
 === Bumping Kotlin version
+
+There are a couple of rules to follow before increasing the project versions:
+
+* If changing one between `kotlin` and `kotlinx.coroutines` version, make sure that all transitive dependencies, like
+`kotlin-stdlib`, still match between the two versions.
+* If changing the `kotlin` version, open a PR also on https://github.com/vert-x3/vertx-codetrans[vertx-codetrans]
 
 Kotlin evolves fast, so just change the project versions, test it, and shot a PR.

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <kotlin.coroutines.version>1.0.0</kotlin.coroutines.version>
+    <kotlin.coroutines.version>1.0.1</kotlin.coroutines.version>
     <!-- latest version compatible with coroutines lib -->
     <kotlin.version>1.3.0</kotlin.version>
     <junit.version>4.12</junit.version>

--- a/vertx-lang-kotlin-coroutines/src/main/asciidoc/index.adoc
+++ b/vertx-lang-kotlin-coroutines/src/main/asciidoc/index.adoc
@@ -244,12 +244,16 @@ include::Example.kt[tags=withTimeout]
 
 == Coroutine builders
 
-Vert.x works will all coroutine builders, as long as an instance of `CoroutineScope` is available: `launch`, `async` and `runBlocking`.
-The `runBlocking` builder must not be used from a Vert.x event loop thread.
+Vert.x works will all coroutine builders, as long as an instance of `CoroutineScope` is available: `launch`, `async`,
+`produce', ... . A couple of important things to remember:
+
+- The `runBlocking` doesn't need a `CoroutineScope` and must not be used from a Vert.x event loop thread.
+- To avoid memory leaks, always use `coroutineScope {..}` to define a child scope. In this way, if a coroutine fails
+inside the scope, all the others, defined inside that scope, will be cancelled too.
 
 == Coroutine interoperability
 
-Vertx integration has been designed to be fully interoperable with Kotlin coroutines
+Vert.x integration has been designed to be fully interoperable with Kotlin coroutines
 
 * `kotlinx.coroutines.experimental.sync.Mutex` are executed on the event loop thread when using the vertx dispatcher
 

--- a/vertx-lang-kotlin-coroutines/src/main/java/examples/Example.kt
+++ b/vertx-lang-kotlin-coroutines/src/main/java/examples/Example.kt
@@ -352,7 +352,7 @@ class ExampleVerticle : CoroutineVerticle() {
 
   fun delayExample() {
     // tag::delay[]
-    launch(vertx.dispatcher()) {
+    launch {
       // Set a one second Vertx timer
       delay(1000)
     }
@@ -361,7 +361,7 @@ class ExampleVerticle : CoroutineVerticle() {
 
   fun cancellationExample() {
     // tag::cancellation[]
-    val job = launch(vertx.dispatcher()) {
+    val job = launch {
       // Set a one second Vertx timer
       while (true) {
         delay(1000)
@@ -376,7 +376,7 @@ class ExampleVerticle : CoroutineVerticle() {
 
   fun withTimeoutExample() {
     // tag::withTimeout[]
-    launch(vertx.dispatcher()) {
+    launch {
       try {
         val id = withTimeout<String>(1000) {
           awaitEvent { anAsyncMethod(it) }


### PR DESCRIPTION
- Updated `kotlinx.coroutines` to 1.0.1.
- Added an extra test for `ReadStream.toChannel` case.
- Updated documentation and readme.