### PR TITLE
Created reified alternative to HttpRequest<Buffer>.as

### DIFF
--- a/vertx-lang-kotlin/pom.xml
+++ b/vertx-lang-kotlin/pom.xml
@@ -312,6 +312,12 @@
       <version>${kotlin.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-core</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 

--- a/vertx-lang-kotlin/src/main/java/io/vertx/kotlin/core/web/httpRequest.kt
+++ b/vertx-lang-kotlin/src/main/java/io/vertx/kotlin/core/web/httpRequest.kt
@@ -1,0 +1,14 @@
+package io.vertx.kotlin.core.web
+
+import io.vertx.core.buffer.Buffer
+import io.vertx.ext.web.client.HttpRequest
+import io.vertx.ext.web.codec.BodyCodec
+
+/**
+ * Configure the request to decode the response as a [U].
+ *
+ * @receiver An [HttpRequest] with [Buffer] response.
+ * @param U The class to which the response should be decoded to.
+ * @return a reference to the [HttpRequest] with type [U].
+ */
+inline fun <reified U> HttpRequest<Buffer>.like(): HttpRequest<U> = `as`(BodyCodec.json(U::class.java))

--- a/vertx-lang-kotlin/src/main/java/io/vertx/kotlin/core/web/httpRequest.kt
+++ b/vertx-lang-kotlin/src/main/java/io/vertx/kotlin/core/web/httpRequest.kt
@@ -8,7 +8,9 @@ import io.vertx.ext.web.codec.BodyCodec
  * Configure the request to decode the response as a [U].
  *
  * @receiver An [HttpRequest] with [Buffer] response.
- * @param U The class to which the response should be decoded to.
+ * @param U the class to which the response should be decoded to.
+ * @param codec what to use to decode [U]. By default, [BodyCodec.json] is used.
  * @return a reference to the [HttpRequest] with type [U].
  */
-inline fun <reified U> HttpRequest<Buffer>.like(): HttpRequest<U> = `as`(BodyCodec.json(U::class.java))
+inline fun <reified U> HttpRequest<Buffer>.like(codec: (Class<U>) -> BodyCodec<U> = { BodyCodec.json(it) }): HttpRequest<U> =
+  `as`(codec(U::class.java))

--- a/vertx-lang-kotlin/src/main/java/io/vertx/kotlin/ext/web/client/HttpRequestExtensions.kt
+++ b/vertx-lang-kotlin/src/main/java/io/vertx/kotlin/ext/web/client/HttpRequestExtensions.kt
@@ -1,4 +1,4 @@
-package io.vertx.kotlin.core.web
+package io.vertx.kotlin.ext.web.client
 
 import io.vertx.core.buffer.Buffer
 import io.vertx.ext.web.client.HttpRequest
@@ -12,5 +12,6 @@ import io.vertx.ext.web.codec.BodyCodec
  * @param codec what to use to decode [U]. By default, [BodyCodec.json] is used.
  * @return a reference to the [HttpRequest] with type [U].
  */
-inline fun <reified U> HttpRequest<Buffer>.like(codec: (Class<U>) -> BodyCodec<U> = { BodyCodec.json(it) }): HttpRequest<U> =
-  `as`(codec(U::class.java))
+inline fun <reified U> HttpRequest<Buffer>.mapTo(
+  codec: (Class<U>) -> BodyCodec<U> = { BodyCodec.json(it) }
+): HttpRequest<U> = `as`(codec(U::class.java))

--- a/vertx-lang-kotlin/src/test/kotlin/io/vertx/lang/kotlin/test/HttpRequestTest.kt
+++ b/vertx-lang-kotlin/src/test/kotlin/io/vertx/lang/kotlin/test/HttpRequestTest.kt
@@ -1,0 +1,43 @@
+package io.vertx.lang.kotlin.test
+
+import io.vertx.core.http.HttpTestBase
+import io.vertx.ext.web.client.WebClient
+import io.vertx.kotlin.core.http.HttpClientOptions
+import io.vertx.kotlin.core.http.HttpServerOptions
+import io.vertx.kotlin.core.json.JsonObject
+import io.vertx.kotlin.core.web.like
+import io.vertx.lang.kotlin.test.jackson.WineAndCheese
+import org.junit.Before
+import org.junit.Test
+
+
+class HttpRequestTest : HttpTestBase() {
+
+  private lateinit var webClient: WebClient
+
+  @Before
+  fun setup() {
+    super.setUp()
+    client = vertx.createHttpClient(HttpClientOptions(defaultPort = 8080, defaultHost = "localhost"))
+    webClient = WebClient.wrap(client)
+    server.close()
+    server = vertx.createHttpServer(HttpServerOptions(port = DEFAULT_HTTP_PORT, host = DEFAULT_HTTP_HOST))
+  }
+
+  @Test
+  fun testResponseBodyAsAsJsonMapped() {
+    val expected = JsonObject("cheese" to "Goat Cheese", "wine" to "Condrieu")
+    server.requestHandler { req -> req.response().end(expected.encode()) }
+    startServer()
+
+    webClient
+      .get(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/somepath")
+      .like<WineAndCheese>()
+      .send(onSuccess { resp ->
+        assertEquals(200, resp.statusCode())
+        assertEquals(WineAndCheese().setCheese("Goat Cheese").setWine("Condrieu"), resp.body())
+        testComplete()
+      })
+    await()
+  }
+}

--- a/vertx-lang-kotlin/src/test/kotlin/io/vertx/lang/kotlin/test/HttpRequestTest.kt
+++ b/vertx-lang-kotlin/src/test/kotlin/io/vertx/lang/kotlin/test/HttpRequestTest.kt
@@ -6,7 +6,7 @@ import io.vertx.ext.web.codec.BodyCodec
 import io.vertx.kotlin.core.http.HttpClientOptions
 import io.vertx.kotlin.core.http.HttpServerOptions
 import io.vertx.kotlin.core.json.JsonObject
-import io.vertx.kotlin.core.web.like
+import io.vertx.kotlin.ext.web.client.mapTo
 import io.vertx.lang.kotlin.test.jackson.WineAndCheese
 import org.junit.Before
 import org.junit.Test
@@ -33,7 +33,7 @@ class HttpRequestTest : HttpTestBase() {
 
     webClient
       .get(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/somepath")
-      .like<WineAndCheese>()
+      .mapTo<WineAndCheese>()
       .send(onSuccess { resp ->
         assertEquals(200, resp.statusCode())
         assertEquals(WineAndCheese().setCheese("Goat Cheese").setWine("Condrieu"), resp.body())
@@ -50,7 +50,7 @@ class HttpRequestTest : HttpTestBase() {
 
     webClient
       .get(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/somepath")
-      .like<WineAndCheese> { BodyCodec.json(it) }
+      .mapTo<WineAndCheese> { BodyCodec.json(it) }
       .send(onSuccess { resp ->
         assertEquals(200, resp.statusCode())
         assertEquals(WineAndCheese().setCheese("Goat Cheese").setWine("Condrieu"), resp.body())

--- a/vertx-lang-kotlin/src/test/kotlin/io/vertx/lang/kotlin/test/jackson/WineAndCheese.java
+++ b/vertx-lang-kotlin/src/test/kotlin/io/vertx/lang/kotlin/test/jackson/WineAndCheese.java
@@ -1,0 +1,39 @@
+package io.vertx.lang.kotlin.test.jackson;
+
+import java.util.Objects;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public class WineAndCheese {
+
+  private String wine;
+  private String cheese;
+
+  public String getWine() {
+    return wine;
+  }
+
+  public WineAndCheese setWine(String wine) {
+    this.wine = wine;
+    return this;
+  }
+
+  public String getCheese() {
+    return cheese;
+  }
+
+  public WineAndCheese setCheese(String cheese) {
+    this.cheese = cheese;
+    return this;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj instanceof WineAndCheese) {
+      WineAndCheese that = (WineAndCheese) obj;
+      return Objects.equals(wine, that.wine) && Objects.equals(cheese, that.cheese);
+    }
+    return false;
+  }
+}


### PR DESCRIPTION
I used the same test structure as in the `web-client` library.

I didn't create the extension on `HttpRequest<T>` because the Kotlin compiler is not smart enough to understand that the first type is already available in the receiver, making necessary to do the call like `requestWitBufferResponse.like<Buffer, ToClass>().send(..)`