### PR TITLE
Removed check on multi threaded context

### DIFF
--- a/vertx-lang-kotlin-coroutines/src/main/java/io/vertx/kotlin/coroutines/VertxCoroutine.kt
+++ b/vertx-lang-kotlin-coroutines/src/main/java/io/vertx/kotlin/coroutines/VertxCoroutine.kt
@@ -146,7 +146,6 @@ fun Vertx.dispatcher(): CoroutineDispatcher {
  * This is necessary if you want to execute coroutine synchronous operations in your handler
  */
 fun Context.dispatcher(): CoroutineDispatcher {
-  require(!isMultiThreadedWorkerContext) { "Must not be a multithreaded worker verticle." }
   return VertxCoroutineExecutor(this).asCoroutineDispatcher()
 }
 

--- a/vertx-lang-kotlin-coroutines/src/test/kotlin/io/vertx/kotlin/coroutines/CoroutineContextTest.kt
+++ b/vertx-lang-kotlin-coroutines/src/test/kotlin/io/vertx/kotlin/coroutines/CoroutineContextTest.kt
@@ -83,20 +83,6 @@ class CoroutineContextTest {
   }
 
   @Test
-  fun `test in MultithreadedWorker context`(testContext: TestContext) {
-    val async = testContext.async()
-    vertx.deployVerticle(object : CoroutineVerticle() {
-      override suspend fun start() {
-        launch {
-          runTest(testContext, isOnEventLoop = false)
-        }
-      }
-    }, DeploymentOptions().setWorker(true).setMultiThreaded(true), testContext.asyncAssertFailure {
-      async.complete()
-    })
-  }
-
-  @Test
   fun `test using Unconfined dispatcher`(testContext: TestContext) {
     val async = testContext.async()
     val current = Thread.currentThread()

--- a/vertx-lang-kotlin/src/main/asciidoc/dataobjects.adoc
+++ b/vertx-lang-kotlin/src/main/asciidoc/dataobjects.adoc
@@ -1251,18 +1251,6 @@ Sets the value of max worker execute time, in link.
 |[[maxWorkerExecuteTimeUnit]]`@maxWorkerExecuteTimeUnit`|`link:enums.html#TimeUnit[TimeUnit]`|+++
 Set the time unit of <code>maxWorkerExecuteTime</code>
 +++
-|[[multiThreaded]]`@multiThreaded`|`Boolean`|+++
-Set whether the verticle(s) should be deployed as a multi-threaded worker verticle.
- <p>
- <strong>WARNING</strong>: Multi-threaded worker verticles are a deprecated feature.
- <p>
- Most applications will have no need for them. Because of the concurrency in these verticles you have to be
- very careful to keep the verticle in a consistent state using standard Java techniques for multi-threaded
- programming.
- <p>
- You can read the documentation that explains how you can replace this feature by the usage of custom worker
- pools or <code>executeBlocking</code> calls.
-+++
 |[[worker]]`@worker`|`Boolean`|+++
 Set whether the verticle(s) should be deployed as a worker verticle
 +++

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/ext/kotlin/eventbus/bridge/tcp/BridgeEvent.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/ext/kotlin/eventbus/bridge/tcp/BridgeEvent.kt
@@ -1,0 +1,22 @@
+package io.vertx.ext.kotlin.eventbus.bridge.tcp
+
+import io.vertx.ext.eventbus.bridge.tcp.BridgeEvent
+import io.vertx.kotlin.coroutines.awaitResult
+
+/**
+ * Set a handler for the result.
+ * <p>
+ * If the future has already been completed it will be called immediately. Otherwise it will be called when the
+ * future is completed.
+ *
+ * @param handler the Handler that will be called with the result
+ * @returna reference to this, so it can be used fluently *
+ * <p/>
+ * NOTE: This function has been automatically generated from the [io.vertx.ext.eventbus.bridge.tcp.BridgeEvent original] using Vert.x codegen.
+ */
+suspend fun BridgeEvent.setHandlerAwait() : Boolean {
+  return awaitResult{
+    this.setHandler(it)
+  }
+}
+

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/ext/kotlin/eventbus/bridge/tcp/TcpEventBusBridge.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/ext/kotlin/eventbus/bridge/tcp/TcpEventBusBridge.kt
@@ -1,0 +1,63 @@
+package io.vertx.ext.kotlin.eventbus.bridge.tcp
+
+import io.vertx.ext.eventbus.bridge.tcp.TcpEventBusBridge
+import io.vertx.kotlin.coroutines.awaitResult
+
+/**
+ * Listen on default port 7000 with a handler to report the state of the socket listen operation.
+ *
+ * @param handler the result handler
+ * @returnself *
+ * <p/>
+ * NOTE: This function has been automatically generated from the [io.vertx.ext.eventbus.bridge.tcp.TcpEventBusBridge original] using Vert.x codegen.
+ */
+suspend fun TcpEventBusBridge.listenAwait() : TcpEventBusBridge {
+  return awaitResult{
+    this.listen(it)
+  }
+}
+
+/**
+ * Listen on specific port and bind to specific address
+ *
+ * @param port tcp port
+ * @param address tcp address to the bind
+ * @param handler the result handler
+ * @returnself *
+ * <p/>
+ * NOTE: This function has been automatically generated from the [io.vertx.ext.eventbus.bridge.tcp.TcpEventBusBridge original] using Vert.x codegen.
+ */
+suspend fun TcpEventBusBridge.listenAwait(port : Int, address : String) : TcpEventBusBridge {
+  return awaitResult{
+    this.listen(port, address, it)
+  }
+}
+
+/**
+ * Listen on specific port
+ *
+ * @param port tcp port
+ * @param handler the result handler
+ * @returnself *
+ * <p/>
+ * NOTE: This function has been automatically generated from the [io.vertx.ext.eventbus.bridge.tcp.TcpEventBusBridge original] using Vert.x codegen.
+ */
+suspend fun TcpEventBusBridge.listenAwait(port : Int) : TcpEventBusBridge {
+  return awaitResult{
+    this.listen(port, it)
+  }
+}
+
+/**
+ * Close the current socket.
+ *
+ * @param handler the result handler
+ *
+ * <p/>
+ * NOTE: This function has been automatically generated from the [io.vertx.ext.eventbus.bridge.tcp.TcpEventBusBridge original] using Vert.x codegen.
+ */
+suspend fun TcpEventBusBridge.closeAwait() : Unit {
+  return awaitResult{
+    this.close({ ar -> it.handle(ar.mapEmpty()) })}
+}
+

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/DeploymentOptions.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/DeploymentOptions.kt
@@ -17,7 +17,6 @@ import java.util.concurrent.TimeUnit
  * @param isolationGroup  Set the isolation group that will be used when deploying the verticle(s)
  * @param maxWorkerExecuteTime  Sets the value of max worker execute time, in [io.vertx.core.DeploymentOptions]. <p> The default value of [io.vertx.core.DeploymentOptions] is 
  * @param maxWorkerExecuteTimeUnit  Set the time unit of <code>maxWorkerExecuteTime</code>
- * @param multiThreaded  Set whether the verticle(s) should be deployed as a multi-threaded worker verticle. <p> <strong>WARNING</strong>: Multi-threaded worker verticles are a deprecated feature. <p> Most applications will have no need for them. Because of the concurrency in these verticles you have to be very careful to keep the verticle in a consistent state using standard Java techniques for multi-threaded programming. <p> You can read the documentation that explains how you can replace this feature by the usage of custom worker pools or <code>executeBlocking</code> calls.
  * @param worker  Set whether the verticle(s) should be deployed as a worker verticle
  * @param workerPoolName  Set the worker pool name to use for this verticle. When no name is set, the Vert.x worker pool will be used, when a name is set, the verticle will use a named worker pool.
  * @param workerPoolSize  Set the maximum number of worker threads to be used by the Vert.x instance.
@@ -34,7 +33,6 @@ fun DeploymentOptions(
   isolationGroup: String? = null,
   maxWorkerExecuteTime: Long? = null,
   maxWorkerExecuteTimeUnit: TimeUnit? = null,
-  multiThreaded: Boolean? = null,
   worker: Boolean? = null,
   workerPoolName: String? = null,
   workerPoolSize: Int? = null): DeploymentOptions = io.vertx.core.DeploymentOptions().apply {
@@ -62,9 +60,6 @@ fun DeploymentOptions(
   }
   if (maxWorkerExecuteTimeUnit != null) {
     this.setMaxWorkerExecuteTimeUnit(maxWorkerExecuteTimeUnit)
-  }
-  if (multiThreaded != null) {
-    this.setMultiThreaded(multiThreaded)
   }
   if (worker != null) {
     this.setWorker(worker)


### PR DESCRIPTION
Coroutines tests in `RxTest` fail because of this error

```
java.lang.NoClassDefFoundError: io/vertx/lang/rx/TypeArg

	at io.vertx.reactivex.core.Vertx.<clinit>(Vertx.java:90)
	at io.vertx.kotlin.coroutines.RxTest.before(RxTest.kt:25)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at io.vertx.ext.unit.junit.VertxUnitRunner.invokeTestMethod(VertxUnitRunner.java:93)
	at io.vertx.ext.unit.junit.VertxUnitRunner.lambda$invokeExplosively$0(VertxUnitRunner.java:114)
	at io.vertx.ext.unit.impl.TestContextImpl.run(TestContextImpl.java:90)
	at io.vertx.ext.unit.junit.VertxUnitRunner.invokeExplosively(VertxUnitRunner.java:130)
	at io.vertx.ext.unit.junit.VertxUnitRunner.access$000(VertxUnitRunner.java:39)
	at io.vertx.ext.unit.junit.VertxUnitRunner$2.evaluate(VertxUnitRunner.java:194)
	at io.vertx.ext.unit.junit.VertxUnitRunner$3.evaluate(VertxUnitRunner.java:211)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68)
	at com.intellij.rt.execution.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:47)
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:242)
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:70)
Caused by: java.lang.ClassNotFoundException: io.vertx.lang.rx.TypeArg
	at java.net.URLClassLoader.findClass(URLClassLoader.java:382)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:349)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	... 27 more


kotlin.UninitializedPropertyAccessException: lateinit property vertx has not been initialized
```

If I try to open `io.vertx.reactivex.core.Vertx`, IntelliJ tells me that `Library source does not match the bytecode for class Vertx`. Is this a known issue @vietj?