### PR TITLE
Updated Kotlin and coroutines version

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -2,8 +2,8 @@
 
 image:https://travis-ci.org/vert-x3/vertx-lang-kotlin.svg?branch=master["Build Status",link="https://travis-ci.org/vert-x3/vertx-lang-kotlin"]
 image:https://img.shields.io/badge/license-Apache%20License%202.0-blue.svg?style=flat["GitHub license",link="http://www.apache.org/licenses/LICENSE-2.0"]
-image:https://img.shields.io/badge/kotlin-1.3.0-blue.svg["Kotlin version badge",link="https://kotlinlang.org/docs/reference/whatsnew13.html"]
-image:https://img.shields.io/badge/kotlinx.coroutines-1.0.1-blue.svg["Coroutines version badge",link="https://github.com/Kotlin/kotlinx.coroutines#kotlinxcoroutines"]
+image:https://img.shields.io/badge/kotlin-1.3.11-blue.svg["Kotlin version badge",link="https://kotlinlang.org/docs/reference/whatsnew13.html"]
+image:https://img.shields.io/badge/kotlinx.coroutines-1.1.0-blue.svg["Coroutines version badge",link="https://github.com/Kotlin/kotlinx.coroutines#kotlinxcoroutines"]
 
 This is the repository for http://kotlinlang.org[Kotlin] language support for http://vertx.io/docs[Vert.x 3].
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,9 +21,9 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <kotlin.coroutines.version>1.0.1</kotlin.coroutines.version>
+    <kotlin.coroutines.version>1.1.0</kotlin.coroutines.version>
     <!-- latest version compatible with coroutines lib -->
-    <kotlin.version>1.3.0</kotlin.version>
+    <kotlin.version>1.3.11</kotlin.version>
     <junit.version>4.12</junit.version>
     <stack.version>4.0.0-SNAPSHOT</stack.version>
   </properties>

--- a/vertx-lang-kotlin-coroutines/pom.xml
+++ b/vertx-lang-kotlin-coroutines/pom.xml
@@ -90,9 +90,6 @@
       <plugin>
         <groupId>org.jetbrains.kotlin</groupId>
         <artifactId>kotlin-maven-plugin</artifactId>
-        <configuration>
-          <experimentalCoroutines>enable</experimentalCoroutines>
-        </configuration>
         <executions>
           <execution>
             <id>compile</id>

--- a/vertx-lang-kotlin-coroutines/src/test/kotlin/io/vertx/kotlin/coroutines/VertxCoroutineTest.kt
+++ b/vertx-lang-kotlin-coroutines/src/test/kotlin/io/vertx/kotlin/coroutines/VertxCoroutineTest.kt
@@ -280,7 +280,7 @@ class VertxCoroutineTest {
         awaitEvent<Any> { throw cause }
         testContext.fail()
       } catch (e: Exception) {
-        testContext.assertEquals(cause, e)
+        testContext.assertEquals(cause, e.cause)
       }
       async.complete()
     }
@@ -297,7 +297,7 @@ class VertxCoroutineTest {
         }
         testContext.fail()
       } catch (e: Exception) {
-        testContext.assertEquals(cause, e)
+        testContext.assertEquals(cause, e.cause)
       }
       async.complete()
     }
@@ -346,7 +346,7 @@ class VertxCoroutineTest {
         fut.await()
         testContext.fail()
       } catch (e: Exception) {
-        testContext.assertEquals(cause, e)
+        testContext.assertEquals(cause, e.cause)
         async.complete()
       }
     }

--- a/vertx-lang-kotlin-gen/pom.xml
+++ b/vertx-lang-kotlin-gen/pom.xml
@@ -96,7 +96,6 @@
             </goals>
             <phase>test-compile</phase>
             <configuration>
-              <experimentalCoroutines>enable</experimentalCoroutines>
               <sourceDirs>
                 <sourceDir>src/test/kotlin</sourceDir>
                 <!-- We need this because test-kapt does not store the generated Kotlin source at the right location -->

--- a/vertx-lang-kotlin/pom.xml
+++ b/vertx-lang-kotlin/pom.xml
@@ -610,7 +610,6 @@
         <executions>
           <execution>
             <configuration>
-              <experimentalCoroutines>enable</experimentalCoroutines>
               <sourceDirs>
                 <sourceDir>${basedir}/src/main/kotlin</sourceDir>
                 <sourceDir>${basedir}/src/main/java</sourceDir>
@@ -627,7 +626,6 @@
             </goals>
             <phase>test-compile</phase>
             <configuration>
-              <experimentalCoroutines>enable</experimentalCoroutines>
               <sourceDirs>
                 <sourceDir>src/test/kotlin</sourceDir>
               </sourceDirs>


### PR DESCRIPTION
- Removed `experimentalCoroutines` from `pom.xml`.
- Starting from coroutines 1.1 an exception is wrapped into another exception instance with the same type and message in order to have augmented stacktrace.

Another PR will be opened to backport it to 3.6