### PR TITLE
Improve documentation of generated suspending methods

### DIFF
--- a/vertx-lang-kotlin-gen/src/main/java/io/vertx/lang/kotlin/KotlinCoroutineGenerator.java
+++ b/vertx-lang-kotlin-gen/src/main/java/io/vertx/lang/kotlin/KotlinCoroutineGenerator.java
@@ -143,7 +143,7 @@ public class KotlinCoroutineGenerator extends KotlinGeneratorBase<ClassModel> {
   ) {
     List<ParamInfo> params = method.getParams();
     ParamInfo lastParam = params.get(params.size() - 1);
-    TypeInfo returnType = getReturnType(method, lastParam);
+    TypeInfo returnType = getAsyncTypeArgument(method, lastParam);
     String returnTypeAsString = getReturnTypeAsString(returnType, lastParam.isNullableCallback(), type, className);
     generateDoc(model, method, returnTypeAsString, writer);
 
@@ -183,7 +183,7 @@ public class KotlinCoroutineGenerator extends KotlinGeneratorBase<ClassModel> {
     generateFunctionBody(method, objectName, returnType, writer);
   }
 
-  private TypeInfo getReturnType(MethodInfo method, ParamInfo lastParam) {
+  private TypeInfo getAsyncTypeArgument(MethodInfo method, ParamInfo lastParam) {
     ParameterizedTypeInfo lastParamType = (ParameterizedTypeInfo) lastParam.getType();
     TypeInfo handlerArg = lastParamType.getArg(0);
     TypeInfo returnType;

--- a/vertx-lang-kotlin-gen/src/main/java/io/vertx/lang/kotlin/KotlinCoroutineGenerator.java
+++ b/vertx-lang-kotlin-gen/src/main/java/io/vertx/lang/kotlin/KotlinCoroutineGenerator.java
@@ -7,6 +7,7 @@ import io.vertx.codegen.doc.Doc;
 import io.vertx.codegen.doc.Token;
 import io.vertx.codegen.type.*;
 import io.vertx.codegen.writer.CodeWriter;
+import io.vertx.core.Handler;
 import io.vertx.lang.kotlin.helper.KotlinCodeGenHelper;
 
 import java.io.StringWriter;
@@ -18,6 +19,8 @@ import java.util.stream.Stream;
 public class KotlinCoroutineGenerator extends KotlinGeneratorBase<ClassModel> {
 
   private static final Set<String> keyWords = new HashSet<>(Arrays.asList("object", "fun", "in", "typealias", "var", "val"));
+  private static final String methodSuffix = "Await";
+  private static final Set<String> unnecessaryImports = new HashSet<>(Arrays.asList(Handler.class.getCanonicalName()));
 
   public KotlinCoroutineGenerator() {
     super("codegen.kotlin.coroutines");
@@ -48,18 +51,17 @@ public class KotlinCoroutineGenerator extends KotlinGeneratorBase<ClassModel> {
     Map<Boolean, List<MethodInfo>> methodGroupMap = methodStream
       .filter(this::generateFilter)
       .collect(Collectors.groupingBy(MethodInfo::isStaticMethod));
-    boolean hasStatic = methodGroupMap.containsKey(true);
+    boolean hasStaticMethod = methodGroupMap.containsKey(true);
 
     writer.println("package " + type.getRaw().translatePackageName("kotlin"));
     writer.println();
-    generateImport(model, writer, methodGroupMap, hasStatic);
+    generateImport(model, writer, methodGroupMap, hasStaticMethod);
     writer.println();
+    String className = vertxSimpleNameWrapper(type.getSimpleName(), hasStaticMethod);
 
     List<MethodInfo> methods = methodGroupMap.get(false);
     if (methods != null) {
-      methods.forEach(method -> {
-        generateMethod(model, type, method, writer, hasStatic);
-      });
+      methods.forEach(method -> generateMethod(model, type, method, className, true, writer));
     }
 
     methods = methodGroupMap.get(true);
@@ -69,146 +71,11 @@ public class KotlinCoroutineGenerator extends KotlinGeneratorBase<ClassModel> {
       writer.println(" {");
 
       writer.indent();
-      methods.forEach(method -> {
-        generateMethod(model, type, method, writer, hasStatic);
-      });
+      methods.forEach(method -> generateMethod(model, type, method, className, false, writer));
       writer.unindent();
       writer.println("}");
     }
     return buffer.toString();
-  }
-
-  private void generateDoc(ClassModel model, MethodInfo method, CodeWriter writer) {
-    Doc doc = method.getDoc();
-    if (doc != null) {
-      writer.println("/**");
-      Token.toHtml(doc.getTokens(), " *", KotlinCodeGenHelper::renderLinkToHtml, "\n", writer);
-      writer.println(" *");
-      method.getParams().stream().limit(method.getParams().size() - 1).forEach(p -> {
-        writer.print(" * @param " + p.getName() + " ");
-        if (p.getDescription() != null) {
-          String docInfo = Token.toHtml(p.getDescription().getTokens(), "", KotlinCodeGenHelper::renderLinkToHtml, "");
-          writer.print(docInfo);
-        }
-        writer.println();
-      });
-      if (!method.getReturnType().isVoid()) {
-        writer.print(" * @return ");
-        if (method.getReturnDescription() != null) {
-          String docInfo = Token.toHtml(method.getReturnDescription().getTokens(), "", KotlinCodeGenHelper::renderLinkToHtml, "");
-          writer.print(docInfo);
-        }
-      }
-      writer.println(" *");
-      writer.println(" * <p/>");
-      writer.println(" * NOTE: This function has been automatically generated from the [" + model.getType().getName() + " original] using Vert.x codegen.");
-      writer.println(" */");
-    }
-  }
-
-
-  private void generateMethod(ClassModel model, ClassTypeInfo type, MethodInfo method, CodeWriter writer, boolean hasStatic) {
-    generateDoc(model, method, writer);
-    writer.print("suspend fun ");
-    if (!method.getTypeParams().isEmpty() || !type.getParams().isEmpty()) {
-      String typeParamInfo = Stream
-        .concat(
-          method.getTypeParams().stream(),
-          type.getParams().stream())
-        .map(TypeParamInfo::getName)
-        .collect(Collectors.joining(",", "<", ">"));
-      writer.print(typeParamInfo);
-      writer.print(" ");
-    }
-    if (!method.isStaticMethod()) {
-      writer.print(vertxSimpleNameWrapper(type.getSimpleName(), hasStatic));
-      if (!type.getParams().isEmpty()) {
-        writer.print(type.getParams().stream()
-          .map(TypeParamInfo::getName)
-          .collect(Collectors.joining(",", "<", ">")));
-      }
-      writer.print(".");
-    }
-    writer.print(method.getName());
-    writer.print("Await(");
-    List<ParamInfo> params = method.getParams();
-    writer.print(params.stream()
-      .limit(params.size() - 1)
-      .map(p -> p.getName() + " : " + kotlinType(p.getType()))
-      .collect(Collectors.joining(", ")));
-    writer.print(")");
-    ParamInfo lastParam = params.get(params.size() - 1);
-    ParameterizedTypeInfo lastParamType = (ParameterizedTypeInfo) lastParam.getType();
-    TypeInfo handlerArg = lastParamType.getArg(0);
-    TypeInfo returnType;
-    String awaitCallMethod;
-    if (method.getKind() == MethodKind.HANDLER) {
-      returnType = handlerArg;
-      awaitCallMethod = "awaitEvent";
-    } else {
-      returnType = ((ParameterizedTypeInfo) handlerArg).getArg(0);
-      awaitCallMethod = "awaitResult";
-    }
-    writer.print(" : ");
-    if (returnType.equals(type)) {
-      writer.print(vertxSimpleNameWrapper(returnType.getSimpleName(), hasStatic));
-    } else {
-      writer.print(kotlinType(returnType));
-    }
-
-
-    if (lastParam.isNullableCallback()) {
-      writer.print("?");
-    }
-    writer.println(" {");
-
-    writer.indent();
-    writer.print("return ");
-    writer.print(awaitCallMethod);
-    writer.println("{");
-
-    writer.indent();
-    if (method.isStaticMethod()) {
-      writer.print(vertxSimpleNameWrapper(type.getSimpleName(), hasStatic));
-    } else {
-      writer.print("this");
-    }
-    writer.print(".");
-    writer.print(keyWordConverter(method.getName()));
-    writer.print("(");
-    writer.print(params.stream()
-      .limit(params.size() - 1)
-      .map(p -> keyWordConverter(p.getName()))
-      .collect(Collectors.joining(", ")));
-    if (params.size() > 1) {
-      writer.print(", ");
-    }
-    if (returnType.getName().equals("java.lang.Void")) {
-      if (method.getKind() == MethodKind.HANDLER) {
-        writer.print("{ v -> it.handle(null) })");
-      } else {
-        writer.print("{ ar -> it.handle(ar.mapEmpty()) })");
-      }
-    } else {
-      boolean hasLambdaParam = params.stream().limit(params.size() - 1).anyMatch(p -> {
-        ClassKind kind = p.getType().getKind();
-        return kind == ClassKind.HANDLER || kind == ClassKind.FUNCTION;
-      });
-      if (hasLambdaParam) {
-        writer.println("it::handle)");
-      } else {
-        writer.println("it)");
-      }
-    }
-    writer.unindent();
-    writer.println("}");
-    writer.unindent();
-    writer.println("}");
-    writer.println();
-  }
-
-  private String vertxSimpleNameWrapper(String simpleName, boolean hasStatic) {
-    return hasStatic ? simpleName + "VertxAlias" : simpleName;
   }
 
   private void generateImport(ClassModel model, CodeWriter writer, Map<Boolean, List<MethodInfo>> methodGroupMap, boolean hasStatic) {
@@ -221,8 +88,8 @@ public class KotlinCoroutineGenerator extends KotlinGeneratorBase<ClassModel> {
       List<ParamInfo> params = m.getParams();
       if (params.size() > 0) {
         params.stream().limit(params.size() - 1).forEach(p -> addImport(type, imports, p.getType()));
-        ParameterizedTypeInfo param = (ParameterizedTypeInfo) params.get(params.size() - 1).getType();
-        TypeInfo arg = param.getArg(0);
+        ParameterizedTypeInfo lastParam = (ParameterizedTypeInfo) params.get(params.size() - 1).getType();
+        TypeInfo arg = lastParam.getArg(0);
         if (arg.getKind() == ClassKind.ASYNC_RESULT) {
           addImport(type, imports, ((ParameterizedTypeInfo) arg).getArg(0));
         } else {
@@ -235,10 +102,12 @@ public class KotlinCoroutineGenerator extends KotlinGeneratorBase<ClassModel> {
         imports.add("io.vertx.kotlin.coroutines.awaitResult");
       }
     });
-    for (String temp : imports) {
-      writer.print("import ");
-      writer.println(temp);
-    }
+    imports.stream()
+      .filter(temp -> !unnecessaryImports.contains(temp))
+      .forEach(temp -> {
+        writer.print("import ");
+        writer.println(temp);
+      });
 
   }
 
@@ -258,6 +127,207 @@ public class KotlinCoroutineGenerator extends KotlinGeneratorBase<ClassModel> {
         addImport(currentType, imports, arg);
       }
     }
+  }
+
+  private String vertxSimpleNameWrapper(String simpleName, boolean hasStatic) {
+    return hasStatic ? simpleName + "VertxAlias" : simpleName;
+  }
+
+  private void generateMethod(
+    ClassModel model,
+    ClassTypeInfo type,
+    MethodInfo method,
+    String className,
+    Boolean isExtensionMethod,
+    CodeWriter writer
+  ) {
+    List<ParamInfo> params = method.getParams();
+    ParamInfo lastParam = params.get(params.size() - 1);
+    TypeInfo returnType = getReturnType(method, lastParam);
+    String returnTypeAsString = getReturnTypeAsString(returnType, lastParam.isNullableCallback(), type, className);
+    generateDoc(model, method, returnTypeAsString, writer);
+
+    String methodName;
+    if (isExtensionMethod) {
+      StringBuilder methodNameBuilder = new StringBuilder().append(className);
+      if (!type.getParams().isEmpty()) {
+        methodNameBuilder.append(
+          type.getParams()
+            .stream()
+            .map(TypeParamInfo::getName)
+            .collect(Collectors.joining(",", "<", ">"))
+        );
+      }
+      methodNameBuilder.append(".");
+      methodNameBuilder.append(method.getName());
+      methodName = methodNameBuilder.toString();
+    } else {
+      methodName = method.getName();
+    }
+    generateMethodSignature(
+      type,
+      method,
+      className,
+      methodName,
+      returnType,
+      lastParam.isNullableCallback(),
+      writer
+    );
+
+    String objectName;
+    if (isExtensionMethod) {
+      objectName = "this";
+    } else {
+      objectName = className;
+    }
+    generateFunctionBody(method, objectName, returnType, writer);
+  }
+
+  private TypeInfo getReturnType(MethodInfo method, ParamInfo lastParam) {
+    ParameterizedTypeInfo lastParamType = (ParameterizedTypeInfo) lastParam.getType();
+    TypeInfo handlerArg = lastParamType.getArg(0);
+    TypeInfo returnType;
+    if (method.getKind() == MethodKind.HANDLER) {
+      returnType = handlerArg;
+    } else {
+      returnType = ((ParameterizedTypeInfo) handlerArg).getArg(0);
+    }
+    return returnType;
+  }
+
+  private void generateDoc(
+    ClassModel model,
+    MethodInfo method,
+    String returnType,
+    CodeWriter writer
+  ) {
+    Doc doc = method.getDoc();
+    if (doc != null) {
+      writer.println("/**");
+      writer.println(" * Suspending version of method [" + model.getType().getName() + "." + method.getName() + "]");
+      writer.println(" *");
+
+      List<ParamInfo> parameters = method.getParams();
+      parameters.stream().limit(parameters.size() - 1).forEach(p -> {
+        writer.print(" * @param " + p.getName() + " ");
+        if (p.getDescription() != null) {
+          String docInfo = Token.toHtml(p.getDescription().getTokens(), "", KotlinCodeGenHelper::renderLinkToHtml, "");
+          writer.print(docInfo);
+        }
+        writer.println();
+      });
+      if (!returnType.equals("Unit")) {
+        writer.println(" * @return [" + returnType + "]");
+      }
+      writer.println(" *");
+      writer.println(" * NOTE: This function has been automatically generated from [" + model.getType().getName() + "] using Vert.x codegen.");
+      writer.println(" */");
+    }
+  }
+
+  private void generateMethodSignature(
+    ClassTypeInfo type,
+    MethodInfo method,
+    String className,
+    String methodName,
+    TypeInfo returnType,
+    Boolean isNullable,
+    CodeWriter writer
+  ) {
+    writer.print("suspend fun ");
+    if (!method.getTypeParams().isEmpty() || !type.getParams().isEmpty()) {
+      String typeParamInfo = Stream
+        .concat(
+          method.getTypeParams().stream(),
+          type.getParams().stream())
+        .map(TypeParamInfo::getName)
+        .collect(Collectors.joining(",", "<", ">"));
+      writer.print(typeParamInfo);
+      writer.print(" ");
+    }
+    writer.print(methodName);
+    writer.print(methodSuffix);
+    writer.print("(");
+    List<ParamInfo> params = method.getParams();
+    writer.print(params.stream()
+      .limit(params.size() - 1)
+      .map(p -> p.getName() + ": " + kotlinType(p.getType()))
+      .collect(Collectors.joining(", ")));
+    writer.print(")");
+    writer.print(": ");
+    writer.print(getReturnTypeAsString(returnType, isNullable, type, className));
+  }
+
+  private String getReturnTypeAsString(TypeInfo returnType, Boolean isNullable, ClassTypeInfo type, String className) {
+    String returnTypeAsString;
+    if (returnType.equals(type)) {
+      returnTypeAsString = className;
+    } else {
+      returnTypeAsString = kotlinType(returnType);
+    }
+    if (isNullable) {
+      returnTypeAsString += "?";
+    }
+    return returnTypeAsString;
+  }
+
+  private void generateFunctionBody(MethodInfo method, String objectName, TypeInfo returnType, CodeWriter writer) {
+    List<ParamInfo> params = method.getParams();
+    writer.println(" {");
+
+    writer.indent();
+    writer.print("return ");
+    String awaitCallMethod;
+    if (method.getKind() == MethodKind.HANDLER) {
+      awaitCallMethod = "awaitEvent";
+    } else {
+      awaitCallMethod = "awaitResult";
+    }
+    writer.print(awaitCallMethod);
+    writer.println(" {");
+
+    writer.indent();
+    writer.print(objectName);
+    writer.print(".");
+    writer.print(keyWordConverter(method.getName()));
+    boolean methodHasMoreThanOneParameter = params.size() > 1;
+    if (methodHasMoreThanOneParameter) {
+      writer.print("(");
+      writer.print(params.stream()
+        .limit(params.size() - 1)
+        .map(p -> keyWordConverter(p.getName()))
+        .collect(Collectors.joining(", ")));
+    }
+    if (returnType.getName().equals("java.lang.Void")) {
+      if (methodHasMoreThanOneParameter) {
+        writer.print(")");
+      }
+      if (method.getKind() == MethodKind.HANDLER) {
+        writer.println(" { v -> it.handle(null) }");
+      } else {
+        writer.println(" { ar -> it.handle(ar.mapEmpty()) }");
+      }
+    } else {
+      boolean hasLambdaParam = params.stream().limit(params.size() - 1).anyMatch(p -> {
+        ClassKind kind = p.getType().getKind();
+        return kind == ClassKind.HANDLER || kind == ClassKind.FUNCTION;
+      });
+      if (methodHasMoreThanOneParameter) {
+        writer.print(", ");
+      } else {
+        writer.print("(");
+      }
+      if (hasLambdaParam) {
+        writer.println("it::handle)");
+      } else {
+        writer.println("it)");
+      }
+    }
+    writer.unindent();
+    writer.println("}");
+    writer.unindent();
+    writer.println("}");
+    writer.println();
   }
 
   private String kotlinType(TypeInfo type) {
@@ -297,9 +367,7 @@ public class KotlinCoroutineGenerator extends KotlinGeneratorBase<ClassModel> {
 
   private boolean generateFilter(MethodInfo it) {
     MethodKind methodKind = it.getKind();
-    return
-      !it.isDeprecated() &&
-        (it.isFluent() || it.getReturnType().isVoid()) && methodKind == MethodKind.FUTURE;
+    return !it.isDeprecated() && (it.isFluent() || it.getReturnType().isVoid()) && methodKind == MethodKind.FUTURE;
   }
 
   /**

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/cassandra/CassandraClient.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/cassandra/CassandraClient.kt
@@ -9,136 +9,136 @@ import io.vertx.cassandra.ResultSet
 import io.vertx.kotlin.coroutines.awaitResult
 
 /**
- * Connect to a Cassandra service.
+ * Suspending version of method [io.vertx.cassandra.CassandraClient.connect]
  *
- * @return current Cassandra client instance *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.cassandra.CassandraClient original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.cassandra.CassandraClient] using Vert.x codegen.
  */
-suspend fun CassandraClient.connectAwait() : Unit {
-  return awaitResult{
-    this.connect({ ar -> it.handle(ar.mapEmpty()) })}
+suspend fun CassandraClient.connectAwait(): Unit {
+  return awaitResult {
+    this.connect { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Connect to a Cassandra service.
+ * Suspending version of method [io.vertx.cassandra.CassandraClient.connect]
  *
  * @param keyspace The name of the keyspace to use for the created connection.
- * @return current Cassandra client instance *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.cassandra.CassandraClient original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.cassandra.CassandraClient] using Vert.x codegen.
  */
-suspend fun CassandraClient.connectAwait(keyspace : String) : Unit {
-  return awaitResult{
-    this.connect(keyspace, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun CassandraClient.connectAwait(keyspace: String): Unit {
+  return awaitResult {
+    this.connect(keyspace) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Execute the query and provide a handler for consuming results.
+ * Suspending version of method [io.vertx.cassandra.CassandraClient.execute]
  *
  * @param query the query to execute
- * @return current Cassandra client instance *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.cassandra.CassandraClient original] using Vert.x codegen.
+ * @return [ResultSet]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.cassandra.CassandraClient] using Vert.x codegen.
  */
-suspend fun CassandraClient.executeAwait(query : String) : ResultSet {
-  return awaitResult{
+suspend fun CassandraClient.executeAwait(query: String): ResultSet {
+  return awaitResult {
     this.execute(query, it)
   }
 }
 
 /**
- * Executes the given SQL <code>SELECT</code> statement which returns the results of the query as a read stream.
+ * Suspending version of method [io.vertx.cassandra.CassandraClient.queryStream]
  *
  * @param sql the SQL to execute. For example <code>SELECT * FROM table ...</code>.
- * @return current Cassandra client instance *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.cassandra.CassandraClient original] using Vert.x codegen.
+ * @return [CassandraRowStream]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.cassandra.CassandraClient] using Vert.x codegen.
  */
-suspend fun CassandraClient.queryStreamAwait(sql : String) : CassandraRowStream {
-  return awaitResult{
+suspend fun CassandraClient.queryStreamAwait(sql: String): CassandraRowStream {
+  return awaitResult {
     this.queryStream(sql, it)
   }
 }
 
 /**
- * Disconnects from the Cassandra service.
+ * Suspending version of method [io.vertx.cassandra.CassandraClient.disconnect]
  *
- * @return current Cassandra client instance *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.cassandra.CassandraClient original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.cassandra.CassandraClient] using Vert.x codegen.
  */
-suspend fun CassandraClient.disconnectAwait() : Unit {
-  return awaitResult{
-    this.disconnect({ ar -> it.handle(ar.mapEmpty()) })}
+suspend fun CassandraClient.disconnectAwait(): Unit {
+  return awaitResult {
+    this.disconnect { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Execute the query and provide a handler for consuming results.
+ * Suspending version of method [io.vertx.cassandra.CassandraClient.executeWithFullFetch]
  *
  * @param query the query to execute
- * @return current Cassandra client instance *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.cassandra.CassandraClient original] using Vert.x codegen.
+ * @return [List<Row>]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.cassandra.CassandraClient] using Vert.x codegen.
  */
-suspend fun CassandraClient.executeWithFullFetchAwait(query : String) : List<Row> {
-  return awaitResult{
+suspend fun CassandraClient.executeWithFullFetchAwait(query: String): List<Row> {
+  return awaitResult {
     this.executeWithFullFetch(query, it)
   }
 }
 
 /**
- * Execute the query and provide a handler for consuming results.
+ * Suspending version of method [io.vertx.cassandra.CassandraClient.executeWithFullFetch]
  *
  * @param statement the statement to execute
- * @return current Cassandra client instance *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.cassandra.CassandraClient original] using Vert.x codegen.
+ * @return [List<Row>]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.cassandra.CassandraClient] using Vert.x codegen.
  */
-suspend fun CassandraClient.executeWithFullFetchAwait(statement : Statement) : List<Row> {
-  return awaitResult{
+suspend fun CassandraClient.executeWithFullFetchAwait(statement: Statement): List<Row> {
+  return awaitResult {
     this.executeWithFullFetch(statement, it)
   }
 }
 
 /**
- * Execute the statement and provide a handler for consuming results.
+ * Suspending version of method [io.vertx.cassandra.CassandraClient.execute]
  *
  * @param statement the statement to execute
- * @return current Cassandra client instance *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.cassandra.CassandraClient original] using Vert.x codegen.
+ * @return [ResultSet]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.cassandra.CassandraClient] using Vert.x codegen.
  */
-suspend fun CassandraClient.executeAwait(statement : Statement) : ResultSet {
-  return awaitResult{
+suspend fun CassandraClient.executeAwait(statement: Statement): ResultSet {
+  return awaitResult {
     this.execute(statement, it)
   }
 }
 
 /**
- * Prepares the provided query string.
+ * Suspending version of method [io.vertx.cassandra.CassandraClient.prepare]
  *
  * @param query the query to prepare
- * @return current Cassandra client instance *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.cassandra.CassandraClient original] using Vert.x codegen.
+ * @return [PreparedStatement]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.cassandra.CassandraClient] using Vert.x codegen.
  */
-suspend fun CassandraClient.prepareAwait(query : String) : PreparedStatement {
-  return awaitResult{
+suspend fun CassandraClient.prepareAwait(query: String): PreparedStatement {
+  return awaitResult {
     this.prepare(query, it)
   }
 }
 
 /**
- * Executes the given SQL statement which returns the results of the query as a read stream.
+ * Suspending version of method [io.vertx.cassandra.CassandraClient.queryStream]
  *
  * @param statement the statement to execute.
- * @return current Cassandra client instance *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.cassandra.CassandraClient original] using Vert.x codegen.
+ * @return [CassandraRowStream]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.cassandra.CassandraClient] using Vert.x codegen.
  */
-suspend fun CassandraClient.queryStreamAwait(statement : Statement) : CassandraRowStream {
-  return awaitResult{
+suspend fun CassandraClient.queryStreamAwait(statement: Statement): CassandraRowStream {
+  return awaitResult {
     this.queryStream(statement, it)
   }
 }

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/cassandra/ResultSet.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/cassandra/ResultSet.kt
@@ -5,36 +5,39 @@ import io.vertx.cassandra.ResultSet
 import io.vertx.kotlin.coroutines.awaitResult
 
 /**
+ * Suspending version of method [io.vertx.cassandra.ResultSet.fetchMoreResults]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.cassandra.ResultSet original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.cassandra.ResultSet] using Vert.x codegen.
  */
-suspend fun ResultSet.fetchMoreResultsAwait() : Unit {
-  return awaitResult{
-    this.fetchMoreResults({ ar -> it.handle(ar.mapEmpty()) })}
+suspend fun ResultSet.fetchMoreResultsAwait(): Unit {
+  return awaitResult {
+    this.fetchMoreResults { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
+ * Suspending version of method [io.vertx.cassandra.ResultSet.one]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.cassandra.ResultSet original] using Vert.x codegen.
+ * @return [Row?]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.cassandra.ResultSet] using Vert.x codegen.
  */
-suspend fun ResultSet.oneAwait() : Row? {
-  return awaitResult{
+suspend fun ResultSet.oneAwait(): Row? {
+  return awaitResult {
     this.one(it)
   }
 }
 
 /**
+ * Suspending version of method [io.vertx.cassandra.ResultSet.all]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.cassandra.ResultSet original] using Vert.x codegen.
+ * @return [List<Row>]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.cassandra.ResultSet] using Vert.x codegen.
  */
-suspend fun ResultSet.allAwait() : List<Row> {
-  return awaitResult{
+suspend fun ResultSet.allAwait(): List<Row> {
+  return awaitResult {
     this.all(it)
   }
 }

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/circuitbreaker/CircuitBreaker.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/circuitbreaker/CircuitBreaker.kt
@@ -2,35 +2,34 @@ package io.vertx.kotlin.circuitbreaker
 
 import io.vertx.circuitbreaker.CircuitBreaker
 import io.vertx.core.Future
-import io.vertx.core.Handler
 import io.vertx.kotlin.coroutines.awaitResult
 import java.util.function.Function
 
 /**
- * Same as [io.vertx.circuitbreaker.CircuitBreaker] but using a callback.
+ * Suspending version of method [io.vertx.circuitbreaker.CircuitBreaker.executeCommandWithFallback]
  *
  * @param command the operation
  * @param fallback the fallback
+ * @return [T]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.circuitbreaker.CircuitBreaker original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.circuitbreaker.CircuitBreaker] using Vert.x codegen.
  */
-suspend fun <T> CircuitBreaker.executeCommandWithFallbackAwait(command : (Future<T>) -> Unit, fallback : (Throwable) -> T) : T {
-  return awaitResult{
+suspend fun <T> CircuitBreaker.executeCommandWithFallbackAwait(command: (Future<T>) -> Unit, fallback: (Throwable) -> T): T {
+  return awaitResult {
     this.executeCommandWithFallback(command, fallback, it::handle)
   }
 }
 
 /**
- * Same as [io.vertx.circuitbreaker.CircuitBreaker] but using the circuit breaker default fallback.
+ * Suspending version of method [io.vertx.circuitbreaker.CircuitBreaker.executeCommand]
  *
  * @param command the operation
+ * @return [T]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.circuitbreaker.CircuitBreaker original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.circuitbreaker.CircuitBreaker] using Vert.x codegen.
  */
-suspend fun <T> CircuitBreaker.executeCommandAwait(command : (Future<T>) -> Unit) : T {
-  return awaitResult{
+suspend fun <T> CircuitBreaker.executeCommandAwait(command: (Future<T>) -> Unit): T {
+  return awaitResult {
     this.executeCommand(command, it::handle)
   }
 }

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/config/ConfigRetriever.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/config/ConfigRetriever.kt
@@ -5,15 +5,14 @@ import io.vertx.core.json.JsonObject
 import io.vertx.kotlin.coroutines.awaitResult
 
 /**
- * Reads the configuration from the different 
- * and computes the final configuration.
+ * Suspending version of method [io.vertx.config.ConfigRetriever.getConfig]
  *
+ * @return [JsonObject]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.config.ConfigRetriever original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.config.ConfigRetriever] using Vert.x codegen.
  */
-suspend fun ConfigRetriever.getConfigAwait() : JsonObject {
-  return awaitResult{
+suspend fun ConfigRetriever.getConfigAwait(): JsonObject {
+  return awaitResult {
     this.getConfig(it)
   }
 }

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/CompositeFuture.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/CompositeFuture.kt
@@ -3,8 +3,8 @@ package io.vertx.kotlin.core
 import io.vertx.core.CompositeFuture
 import io.vertx.kotlin.coroutines.awaitResult
 
-suspend fun CompositeFuture.setHandlerAwait() : CompositeFuture {
-  return awaitResult{
+suspend fun CompositeFuture.setHandlerAwait(): CompositeFuture {
+  return awaitResult {
     this.setHandler(it)
   }
 }

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/Context.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/Context.kt
@@ -2,52 +2,33 @@ package io.vertx.kotlin.core
 
 import io.vertx.core.Context
 import io.vertx.core.Future
-import io.vertx.core.Handler
 import io.vertx.kotlin.coroutines.awaitResult
 
 /**
- * Safely execute some blocking code.
- * <p>
- * Executes the blocking code in the handler <code>blockingCodeHandler</code> using a thread from the worker pool.
- * <p>
- * When the code is complete the handler <code>resultHandler</code> will be called with the result on the original context
- * (e.g. on the original event loop of the caller).
- * <p>
- * A <code>Future</code> instance is passed into <code>blockingCodeHandler</code>. When the blocking code successfully completes,
- * the handler should call the [io.vertx.core.Future] or [io.vertx.core.Future] method, or the [io.vertx.core.Future]
- * method if it failed.
- * <p>
- * The blocking code should block for a reasonable amount of time (i.e no more than a few seconds). Long blocking operations
- * or polling operations (i.e a thread that spin in a loop polling events in a blocking fashion) are precluded.
- * <p>
- * When the blocking operation lasts more than the 10 seconds, a message will be printed on the console by the
- * blocked thread checker.
- * <p>
- * Long blocking operations should use a dedicated thread managed by the application, which can interact with
- * verticles using the event-bus or [io.vertx.core.Context]
+ * Suspending version of method [io.vertx.core.Context.executeBlocking]
  *
  * @param blockingCodeHandler handler representing the blocking code to run
  * @param ordered if true then if executeBlocking is called several times on the same context, the executions for that context will be executed serially, not in parallel. if false then they will be no ordering guarantees
+ * @return [T?]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.Context original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.core.Context] using Vert.x codegen.
  */
-suspend fun <T> Context.executeBlockingAwait(blockingCodeHandler : (Future<T>) -> Unit, ordered : Boolean) : T? {
-  return awaitResult{
+suspend fun <T> Context.executeBlockingAwait(blockingCodeHandler: (Future<T>) -> Unit, ordered: Boolean): T? {
+  return awaitResult {
     this.executeBlocking(blockingCodeHandler, ordered, it::handle)
   }
 }
 
 /**
- * Invoke [io.vertx.core.Context] with order = true.
+ * Suspending version of method [io.vertx.core.Context.executeBlocking]
  *
  * @param blockingCodeHandler handler representing the blocking code to run
+ * @return [T?]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.Context original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.core.Context] using Vert.x codegen.
  */
-suspend fun <T> Context.executeBlockingAwait(blockingCodeHandler : (Future<T>) -> Unit) : T? {
-  return awaitResult{
+suspend fun <T> Context.executeBlockingAwait(blockingCodeHandler: (Future<T>) -> Unit): T? {
+  return awaitResult {
     this.executeBlocking(blockingCodeHandler, it::handle)
   }
 }

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/Future.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/Future.kt
@@ -4,17 +4,14 @@ import io.vertx.core.Future
 import io.vertx.kotlin.coroutines.awaitResult
 
 /**
- * Set a handler for the result.
- * <p>
- * If the future has already been completed it will be called immediately. Otherwise it will be called when the
- * future is completed.
+ * Suspending version of method [io.vertx.core.Future.setHandler]
  *
- * @return a reference to this, so it can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.Future original] using Vert.x codegen.
+ * @return [T]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.Future] using Vert.x codegen.
  */
-suspend fun <T> Future<T>.setHandlerAwait() : T {
-  return awaitResult{
+suspend fun <T> Future<T>.setHandlerAwait(): T {
+  return awaitResult {
     this.setHandler(it)
   }
 }

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/Vertx.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/Vertx.kt
@@ -2,7 +2,6 @@ package io.vertx.kotlin.core
 
 import io.vertx.core.DeploymentOptions
 import io.vertx.core.Future
-import io.vertx.core.Handler
 import io.vertx.core.Verticle
 import io.vertx.core.Vertx as VertxVertxAlias
 import io.vertx.core.VertxOptions
@@ -10,184 +9,143 @@ import io.vertx.kotlin.coroutines.awaitResult
 import java.util.function.Supplier
 
 /**
- * Like [io.vertx.core.Vertx] but the completionHandler will be called when the close is complete
+ * Suspending version of method [io.vertx.core.Vertx.close]
  *
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.Vertx original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.core.Vertx] using Vert.x codegen.
  */
-suspend fun VertxVertxAlias.closeAwait() : Unit {
-  return awaitResult{
-    this.close({ ar -> it.handle(ar.mapEmpty()) })}
+suspend fun VertxVertxAlias.closeAwait(): Unit {
+  return awaitResult {
+    this.close { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Like [io.vertx.core.Vertx] but the completionHandler will be notified when the deployment is complete.
- * <p>
- * If the deployment is successful the result will contain a String representing the unique deployment ID of the
- * deployment.
- * <p>
- * This deployment ID can subsequently be used to undeploy the verticle.
+ * Suspending version of method [io.vertx.core.Vertx.deployVerticle]
  *
  * @param name The identifier
+ * @return [String]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.Vertx original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.core.Vertx] using Vert.x codegen.
  */
-suspend fun VertxVertxAlias.deployVerticleAwait(name : String) : String {
-  return awaitResult{
+suspend fun VertxVertxAlias.deployVerticleAwait(name: String): String {
+  return awaitResult {
     this.deployVerticle(name, it)
   }
 }
 
 /**
- * Like [io.vertx.core.Vertx] but [io.vertx.core.DeploymentOptions] are provided to configure the
- * deployment.
+ * Suspending version of method [io.vertx.core.Vertx.deployVerticle]
  *
  * @param name the name
  * @param options the deployment options.
+ * @return [String]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.Vertx original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.core.Vertx] using Vert.x codegen.
  */
-suspend fun VertxVertxAlias.deployVerticleAwait(name : String, options : DeploymentOptions) : String {
-  return awaitResult{
+suspend fun VertxVertxAlias.deployVerticleAwait(name: String, options: DeploymentOptions): String {
+  return awaitResult {
     this.deployVerticle(name, options, it)
   }
 }
 
 /**
- * Like [io.vertx.core.Vertx][#undeploy(String)][io.vertx.core.Vertx] but the completionHandler will be notified when the undeployment is complete.
+ * Suspending version of method [io.vertx.core.Vertx.undeploy]
  *
  * @param deploymentID the deployment ID
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.Vertx original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.core.Vertx] using Vert.x codegen.
  */
-suspend fun VertxVertxAlias.undeployAwait(deploymentID : String) : Unit {
-  return awaitResult{
-    this.undeploy(deploymentID, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun VertxVertxAlias.undeployAwait(deploymentID: String): Unit {
+  return awaitResult {
+    this.undeploy(deploymentID) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Safely execute some blocking code.
- * <p>
- * Executes the blocking code in the handler <code>blockingCodeHandler</code> using a thread from the worker pool.
- * <p>
- * When the code is complete the handler <code>resultHandler</code> will be called with the result on the original context
- * (e.g. on the original event loop of the caller).
- * <p>
- * A <code>Future</code> instance is passed into <code>blockingCodeHandler</code>. When the blocking code successfully completes,
- * the handler should call the [io.vertx.core.Future] or [io.vertx.core.Future] method, or the [io.vertx.core.Future]
- * method if it failed.
- * <p>
- * In the <code>blockingCodeHandler</code> the current context remains the original context and therefore any task
- * scheduled in the <code>blockingCodeHandler</code> will be executed on the this context and not on the worker thread.
- * <p>
- * The blocking code should block for a reasonable amount of time (i.e no more than a few seconds). Long blocking operations
- * or polling operations (i.e a thread that spin in a loop polling events in a blocking fashion) are precluded.
- * <p>
- * When the blocking operation lasts more than the 10 seconds, a message will be printed on the console by the
- * blocked thread checker.
- * <p>
- * Long blocking operations should use a dedicated thread managed by the application, which can interact with
- * verticles using the event-bus or [io.vertx.core.Context]
+ * Suspending version of method [io.vertx.core.Vertx.executeBlocking]
  *
  * @param blockingCodeHandler handler representing the blocking code to run
  * @param ordered if true then if executeBlocking is called several times on the same context, the executions for that context will be executed serially, not in parallel. if false then they will be no ordering guarantees
+ * @return [T?]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.Vertx original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.core.Vertx] using Vert.x codegen.
  */
-suspend fun <T> VertxVertxAlias.executeBlockingAwait(blockingCodeHandler : (Future<T>) -> Unit, ordered : Boolean) : T? {
-  return awaitResult{
+suspend fun <T> VertxVertxAlias.executeBlockingAwait(blockingCodeHandler: (Future<T>) -> Unit, ordered: Boolean): T? {
+  return awaitResult {
     this.executeBlocking(blockingCodeHandler, ordered, it::handle)
   }
 }
 
 /**
- * Like [io.vertx.core.Vertx] called with ordered = true.
+ * Suspending version of method [io.vertx.core.Vertx.executeBlocking]
  *
  * @param blockingCodeHandler 
+ * @return [T?]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.Vertx original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.core.Vertx] using Vert.x codegen.
  */
-suspend fun <T> VertxVertxAlias.executeBlockingAwait(blockingCodeHandler : (Future<T>) -> Unit) : T? {
-  return awaitResult{
+suspend fun <T> VertxVertxAlias.executeBlockingAwait(blockingCodeHandler: (Future<T>) -> Unit): T? {
+  return awaitResult {
     this.executeBlocking(blockingCodeHandler, it::handle)
   }
 }
 
 /**
- * Like [io.vertx.core.Vertx] but the completionHandler will be notified when the deployment is complete.
- * <p>
- * If the deployment is successful the result will contain a string representing the unique deployment ID of the
- * deployment.
- * <p>
- * This deployment ID can subsequently be used to undeploy the verticle.
+ * Suspending version of method [io.vertx.core.Vertx.deployVerticle]
  *
  * @param verticle the verticle instance to deploy
+ * @return [String]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.Vertx original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.core.Vertx] using Vert.x codegen.
  */
-suspend fun VertxVertxAlias.deployVerticleAwait(verticle : Verticle) : String {
-  return awaitResult{
+suspend fun VertxVertxAlias.deployVerticleAwait(verticle: Verticle): String {
+  return awaitResult {
     this.deployVerticle(verticle, it)
   }
 }
 
 /**
- * Like [io.vertx.core.Vertx] but [io.vertx.core.DeploymentOptions] are provided to configure the
- * deployment.
+ * Suspending version of method [io.vertx.core.Vertx.deployVerticle]
  *
  * @param verticle the verticle instance to deploy
  * @param options the deployment options.
+ * @return [String]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.Vertx original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.core.Vertx] using Vert.x codegen.
  */
-suspend fun VertxVertxAlias.deployVerticleAwait(verticle : Verticle, options : DeploymentOptions) : String {
-  return awaitResult{
+suspend fun VertxVertxAlias.deployVerticleAwait(verticle: Verticle, options: DeploymentOptions): String {
+  return awaitResult {
     this.deployVerticle(verticle, options, it)
   }
 }
 
 /**
- * Like [io.vertx.core.Vertx] but [io.vertx.core.Verticle] instance is created by
- * invoking the <code>verticleSupplier</code>.
- * <p>
- * The supplier will be invoked as many times as [io.vertx.core.DeploymentOptions].
- * It must not return the same instance twice.
- * <p>
- * Note that the supplier will be invoked on the caller thread.
+ * Suspending version of method [io.vertx.core.Vertx.deployVerticle]
  *
  * @param verticleSupplier 
  * @param options 
+ * @return [String]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.Vertx original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.core.Vertx] using Vert.x codegen.
  */
-suspend fun VertxVertxAlias.deployVerticleAwait(verticleSupplier : Supplier<Verticle>, options : DeploymentOptions) : String {
-  return awaitResult{
+suspend fun VertxVertxAlias.deployVerticleAwait(verticleSupplier: Supplier<Verticle>, options: DeploymentOptions): String {
+  return awaitResult {
     this.deployVerticle(verticleSupplier, options, it)
   }
 }
 
 object Vertx {
   /**
-   * Creates a clustered instance using the specified options.
-   * <p>
-   * The instance is created asynchronously and the resultHandler is called with the result when it is ready.
+   * Suspending version of method [io.vertx.core.Vertx.clusteredVertx]
    *
    * @param options the options to use
+   * @return [VertxVertxAlias]
    *
-   * <p/>
-   * NOTE: This function has been automatically generated from the [io.vertx.core.Vertx original] using Vert.x codegen.
+   * NOTE: This function has been automatically generated from [io.vertx.core.Vertx] using Vert.x codegen.
    */
-  suspend fun clusteredVertxAwait(options : VertxOptions) : VertxVertxAlias {
-    return awaitResult{
+  suspend fun clusteredVertxAwait(options: VertxOptions): VertxVertxAlias {
+    return awaitResult {
       VertxVertxAlias.clusteredVertx(options, it)
     }
   }

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/WorkerExecutor.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/WorkerExecutor.kt
@@ -1,47 +1,34 @@
 package io.vertx.kotlin.core
 
 import io.vertx.core.Future
-import io.vertx.core.Handler
 import io.vertx.core.WorkerExecutor
 import io.vertx.kotlin.coroutines.awaitResult
 
 /**
- * Safely execute some blocking code.
- * <p>
- * Executes the blocking code in the handler <code>blockingCodeHandler</code> using a thread from the worker pool.
- * <p>
- * When the code is complete the handler <code>resultHandler</code> will be called with the result on the original context
- * (i.e. on the original event loop of the caller).
- * <p>
- * A <code>Future</code> instance is passed into <code>blockingCodeHandler</code>. When the blocking code successfully completes,
- * the handler should call the [io.vertx.core.Future] or [io.vertx.core.Future] method, or the [io.vertx.core.Future]
- * method if it failed.
- * <p>
- * In the <code>blockingCodeHandler</code> the current context remains the original context and therefore any task
- * scheduled in the <code>blockingCodeHandler</code> will be executed on the this context and not on the worker thread.
+ * Suspending version of method [io.vertx.core.WorkerExecutor.executeBlocking]
  *
  * @param blockingCodeHandler handler representing the blocking code to run
  * @param ordered if true then if executeBlocking is called several times on the same context, the executions for that context will be executed serially, not in parallel. if false then they will be no ordering guarantees
+ * @return [T?]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.WorkerExecutor original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.core.WorkerExecutor] using Vert.x codegen.
  */
-suspend fun <T> WorkerExecutor.executeBlockingAwait(blockingCodeHandler : (Future<T>) -> Unit, ordered : Boolean) : T? {
-  return awaitResult{
+suspend fun <T> WorkerExecutor.executeBlockingAwait(blockingCodeHandler: (Future<T>) -> Unit, ordered: Boolean): T? {
+  return awaitResult {
     this.executeBlocking(blockingCodeHandler, ordered, it::handle)
   }
 }
 
 /**
- * Like [io.vertx.core.WorkerExecutor] called with ordered = true.
+ * Suspending version of method [io.vertx.core.WorkerExecutor.executeBlocking]
  *
  * @param blockingCodeHandler 
+ * @return [T?]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.WorkerExecutor original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.core.WorkerExecutor] using Vert.x codegen.
  */
-suspend fun <T> WorkerExecutor.executeBlockingAwait(blockingCodeHandler : (Future<T>) -> Unit) : T? {
-  return awaitResult{
+suspend fun <T> WorkerExecutor.executeBlockingAwait(blockingCodeHandler: (Future<T>) -> Unit): T? {
+  return awaitResult {
     this.executeBlocking(blockingCodeHandler, it::handle)
   }
 }

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/datagram/DatagramSocket.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/datagram/DatagramSocket.kt
@@ -5,178 +5,168 @@ import io.vertx.core.datagram.DatagramSocket
 import io.vertx.kotlin.coroutines.awaitResult
 
 /**
- * Write the given [io.vertx.core.buffer.Buffer] to the [io.vertx.core.net.SocketAddress].
- * The [io.vertx.core.Handler] will be notified once the write completes.
+ * Suspending version of method [io.vertx.core.datagram.DatagramSocket.send]
  *
  * @param packet the [io.vertx.core.buffer.Buffer] to write
  * @param port the host port of the remote peer
  * @param host the host address of the remote peer
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.datagram.DatagramSocket original] using Vert.x codegen.
+ * @return [DatagramSocket]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.datagram.DatagramSocket] using Vert.x codegen.
  */
-suspend fun DatagramSocket.sendAwait(packet : Buffer, port : Int, host : String) : DatagramSocket {
-  return awaitResult{
+suspend fun DatagramSocket.sendAwait(packet: Buffer, port: Int, host: String): DatagramSocket {
+  return awaitResult {
     this.send(packet, port, host, it)
   }
 }
 
 /**
- * Write the given [java.lang.String] to the [io.vertx.core.net.SocketAddress] using UTF8 encoding.
- * The  will be notified once the write completes.
+ * Suspending version of method [io.vertx.core.datagram.DatagramSocket.send]
  *
  * @param str the [java.lang.String] to write
  * @param port the host port of the remote peer
  * @param host the host address of the remote peer
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.datagram.DatagramSocket original] using Vert.x codegen.
+ * @return [DatagramSocket]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.datagram.DatagramSocket] using Vert.x codegen.
  */
-suspend fun DatagramSocket.sendAwait(str : String, port : Int, host : String) : DatagramSocket {
-  return awaitResult{
+suspend fun DatagramSocket.sendAwait(str: String, port: Int, host: String): DatagramSocket {
+  return awaitResult {
     this.send(str, port, host, it)
   }
 }
 
 /**
- * Write the given [java.lang.String] to the [io.vertx.core.net.SocketAddress] using the given encoding.
- * The  will be notified once the write completes.
+ * Suspending version of method [io.vertx.core.datagram.DatagramSocket.send]
  *
  * @param str the [java.lang.String] to write
  * @param enc the charset used for encoding
  * @param port the host port of the remote peer
  * @param host the host address of the remote peer
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.datagram.DatagramSocket original] using Vert.x codegen.
+ * @return [DatagramSocket]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.datagram.DatagramSocket] using Vert.x codegen.
  */
-suspend fun DatagramSocket.sendAwait(str : String, enc : String, port : Int, host : String) : DatagramSocket {
-  return awaitResult{
+suspend fun DatagramSocket.sendAwait(str: String, enc: String, port: Int, host: String): DatagramSocket {
+  return awaitResult {
     this.send(str, enc, port, host, it)
   }
 }
 
 /**
- * Closes the [io.vertx.core.datagram.DatagramSocket] implementation asynchronous
- * and notifies the handler once done.
+ * Suspending version of method [io.vertx.core.datagram.DatagramSocket.close]
  *
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.datagram.DatagramSocket original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.core.datagram.DatagramSocket] using Vert.x codegen.
  */
-suspend fun DatagramSocket.closeAwait() : Unit {
-  return awaitResult{
-    this.close({ ar -> it.handle(ar.mapEmpty()) })}
+suspend fun DatagramSocket.closeAwait(): Unit {
+  return awaitResult {
+    this.close { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Joins a multicast group and listens for packets send to it.
- * The  is notified once the operation completes.
+ * Suspending version of method [io.vertx.core.datagram.DatagramSocket.listenMulticastGroup]
  *
  * @param multicastAddress the address of the multicast group to join
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.datagram.DatagramSocket original] using Vert.x codegen.
+ * @return [DatagramSocket]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.datagram.DatagramSocket] using Vert.x codegen.
  */
-suspend fun DatagramSocket.listenMulticastGroupAwait(multicastAddress : String) : DatagramSocket {
-  return awaitResult{
+suspend fun DatagramSocket.listenMulticastGroupAwait(multicastAddress: String): DatagramSocket {
+  return awaitResult {
     this.listenMulticastGroup(multicastAddress, it)
   }
 }
 
 /**
- * Joins a multicast group and listens for packets send to it on the given network interface.
- * The  is notified once the operation completes.
+ * Suspending version of method [io.vertx.core.datagram.DatagramSocket.listenMulticastGroup]
  *
  * @param multicastAddress the address of the multicast group to join
  * @param networkInterface the network interface on which to listen for packets.
  * @param source the address of the source for which we will listen for multicast packets
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.datagram.DatagramSocket original] using Vert.x codegen.
+ * @return [DatagramSocket]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.datagram.DatagramSocket] using Vert.x codegen.
  */
-suspend fun DatagramSocket.listenMulticastGroupAwait(multicastAddress : String, networkInterface : String, source : String) : DatagramSocket {
-  return awaitResult{
+suspend fun DatagramSocket.listenMulticastGroupAwait(multicastAddress: String, networkInterface: String, source: String): DatagramSocket {
+  return awaitResult {
     this.listenMulticastGroup(multicastAddress, networkInterface, source, it)
   }
 }
 
 /**
- * Leaves a multicast group and stops listening for packets send to it.
- * The  is notified once the operation completes.
+ * Suspending version of method [io.vertx.core.datagram.DatagramSocket.unlistenMulticastGroup]
  *
  * @param multicastAddress the address of the multicast group to leave
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.datagram.DatagramSocket original] using Vert.x codegen.
+ * @return [DatagramSocket]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.datagram.DatagramSocket] using Vert.x codegen.
  */
-suspend fun DatagramSocket.unlistenMulticastGroupAwait(multicastAddress : String) : DatagramSocket {
-  return awaitResult{
+suspend fun DatagramSocket.unlistenMulticastGroupAwait(multicastAddress: String): DatagramSocket {
+  return awaitResult {
     this.unlistenMulticastGroup(multicastAddress, it)
   }
 }
 
 /**
- * Leaves a multicast group and stops listening for packets send to it on the given network interface.
- * The  is notified once the operation completes.
+ * Suspending version of method [io.vertx.core.datagram.DatagramSocket.unlistenMulticastGroup]
  *
  * @param multicastAddress the address of the multicast group to join
  * @param networkInterface the network interface on which to listen for packets.
  * @param source the address of the source for which we will listen for multicast packets
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.datagram.DatagramSocket original] using Vert.x codegen.
+ * @return [DatagramSocket]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.datagram.DatagramSocket] using Vert.x codegen.
  */
-suspend fun DatagramSocket.unlistenMulticastGroupAwait(multicastAddress : String, networkInterface : String, source : String) : DatagramSocket {
-  return awaitResult{
+suspend fun DatagramSocket.unlistenMulticastGroupAwait(multicastAddress: String, networkInterface: String, source: String): DatagramSocket {
+  return awaitResult {
     this.unlistenMulticastGroup(multicastAddress, networkInterface, source, it)
   }
 }
 
 /**
- * Block the given address for the given multicast address and notifies the  once
- * the operation completes.
+ * Suspending version of method [io.vertx.core.datagram.DatagramSocket.blockMulticastGroup]
  *
  * @param multicastAddress the address for which you want to block the source address
  * @param sourceToBlock the source address which should be blocked. You will not receive an multicast packets for it anymore.
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.datagram.DatagramSocket original] using Vert.x codegen.
+ * @return [DatagramSocket]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.datagram.DatagramSocket] using Vert.x codegen.
  */
-suspend fun DatagramSocket.blockMulticastGroupAwait(multicastAddress : String, sourceToBlock : String) : DatagramSocket {
-  return awaitResult{
+suspend fun DatagramSocket.blockMulticastGroupAwait(multicastAddress: String, sourceToBlock: String): DatagramSocket {
+  return awaitResult {
     this.blockMulticastGroup(multicastAddress, sourceToBlock, it)
   }
 }
 
 /**
- * Block the given address for the given multicast address on the given network interface and notifies
- * the  once the operation completes.
+ * Suspending version of method [io.vertx.core.datagram.DatagramSocket.blockMulticastGroup]
  *
  * @param multicastAddress the address for which you want to block the source address
  * @param networkInterface the network interface on which the blocking should occur.
  * @param sourceToBlock the source address which should be blocked. You will not receive an multicast packets for it anymore.
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.datagram.DatagramSocket original] using Vert.x codegen.
+ * @return [DatagramSocket]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.datagram.DatagramSocket] using Vert.x codegen.
  */
-suspend fun DatagramSocket.blockMulticastGroupAwait(multicastAddress : String, networkInterface : String, sourceToBlock : String) : DatagramSocket {
-  return awaitResult{
+suspend fun DatagramSocket.blockMulticastGroupAwait(multicastAddress: String, networkInterface: String, sourceToBlock: String): DatagramSocket {
+  return awaitResult {
     this.blockMulticastGroup(multicastAddress, networkInterface, sourceToBlock, it)
   }
 }
 
 /**
- * Start listening on the given port and host. The handler will be called when the socket is listening.
+ * Suspending version of method [io.vertx.core.datagram.DatagramSocket.listen]
  *
  * @param port the port to listen on
  * @param host the host to listen on
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.datagram.DatagramSocket original] using Vert.x codegen.
+ * @return [DatagramSocket]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.datagram.DatagramSocket] using Vert.x codegen.
  */
-suspend fun DatagramSocket.listenAwait(port : Int, host : String) : DatagramSocket {
-  return awaitResult{
+suspend fun DatagramSocket.listenAwait(port: Int, host: String): DatagramSocket {
+  return awaitResult {
     this.listen(port, host, it)
   }
 }

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/dns/DnsClient.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/dns/DnsClient.kt
@@ -6,170 +6,169 @@ import io.vertx.core.dns.SrvRecord
 import io.vertx.kotlin.coroutines.awaitResult
 
 /**
- * Try to lookup the A (ipv4) or AAAA (ipv6) record for the given name. The first found will be used.
+ * Suspending version of method [io.vertx.core.dns.DnsClient.lookup]
  *
  * @param name the name to resolve
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.dns.DnsClient original] using Vert.x codegen.
+ * @return [String?]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.dns.DnsClient] using Vert.x codegen.
  */
-suspend fun DnsClient.lookupAwait(name : String) : String? {
-  return awaitResult{
+suspend fun DnsClient.lookupAwait(name: String): String? {
+  return awaitResult {
     this.lookup(name, it)
   }
 }
 
 /**
- * Try to lookup the A (ipv4) record for the given name. The first found will be used.
+ * Suspending version of method [io.vertx.core.dns.DnsClient.lookup4]
  *
  * @param name the name to resolve
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.dns.DnsClient original] using Vert.x codegen.
+ * @return [String?]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.dns.DnsClient] using Vert.x codegen.
  */
-suspend fun DnsClient.lookup4Await(name : String) : String? {
-  return awaitResult{
+suspend fun DnsClient.lookup4Await(name: String): String? {
+  return awaitResult {
     this.lookup4(name, it)
   }
 }
 
 /**
- * Try to lookup the AAAA (ipv6) record for the given name. The first found will be used.
+ * Suspending version of method [io.vertx.core.dns.DnsClient.lookup6]
  *
  * @param name the name to resolve
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.dns.DnsClient original] using Vert.x codegen.
+ * @return [String?]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.dns.DnsClient] using Vert.x codegen.
  */
-suspend fun DnsClient.lookup6Await(name : String) : String? {
-  return awaitResult{
+suspend fun DnsClient.lookup6Await(name: String): String? {
+  return awaitResult {
     this.lookup6(name, it)
   }
 }
 
 /**
- * Try to resolve all A (ipv4) records for the given name.
+ * Suspending version of method [io.vertx.core.dns.DnsClient.resolveA]
  *
  * @param name the name to resolve
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.dns.DnsClient original] using Vert.x codegen.
+ * @return [List<String>]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.dns.DnsClient] using Vert.x codegen.
  */
-suspend fun DnsClient.resolveAAwait(name : String) : List<String> {
-  return awaitResult{
+suspend fun DnsClient.resolveAAwait(name: String): List<String> {
+  return awaitResult {
     this.resolveA(name, it)
   }
 }
 
 /**
- * Try to resolve all AAAA (ipv6) records for the given name.
+ * Suspending version of method [io.vertx.core.dns.DnsClient.resolveAAAA]
  *
  * @param name the name to resolve
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.dns.DnsClient original] using Vert.x codegen.
+ * @return [List<String>]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.dns.DnsClient] using Vert.x codegen.
  */
-suspend fun DnsClient.resolveAAAAAwait(name : String) : List<String> {
-  return awaitResult{
+suspend fun DnsClient.resolveAAAAAwait(name: String): List<String> {
+  return awaitResult {
     this.resolveAAAA(name, it)
   }
 }
 
 /**
- * Try to resolve the CNAME record for the given name.
+ * Suspending version of method [io.vertx.core.dns.DnsClient.resolveCNAME]
  *
  * @param name the name to resolve the CNAME for
- * @return a reference to this, so the API can be used fluently. *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.dns.DnsClient original] using Vert.x codegen.
+ * @return [List<String>]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.dns.DnsClient] using Vert.x codegen.
  */
-suspend fun DnsClient.resolveCNAMEAwait(name : String) : List<String> {
-  return awaitResult{
+suspend fun DnsClient.resolveCNAMEAwait(name: String): List<String> {
+  return awaitResult {
     this.resolveCNAME(name, it)
   }
 }
 
 /**
- * Try to resolve the MX records for the given name.
+ * Suspending version of method [io.vertx.core.dns.DnsClient.resolveMX]
  *
  * @param name the name for which the MX records should be resolved
- * @return a reference to this, so the API can be used fluently. *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.dns.DnsClient original] using Vert.x codegen.
+ * @return [List<MxRecord>]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.dns.DnsClient] using Vert.x codegen.
  */
-suspend fun DnsClient.resolveMXAwait(name : String) : List<MxRecord> {
-  return awaitResult{
+suspend fun DnsClient.resolveMXAwait(name: String): List<MxRecord> {
+  return awaitResult {
     this.resolveMX(name, it)
   }
 }
 
 /**
- * Try to resolve the TXT records for the given name.
+ * Suspending version of method [io.vertx.core.dns.DnsClient.resolveTXT]
  *
  * @param name the name for which the TXT records should be resolved
- * @return a reference to this, so the API can be used fluently. *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.dns.DnsClient original] using Vert.x codegen.
+ * @return [List<String>]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.dns.DnsClient] using Vert.x codegen.
  */
-suspend fun DnsClient.resolveTXTAwait(name : String) : List<String> {
-  return awaitResult{
+suspend fun DnsClient.resolveTXTAwait(name: String): List<String> {
+  return awaitResult {
     this.resolveTXT(name, it)
   }
 }
 
 /**
- * Try to resolve the PTR record for the given name.
+ * Suspending version of method [io.vertx.core.dns.DnsClient.resolvePTR]
  *
  * @param name the name to resolve the PTR for
- * @return a reference to this, so the API can be used fluently. *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.dns.DnsClient original] using Vert.x codegen.
+ * @return [String?]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.dns.DnsClient] using Vert.x codegen.
  */
-suspend fun DnsClient.resolvePTRAwait(name : String) : String? {
-  return awaitResult{
+suspend fun DnsClient.resolvePTRAwait(name: String): String? {
+  return awaitResult {
     this.resolvePTR(name, it)
   }
 }
 
 /**
- * Try to resolve the NS records for the given name.
+ * Suspending version of method [io.vertx.core.dns.DnsClient.resolveNS]
  *
  * @param name the name for which the NS records should be resolved
- * @return a reference to this, so the API can be used fluently. *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.dns.DnsClient original] using Vert.x codegen.
+ * @return [List<String>]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.dns.DnsClient] using Vert.x codegen.
  */
-suspend fun DnsClient.resolveNSAwait(name : String) : List<String> {
-  return awaitResult{
+suspend fun DnsClient.resolveNSAwait(name: String): List<String> {
+  return awaitResult {
     this.resolveNS(name, it)
   }
 }
 
 /**
- * Try to resolve the SRV records for the given name.
+ * Suspending version of method [io.vertx.core.dns.DnsClient.resolveSRV]
  *
  * @param name the name for which the SRV records should be resolved
- * @return a reference to this, so the API can be used fluently. *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.dns.DnsClient original] using Vert.x codegen.
+ * @return [List<SrvRecord>]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.dns.DnsClient] using Vert.x codegen.
  */
-suspend fun DnsClient.resolveSRVAwait(name : String) : List<SrvRecord> {
-  return awaitResult{
+suspend fun DnsClient.resolveSRVAwait(name: String): List<SrvRecord> {
+  return awaitResult {
     this.resolveSRV(name, it)
   }
 }
 
 /**
- * Try to do a reverse lookup of an IP address. This is basically the same as doing trying to resolve a PTR record
- * but allows you to just pass in the IP address and not a valid ptr query string.
+ * Suspending version of method [io.vertx.core.dns.DnsClient.reverseLookup]
  *
  * @param ipaddress the IP address to resolve the PTR for
- * @return a reference to this, so the API can be used fluently. *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.dns.DnsClient original] using Vert.x codegen.
+ * @return [String?]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.dns.DnsClient] using Vert.x codegen.
  */
-suspend fun DnsClient.reverseLookupAwait(ipaddress : String) : String? {
-  return awaitResult{
+suspend fun DnsClient.reverseLookupAwait(ipaddress: String): String? {
+  return awaitResult {
     this.reverseLookup(ipaddress, it)
   }
 }

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/eventbus/EventBus.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/eventbus/EventBus.kt
@@ -6,34 +6,32 @@ import io.vertx.core.eventbus.Message
 import io.vertx.kotlin.coroutines.awaitResult
 
 /**
- * Like [io.vertx.core.eventbus.EventBus] but specifying a <code>replyHandler</code> that will be called if the recipient
- * subsequently replies to the message.
+ * Suspending version of method [io.vertx.core.eventbus.EventBus.send]
  *
  * @param address the address to send it to
  * @param message the message, may be <code>null</code>
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.eventbus.EventBus original] using Vert.x codegen.
+ * @return [Message<T>]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.eventbus.EventBus] using Vert.x codegen.
  */
-suspend fun <T> EventBus.sendAwait(address : String, message : Any) : Message<T> {
-  return awaitResult{
+suspend fun <T> EventBus.sendAwait(address: String, message: Any): Message<T> {
+  return awaitResult {
     this.send(address, message, it)
   }
 }
 
 /**
- * Like [io.vertx.core.eventbus.EventBus] but specifying a <code>replyHandler</code> that will be called if the recipient
- * subsequently replies to the message.
+ * Suspending version of method [io.vertx.core.eventbus.EventBus.send]
  *
  * @param address the address to send it to
  * @param message the message, may be <code>null</code>
  * @param options delivery options
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.eventbus.EventBus original] using Vert.x codegen.
+ * @return [Message<T>]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.eventbus.EventBus] using Vert.x codegen.
  */
-suspend fun <T> EventBus.sendAwait(address : String, message : Any, options : DeliveryOptions) : Message<T> {
-  return awaitResult{
+suspend fun <T> EventBus.sendAwait(address: String, message: Any, options: DeliveryOptions): Message<T> {
+  return awaitResult {
     this.send(address, message, options, it)
   }
 }

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/eventbus/Message.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/eventbus/Message.kt
@@ -5,32 +5,30 @@ import io.vertx.core.eventbus.Message
 import io.vertx.kotlin.coroutines.awaitResult
 
 /**
- * The same as <code>reply(R message)</code> but you can specify handler for the reply - i.e.
- * to receive the reply to the reply.
+ * Suspending version of method [io.vertx.core.eventbus.Message.reply]
  *
  * @param message the message to reply with.
+ * @return [Message<R>]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.eventbus.Message original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.core.eventbus.Message] using Vert.x codegen.
  */
-suspend fun <R,T> Message<T>.replyAwait(message : Any) : Message<R> {
-  return awaitResult{
+suspend fun <R,T> Message<T>.replyAwait(message: Any): Message<R> {
+  return awaitResult {
     this.reply(message, it)
   }
 }
 
 /**
- * The same as <code>reply(R message, DeliveryOptions)</code> but you can specify handler for the reply - i.e.
- * to receive the reply to the reply.
+ * Suspending version of method [io.vertx.core.eventbus.Message.reply]
  *
  * @param message the reply message
  * @param options the delivery options
+ * @return [Message<R>]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.eventbus.Message original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.core.eventbus.Message] using Vert.x codegen.
  */
-suspend fun <R,T> Message<T>.replyAwait(message : Any, options : DeliveryOptions) : Message<R> {
-  return awaitResult{
+suspend fun <R,T> Message<T>.replyAwait(message: Any, options: DeliveryOptions): Message<R> {
+  return awaitResult {
     this.reply(message, options, it)
   }
 }

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/eventbus/MessageConsumer.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/eventbus/MessageConsumer.kt
@@ -4,26 +4,26 @@ import io.vertx.core.eventbus.MessageConsumer
 import io.vertx.kotlin.coroutines.awaitResult
 
 /**
- * Optional method which can be called to indicate when the registration has been propagated across the cluster.
+ * Suspending version of method [io.vertx.core.eventbus.MessageConsumer.completionHandler]
  *
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.eventbus.MessageConsumer original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.core.eventbus.MessageConsumer] using Vert.x codegen.
  */
-suspend fun <T> MessageConsumer<T>.completionHandlerAwait() : Unit {
-  return awaitResult{
-    this.completionHandler({ ar -> it.handle(ar.mapEmpty()) })}
+suspend fun <T> MessageConsumer<T>.completionHandlerAwait(): Unit {
+  return awaitResult {
+    this.completionHandler { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Unregisters the handler which created this registration
+ * Suspending version of method [io.vertx.core.eventbus.MessageConsumer.unregister]
  *
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.eventbus.MessageConsumer original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.core.eventbus.MessageConsumer] using Vert.x codegen.
  */
-suspend fun <T> MessageConsumer<T>.unregisterAwait() : Unit {
-  return awaitResult{
-    this.unregister({ ar -> it.handle(ar.mapEmpty()) })}
+suspend fun <T> MessageConsumer<T>.unregisterAwait(): Unit {
+  return awaitResult {
+    this.unregister { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/file/AsyncFile.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/file/AsyncFile.kt
@@ -5,73 +5,57 @@ import io.vertx.core.file.AsyncFile
 import io.vertx.kotlin.coroutines.awaitResult
 
 /**
- * Close the file. The actual close happens asynchronously.
- * The handler will be called when the close is complete, or an error occurs.
+ * Suspending version of method [io.vertx.core.file.AsyncFile.close]
  *
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.file.AsyncFile original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.core.file.AsyncFile] using Vert.x codegen.
  */
-suspend fun AsyncFile.closeAwait() : Unit {
-  return awaitResult{
-    this.close({ ar -> it.handle(ar.mapEmpty()) })}
+suspend fun AsyncFile.closeAwait(): Unit {
+  return awaitResult {
+    this.close { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Write a [io.vertx.core.buffer.Buffer] to the file at position <code>position</code> in the file, asynchronously.
- * <p>
- * If <code>position</code> lies outside of the current size
- * of the file, the file will be enlarged to encompass it.
- * <p>
- * When multiple writes are invoked on the same file
- * there are no guarantees as to order in which those writes actually occur
- * <p>
- * The handler will be called when the write is complete, or if an error occurs.
+ * Suspending version of method [io.vertx.core.file.AsyncFile.write]
  *
  * @param buffer the buffer to write
  * @param position the position in the file to write it at
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.file.AsyncFile original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.file.AsyncFile] using Vert.x codegen.
  */
-suspend fun AsyncFile.writeAwait(buffer : Buffer, position : Long) : Unit {
-  return awaitResult{
-    this.write(buffer, position, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun AsyncFile.writeAwait(buffer: Buffer, position: Long): Unit {
+  return awaitResult {
+    this.write(buffer, position) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Reads <code>length</code> bytes of data from the file at position <code>position</code> in the file, asynchronously.
- * <p>
- * The read data will be written into the specified <code>Buffer buffer</code> at position <code>offset</code>.
- * <p>
- * If data is read past the end of the file then zero bytes will be read.<p>
- * When multiple reads are invoked on the same file there are no guarantees as to order in which those reads actually occur.
- * <p>
- * The handler will be called when the close is complete, or if an error occurs.
+ * Suspending version of method [io.vertx.core.file.AsyncFile.read]
  *
  * @param buffer the buffer to read into
  * @param offset the offset into the buffer where the data will be read
  * @param position the position in the file where to start reading
  * @param length the number of bytes to read
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.file.AsyncFile original] using Vert.x codegen.
+ * @return [Buffer]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.file.AsyncFile] using Vert.x codegen.
  */
-suspend fun AsyncFile.readAwait(buffer : Buffer, offset : Int, position : Long, length : Int) : Buffer {
-  return awaitResult{
+suspend fun AsyncFile.readAwait(buffer: Buffer, offset: Int, position: Long, length: Int): Buffer {
+  return awaitResult {
     this.read(buffer, offset, position, length, it)
   }
 }
 
 /**
- * Same as [io.vertx.core.file.AsyncFile] but the handler will be called when the flush is complete or if an error occurs
+ * Suspending version of method [io.vertx.core.file.AsyncFile.flush]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.file.AsyncFile original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.file.AsyncFile] using Vert.x codegen.
  */
-suspend fun AsyncFile.flushAwait() : Unit {
-  return awaitResult{
-    this.flush({ ar -> it.handle(ar.mapEmpty()) })}
+suspend fun AsyncFile.flushAwait(): Unit {
+  return awaitResult {
+    this.flush { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/file/FileSystem.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/file/FileSystem.kt
@@ -10,629 +10,516 @@ import io.vertx.core.file.OpenOptions
 import io.vertx.kotlin.coroutines.awaitResult
 
 /**
- * Copy a file from the path <code>from</code> to path <code>to</code>, asynchronously.
- * <p>
- * The copy will fail if the destination already exists.
+ * Suspending version of method [io.vertx.core.file.FileSystem.copy]
  *
  * @param from the path to copy from
  * @param to the path to copy to
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.file.FileSystem original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-suspend fun FileSystem.copyAwait(from : String, to : String) : Unit {
-  return awaitResult{
-    this.copy(from, to, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun FileSystem.copyAwait(from: String, to: String): Unit {
+  return awaitResult {
+    this.copy(from, to) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Copy a file from the path <code>from</code> to path <code>to</code>, asynchronously.
+ * Suspending version of method [io.vertx.core.file.FileSystem.copy]
  *
  * @param from the path to copy from
  * @param to the path to copy to
  * @param options options describing how the file should be copied
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.file.FileSystem original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-suspend fun FileSystem.copyAwait(from : String, to : String, options : CopyOptions) : Unit {
-  return awaitResult{
-    this.copy(from, to, options, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun FileSystem.copyAwait(from: String, to: String, options: CopyOptions): Unit {
+  return awaitResult {
+    this.copy(from, to, options) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Copy a file from the path <code>from</code> to path <code>to</code>, asynchronously.
- * <p>
- * If <code>recursive</code> is <code>true</code> and <code>from</code> represents a directory, then the directory and its contents
- * will be copied recursively to the destination <code>to</code>.
- * <p>
- * The copy will fail if the destination if the destination already exists.
+ * Suspending version of method [io.vertx.core.file.FileSystem.copyRecursive]
  *
  * @param from the path to copy from
  * @param to the path to copy to
  * @param recursive 
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.file.FileSystem original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-suspend fun FileSystem.copyRecursiveAwait(from : String, to : String, recursive : Boolean) : Unit {
-  return awaitResult{
-    this.copyRecursive(from, to, recursive, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun FileSystem.copyRecursiveAwait(from: String, to: String, recursive: Boolean): Unit {
+  return awaitResult {
+    this.copyRecursive(from, to, recursive) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Move a file from the path <code>from</code> to path <code>to</code>, asynchronously.
- * <p>
- * The move will fail if the destination already exists.
+ * Suspending version of method [io.vertx.core.file.FileSystem.move]
  *
  * @param from the path to copy from
  * @param to the path to copy to
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.file.FileSystem original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-suspend fun FileSystem.moveAwait(from : String, to : String) : Unit {
-  return awaitResult{
-    this.move(from, to, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun FileSystem.moveAwait(from: String, to: String): Unit {
+  return awaitResult {
+    this.move(from, to) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Move a file from the path <code>from</code> to path <code>to</code>, asynchronously.
+ * Suspending version of method [io.vertx.core.file.FileSystem.move]
  *
  * @param from the path to copy from
  * @param to the path to copy to
  * @param options options describing how the file should be copied
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.file.FileSystem original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-suspend fun FileSystem.moveAwait(from : String, to : String, options : CopyOptions) : Unit {
-  return awaitResult{
-    this.move(from, to, options, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun FileSystem.moveAwait(from: String, to: String, options: CopyOptions): Unit {
+  return awaitResult {
+    this.move(from, to, options) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Truncate the file represented by <code>path</code> to length <code>len</code> in bytes, asynchronously.
- * <p>
- * The operation will fail if the file does not exist or <code>len</code> is less than <code>zero</code>.
+ * Suspending version of method [io.vertx.core.file.FileSystem.truncate]
  *
  * @param path the path to the file
  * @param len the length to truncate it to
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.file.FileSystem original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-suspend fun FileSystem.truncateAwait(path : String, len : Long) : Unit {
-  return awaitResult{
-    this.truncate(path, len, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun FileSystem.truncateAwait(path: String, len: Long): Unit {
+  return awaitResult {
+    this.truncate(path, len) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Change the permissions on the file represented by <code>path</code> to <code>perms</code>, asynchronously.
- * <p>
- * The permission String takes the form rwxr-x--- as
- * specified <a href="http://download.oracle.com/javase/7/docs/api/java/nio/file/attribute/PosixFilePermissions.html">here</a>.
+ * Suspending version of method [io.vertx.core.file.FileSystem.chmod]
  *
  * @param path the path to the file
  * @param perms the permissions string
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.file.FileSystem original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-suspend fun FileSystem.chmodAwait(path : String, perms : String) : Unit {
-  return awaitResult{
-    this.chmod(path, perms, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun FileSystem.chmodAwait(path: String, perms: String): Unit {
+  return awaitResult {
+    this.chmod(path, perms) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Change the permissions on the file represented by <code>path</code> to <code>perms</code>, asynchronously.<p>
- * The permission String takes the form rwxr-x--- as
- * specified in {<a href="http://download.oracle.com/javase/7/docs/api/java/nio/file/attribute/PosixFilePermissions.html">here</a>}.
- * <p>
- * If the file is directory then all contents will also have their permissions changed recursively. Any directory permissions will
- * be set to <code>dirPerms</code>, whilst any normal file permissions will be set to <code>perms</code>.
+ * Suspending version of method [io.vertx.core.file.FileSystem.chmodRecursive]
  *
  * @param path the path to the file
  * @param perms the permissions string
  * @param dirPerms the directory permissions
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.file.FileSystem original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-suspend fun FileSystem.chmodRecursiveAwait(path : String, perms : String, dirPerms : String) : Unit {
-  return awaitResult{
-    this.chmodRecursive(path, perms, dirPerms, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun FileSystem.chmodRecursiveAwait(path: String, perms: String, dirPerms: String): Unit {
+  return awaitResult {
+    this.chmodRecursive(path, perms, dirPerms) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Change the ownership on the file represented by <code>path</code> to <code>user</code> and {code group}, asynchronously.
+ * Suspending version of method [io.vertx.core.file.FileSystem.chown]
  *
  * @param path the path to the file
  * @param user the user name, <code>null</code> will not change the user name
  * @param group the user group, <code>null</code> will not change the user group name
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.file.FileSystem original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-suspend fun FileSystem.chownAwait(path : String, user : String, group : String) : Unit {
-  return awaitResult{
-    this.chown(path, user, group, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun FileSystem.chownAwait(path: String, user: String, group: String): Unit {
+  return awaitResult {
+    this.chown(path, user, group) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Obtain properties for the file represented by <code>path</code>, asynchronously.
- * <p>
- * If the file is a link, the link will be followed.
+ * Suspending version of method [io.vertx.core.file.FileSystem.props]
  *
  * @param path the path to the file
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.file.FileSystem original] using Vert.x codegen.
+ * @return [FileProps]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-suspend fun FileSystem.propsAwait(path : String) : FileProps {
-  return awaitResult{
+suspend fun FileSystem.propsAwait(path: String): FileProps {
+  return awaitResult {
     this.props(path, it)
   }
 }
 
 /**
- * Obtain properties for the link represented by <code>path</code>, asynchronously.
- * <p>
- * The link will not be followed.
+ * Suspending version of method [io.vertx.core.file.FileSystem.lprops]
  *
  * @param path the path to the file
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.file.FileSystem original] using Vert.x codegen.
+ * @return [FileProps]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-suspend fun FileSystem.lpropsAwait(path : String) : FileProps {
-  return awaitResult{
+suspend fun FileSystem.lpropsAwait(path: String): FileProps {
+  return awaitResult {
     this.lprops(path, it)
   }
 }
 
 /**
- * Create a hard link on the file system from <code>link</code> to <code>existing</code>, asynchronously.
+ * Suspending version of method [io.vertx.core.file.FileSystem.link]
  *
  * @param link the link
  * @param existing the link destination
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.file.FileSystem original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-suspend fun FileSystem.linkAwait(link : String, existing : String) : Unit {
-  return awaitResult{
-    this.link(link, existing, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun FileSystem.linkAwait(link: String, existing: String): Unit {
+  return awaitResult {
+    this.link(link, existing) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Create a symbolic link on the file system from <code>link</code> to <code>existing</code>, asynchronously.
+ * Suspending version of method [io.vertx.core.file.FileSystem.symlink]
  *
  * @param link the link
  * @param existing the link destination
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.file.FileSystem original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-suspend fun FileSystem.symlinkAwait(link : String, existing : String) : Unit {
-  return awaitResult{
-    this.symlink(link, existing, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun FileSystem.symlinkAwait(link: String, existing: String): Unit {
+  return awaitResult {
+    this.symlink(link, existing) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Unlinks the link on the file system represented by the path <code>link</code>, asynchronously.
+ * Suspending version of method [io.vertx.core.file.FileSystem.unlink]
  *
  * @param link the link
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.file.FileSystem original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-suspend fun FileSystem.unlinkAwait(link : String) : Unit {
-  return awaitResult{
-    this.unlink(link, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun FileSystem.unlinkAwait(link: String): Unit {
+  return awaitResult {
+    this.unlink(link) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Returns the path representing the file that the symbolic link specified by <code>link</code> points to, asynchronously.
+ * Suspending version of method [io.vertx.core.file.FileSystem.readSymlink]
  *
  * @param link the link
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.file.FileSystem original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-suspend fun FileSystem.readSymlinkAwait(link : String) : String {
-  return awaitResult{
+suspend fun FileSystem.readSymlinkAwait(link: String): String {
+  return awaitResult {
     this.readSymlink(link, it)
   }
 }
 
 /**
- * Deletes the file represented by the specified <code>path</code>, asynchronously.
+ * Suspending version of method [io.vertx.core.file.FileSystem.delete]
  *
  * @param path path to the file
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.file.FileSystem original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-suspend fun FileSystem.deleteAwait(path : String) : Unit {
-  return awaitResult{
-    this.delete(path, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun FileSystem.deleteAwait(path: String): Unit {
+  return awaitResult {
+    this.delete(path) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Deletes the file represented by the specified <code>path</code>, asynchronously.
- * <p>
- * If the path represents a directory and <code>recursive = true</code> then the directory and its contents will be
- * deleted recursively.
+ * Suspending version of method [io.vertx.core.file.FileSystem.deleteRecursive]
  *
  * @param path path to the file
  * @param recursive delete recursively?
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.file.FileSystem original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-suspend fun FileSystem.deleteRecursiveAwait(path : String, recursive : Boolean) : Unit {
-  return awaitResult{
-    this.deleteRecursive(path, recursive, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun FileSystem.deleteRecursiveAwait(path: String, recursive: Boolean): Unit {
+  return awaitResult {
+    this.deleteRecursive(path, recursive) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Create the directory represented by <code>path</code>, asynchronously.
- * <p>
- * The operation will fail if the directory already exists.
+ * Suspending version of method [io.vertx.core.file.FileSystem.mkdir]
  *
  * @param path path to the file
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.file.FileSystem original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-suspend fun FileSystem.mkdirAwait(path : String) : Unit {
-  return awaitResult{
-    this.mkdir(path, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun FileSystem.mkdirAwait(path: String): Unit {
+  return awaitResult {
+    this.mkdir(path) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Create the directory represented by <code>path</code>, asynchronously.
- * <p>
- * The new directory will be created with permissions as specified by <code>perms</code>.
- * <p>
- * The permission String takes the form rwxr-x--- as specified
- * in <a href="http://download.oracle.com/javase/7/docs/api/java/nio/file/attribute/PosixFilePermissions.html">here</a>.
- * <p>
- * The operation will fail if the directory already exists.
+ * Suspending version of method [io.vertx.core.file.FileSystem.mkdir]
  *
  * @param path path to the file
  * @param perms the permissions string
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.file.FileSystem original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-suspend fun FileSystem.mkdirAwait(path : String, perms : String) : Unit {
-  return awaitResult{
-    this.mkdir(path, perms, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun FileSystem.mkdirAwait(path: String, perms: String): Unit {
+  return awaitResult {
+    this.mkdir(path, perms) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Create the directory represented by <code>path</code> and any non existent parents, asynchronously.
- * <p>
- * The operation will fail if the directory already exists.
+ * Suspending version of method [io.vertx.core.file.FileSystem.mkdirs]
  *
  * @param path path to the file
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.file.FileSystem original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-suspend fun FileSystem.mkdirsAwait(path : String) : Unit {
-  return awaitResult{
-    this.mkdirs(path, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun FileSystem.mkdirsAwait(path: String): Unit {
+  return awaitResult {
+    this.mkdirs(path) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Create the directory represented by <code>path</code> and any non existent parents, asynchronously.
- * <p>
- * The new directory will be created with permissions as specified by <code>perms</code>.
- * <p>
- * The permission String takes the form rwxr-x--- as specified
- * in <a href="http://download.oracle.com/javase/7/docs/api/java/nio/file/attribute/PosixFilePermissions.html">here</a>.
- * <p>
- * The operation will fail if the directory already exists.<p>
+ * Suspending version of method [io.vertx.core.file.FileSystem.mkdirs]
  *
  * @param path path to the file
  * @param perms the permissions string
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.file.FileSystem original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-suspend fun FileSystem.mkdirsAwait(path : String, perms : String) : Unit {
-  return awaitResult{
-    this.mkdirs(path, perms, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun FileSystem.mkdirsAwait(path: String, perms: String): Unit {
+  return awaitResult {
+    this.mkdirs(path, perms) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Read the contents of the directory specified by <code>path</code>, asynchronously.
- * <p>
- * The result is an array of String representing the paths of the files inside the directory.
+ * Suspending version of method [io.vertx.core.file.FileSystem.readDir]
  *
  * @param path path to the file
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.file.FileSystem original] using Vert.x codegen.
+ * @return [List<String>]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-suspend fun FileSystem.readDirAwait(path : String) : List<String> {
-  return awaitResult{
+suspend fun FileSystem.readDirAwait(path: String): List<String> {
+  return awaitResult {
     this.readDir(path, it)
   }
 }
 
 /**
- * Read the contents of the directory specified by <code>path</code>, asynchronously.
- * <p>
- * The parameter <code>filter</code> is a regular expression. If <code>filter</code> is specified then only the paths that
- * match  @{filter}will be returned.
- * <p>
- * The result is an array of String representing the paths of the files inside the directory.
+ * Suspending version of method [io.vertx.core.file.FileSystem.readDir]
  *
  * @param path path to the directory
  * @param filter the filter expression
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.file.FileSystem original] using Vert.x codegen.
+ * @return [List<String>]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-suspend fun FileSystem.readDirAwait(path : String, filter : String) : List<String> {
-  return awaitResult{
+suspend fun FileSystem.readDirAwait(path: String, filter: String): List<String> {
+  return awaitResult {
     this.readDir(path, filter, it)
   }
 }
 
 /**
- * Reads the entire file as represented by the path <code>path</code> as a , asynchronously.
- * <p>
- * Do not use this method to read very large files or you risk running out of available RAM.
+ * Suspending version of method [io.vertx.core.file.FileSystem.readFile]
  *
  * @param path path to the file
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.file.FileSystem original] using Vert.x codegen.
+ * @return [Buffer]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-suspend fun FileSystem.readFileAwait(path : String) : Buffer {
-  return awaitResult{
+suspend fun FileSystem.readFileAwait(path: String): Buffer {
+  return awaitResult {
     this.readFile(path, it)
   }
 }
 
 /**
- * Creates the file, and writes the specified <code>Buffer data</code> to the file represented by the path <code>path</code>,
- * asynchronously.
+ * Suspending version of method [io.vertx.core.file.FileSystem.writeFile]
  *
  * @param path path to the file
  * @param data 
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.file.FileSystem original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-suspend fun FileSystem.writeFileAwait(path : String, data : Buffer) : Unit {
-  return awaitResult{
-    this.writeFile(path, data, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun FileSystem.writeFileAwait(path: String, data: Buffer): Unit {
+  return awaitResult {
+    this.writeFile(path, data) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Open the file represented by <code>path</code>, asynchronously.
- * <p>
- * The file is opened for both reading and writing. If the file does not already exist it will be created.
+ * Suspending version of method [io.vertx.core.file.FileSystem.open]
  *
  * @param path path to the file
  * @param options options describing how the file should be opened
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.file.FileSystem original] using Vert.x codegen.
+ * @return [AsyncFile]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-suspend fun FileSystem.openAwait(path : String, options : OpenOptions) : AsyncFile {
-  return awaitResult{
+suspend fun FileSystem.openAwait(path: String, options: OpenOptions): AsyncFile {
+  return awaitResult {
     this.open(path, options, it)
   }
 }
 
 /**
- * Creates an empty file with the specified <code>path</code>, asynchronously.
+ * Suspending version of method [io.vertx.core.file.FileSystem.createFile]
  *
  * @param path path to the file
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.file.FileSystem original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-suspend fun FileSystem.createFileAwait(path : String) : Unit {
-  return awaitResult{
-    this.createFile(path, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun FileSystem.createFileAwait(path: String): Unit {
+  return awaitResult {
+    this.createFile(path) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Creates an empty file with the specified <code>path</code> and permissions <code>perms</code>, asynchronously.
+ * Suspending version of method [io.vertx.core.file.FileSystem.createFile]
  *
  * @param path path to the file
  * @param perms the permissions string
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.file.FileSystem original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-suspend fun FileSystem.createFileAwait(path : String, perms : String) : Unit {
-  return awaitResult{
-    this.createFile(path, perms, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun FileSystem.createFileAwait(path: String, perms: String): Unit {
+  return awaitResult {
+    this.createFile(path, perms) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Determines whether the file as specified by the path <code>path</code> exists, asynchronously.
+ * Suspending version of method [io.vertx.core.file.FileSystem.exists]
  *
  * @param path path to the file
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.file.FileSystem original] using Vert.x codegen.
+ * @return [Boolean]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-suspend fun FileSystem.existsAwait(path : String) : Boolean {
-  return awaitResult{
+suspend fun FileSystem.existsAwait(path: String): Boolean {
+  return awaitResult {
     this.exists(path, it)
   }
 }
 
 /**
- * Returns properties of the file-system being used by the specified <code>path</code>, asynchronously.
+ * Suspending version of method [io.vertx.core.file.FileSystem.fsProps]
  *
  * @param path path to anywhere on the filesystem
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.file.FileSystem original] using Vert.x codegen.
+ * @return [FileSystemProps]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-suspend fun FileSystem.fsPropsAwait(path : String) : FileSystemProps {
-  return awaitResult{
+suspend fun FileSystem.fsPropsAwait(path: String): FileSystemProps {
+  return awaitResult {
     this.fsProps(path, it)
   }
 }
 
 /**
- * Creates a new directory in the default temporary-file directory, using the given
- * prefix to generate its name, asynchronously.
- *
- * <p>
- * As with the <code>File.createTempFile</code> methods, this method is only
- * part of a temporary-file facility.A [java.lang.Runtime],
- * or the [java.io.File] mechanism may be used to delete the directory automatically.
- * </p>
+ * Suspending version of method [io.vertx.core.file.FileSystem.createTempDirectory]
  *
  * @param prefix the prefix string to be used in generating the directory's name; may be <code>null</code>
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.file.FileSystem original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-suspend fun FileSystem.createTempDirectoryAwait(prefix : String) : String {
-  return awaitResult{
+suspend fun FileSystem.createTempDirectoryAwait(prefix: String): String {
+  return awaitResult {
     this.createTempDirectory(prefix, it)
   }
 }
 
 /**
- * Creates a new directory in the default temporary-file directory, using the given
- * prefix to generate its name, asynchronously.
- * <p>
- * The new directory will be created with permissions as specified by <code>perms</code>.
- * </p>
- * The permission String takes the form rwxr-x--- as specified
- * in <a href="http://download.oracle.com/javase/7/docs/api/java/nio/file/attribute/PosixFilePermissions.html">here</a>.
- *
- * <p>
- * As with the <code>File.createTempFile</code> methods, this method is only
- * part of a temporary-file facility.A [java.lang.Runtime],
- * or the [java.io.File] mechanism may be used to delete the directory automatically.
- * </p>
+ * Suspending version of method [io.vertx.core.file.FileSystem.createTempDirectory]
  *
  * @param prefix the prefix string to be used in generating the directory's name; may be <code>null</code>
  * @param perms the permissions string
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.file.FileSystem original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-suspend fun FileSystem.createTempDirectoryAwait(prefix : String, perms : String) : String {
-  return awaitResult{
+suspend fun FileSystem.createTempDirectoryAwait(prefix: String, perms: String): String {
+  return awaitResult {
     this.createTempDirectory(prefix, perms, it)
   }
 }
 
 /**
- * Creates a new directory in the directory provided by the path <code>path</code>, using the given
- * prefix to generate its name, asynchronously.
- * <p>
- * The new directory will be created with permissions as specified by <code>perms</code>.
- * </p>
- * The permission String takes the form rwxr-x--- as specified
- * in <a href="http://download.oracle.com/javase/7/docs/api/java/nio/file/attribute/PosixFilePermissions.html">here</a>.
- *
- * <p>
- * As with the <code>File.createTempFile</code> methods, this method is only
- * part of a temporary-file facility.A [java.lang.Runtime],
- * or the [java.io.File] mechanism may be used to delete the directory automatically.
- * </p>
+ * Suspending version of method [io.vertx.core.file.FileSystem.createTempDirectory]
  *
  * @param dir the path to directory in which to create the directory
  * @param prefix the prefix string to be used in generating the directory's name; may be <code>null</code>
  * @param perms the permissions string
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.file.FileSystem original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-suspend fun FileSystem.createTempDirectoryAwait(dir : String, prefix : String, perms : String) : String {
-  return awaitResult{
+suspend fun FileSystem.createTempDirectoryAwait(dir: String, prefix: String, perms: String): String {
+  return awaitResult {
     this.createTempDirectory(dir, prefix, perms, it)
   }
 }
 
 /**
- * Creates a new file in the default temporary-file directory, using the given
- * prefix and suffix to generate its name, asynchronously.
- *
- * <p>
- * As with the <code>File.createTempFile</code> methods, this method is only
- * part of a temporary-file facility.A [java.lang.Runtime],
- * or the [java.io.File] mechanism may be used to delete the directory automatically.
- * </p>
+ * Suspending version of method [io.vertx.core.file.FileSystem.createTempFile]
  *
  * @param prefix the prefix string to be used in generating the directory's name; may be <code>null</code>
  * @param suffix the suffix string to be used in generating the file's name; may be <code>null</code>, in which case "<code>.tmp</code>" is used
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.file.FileSystem original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-suspend fun FileSystem.createTempFileAwait(prefix : String, suffix : String) : String {
-  return awaitResult{
+suspend fun FileSystem.createTempFileAwait(prefix: String, suffix: String): String {
+  return awaitResult {
     this.createTempFile(prefix, suffix, it)
   }
 }
 
 /**
- * Creates a new file in the directory provided by the path <code>dir</code>, using the given
- * prefix and suffix to generate its name, asynchronously.
- *
- * <p>
- * As with the <code>File.createTempFile</code> methods, this method is only
- * part of a temporary-file facility.A [java.lang.Runtime],
- * or the [java.io.File] mechanism may be used to delete the directory automatically.
- * </p>
+ * Suspending version of method [io.vertx.core.file.FileSystem.createTempFile]
  *
  * @param prefix the prefix string to be used in generating the directory's name; may be <code>null</code>
  * @param suffix the suffix string to be used in generating the file's name; may be <code>null</code>, in which case "<code>.tmp</code>" is used
  * @param perms 
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.file.FileSystem original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-suspend fun FileSystem.createTempFileAwait(prefix : String, suffix : String, perms : String) : String {
-  return awaitResult{
+suspend fun FileSystem.createTempFileAwait(prefix: String, suffix: String, perms: String): String {
+  return awaitResult {
     this.createTempFile(prefix, suffix, perms, it)
   }
 }
 
 /**
- * Creates a new file in the directory provided by the path <code>dir</code>, using the given
- * prefix and suffix to generate its name, asynchronously.
- * <p>
- * The new directory will be created with permissions as specified by <code>perms</code>.
- * </p>
- * The permission String takes the form rwxr-x--- as specified
- * in <a href="http://download.oracle.com/javase/7/docs/api/java/nio/file/attribute/PosixFilePermissions.html">here</a>.
- *
- * <p>
- * As with the <code>File.createTempFile</code> methods, this method is only
- * part of a temporary-file facility.A [java.lang.Runtime],
- * or the [java.io.File] mechanism may be used to delete the directory automatically.
- * </p>
+ * Suspending version of method [io.vertx.core.file.FileSystem.createTempFile]
  *
  * @param dir the path to directory in which to create the directory
  * @param prefix the prefix string to be used in generating the directory's name; may be <code>null</code>
  * @param suffix the suffix string to be used in generating the file's name; may be <code>null</code>, in which case "<code>.tmp</code>" is used
  * @param perms the permissions string
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.file.FileSystem original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-suspend fun FileSystem.createTempFileAwait(dir : String, prefix : String, suffix : String, perms : String) : String {
-  return awaitResult{
+suspend fun FileSystem.createTempFileAwait(dir: String, prefix: String, suffix: String, perms: String): String {
+  return awaitResult {
     this.createTempFile(dir, prefix, suffix, perms, it)
   }
 }

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/http/HttpClient.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/http/HttpClient.kt
@@ -6,190 +6,178 @@ import io.vertx.core.http.RequestOptions
 import io.vertx.kotlin.coroutines.awaitResult
 
 /**
- * Sends an HTTP GET request to the server with the specified options, specifying a response handler to receive
- * the response
+ * Suspending version of method [io.vertx.core.http.HttpClient.getNow]
  *
  * @param options the request options
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.http.HttpClient original] using Vert.x codegen.
+ * @return [HttpClientResponse]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpClient] using Vert.x codegen.
  */
-suspend fun HttpClient.getNowAwait(options : RequestOptions) : HttpClientResponse {
-  return awaitResult{
+suspend fun HttpClient.getNowAwait(options: RequestOptions): HttpClientResponse {
+  return awaitResult {
     this.getNow(options, it)
   }
 }
 
 /**
- * Sends an HTTP GET request to the server at the specified host and port, specifying a response handler to receive
- * the response
+ * Suspending version of method [io.vertx.core.http.HttpClient.getNow]
  *
  * @param port the port
  * @param host the host
  * @param requestURI the relative URI
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.http.HttpClient original] using Vert.x codegen.
+ * @return [HttpClientResponse]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpClient] using Vert.x codegen.
  */
-suspend fun HttpClient.getNowAwait(port : Int, host : String, requestURI : String) : HttpClientResponse {
-  return awaitResult{
+suspend fun HttpClient.getNowAwait(port: Int, host: String, requestURI: String): HttpClientResponse {
+  return awaitResult {
     this.getNow(port, host, requestURI, it)
   }
 }
 
 /**
- * Sends an HTTP GET request to the server at the specified host and default port, specifying a response handler to receive
- * the response
+ * Suspending version of method [io.vertx.core.http.HttpClient.getNow]
  *
  * @param host the host
  * @param requestURI the relative URI
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.http.HttpClient original] using Vert.x codegen.
+ * @return [HttpClientResponse]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpClient] using Vert.x codegen.
  */
-suspend fun HttpClient.getNowAwait(host : String, requestURI : String) : HttpClientResponse {
-  return awaitResult{
+suspend fun HttpClient.getNowAwait(host: String, requestURI: String): HttpClientResponse {
+  return awaitResult {
     this.getNow(host, requestURI, it)
   }
 }
 
 /**
- * Sends an HTTP GET request  to the server at the default host and port, specifying a response handler to receive
- * the response
+ * Suspending version of method [io.vertx.core.http.HttpClient.getNow]
  *
  * @param requestURI the relative URI
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.http.HttpClient original] using Vert.x codegen.
+ * @return [HttpClientResponse]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpClient] using Vert.x codegen.
  */
-suspend fun HttpClient.getNowAwait(requestURI : String) : HttpClientResponse {
-  return awaitResult{
+suspend fun HttpClient.getNowAwait(requestURI: String): HttpClientResponse {
+  return awaitResult {
     this.getNow(requestURI, it)
   }
 }
 
 /**
- * Sends an HTTP HEAD request to the server with the specified options, specifying a response handler to receive
- * the response
+ * Suspending version of method [io.vertx.core.http.HttpClient.headNow]
  *
  * @param options the request options
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.http.HttpClient original] using Vert.x codegen.
+ * @return [HttpClientResponse]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpClient] using Vert.x codegen.
  */
-suspend fun HttpClient.headNowAwait(options : RequestOptions) : HttpClientResponse {
-  return awaitResult{
+suspend fun HttpClient.headNowAwait(options: RequestOptions): HttpClientResponse {
+  return awaitResult {
     this.headNow(options, it)
   }
 }
 
 /**
- * Sends an HTTP HEAD request to the server at the specified host and port, specifying a response handler to receive
- * the response
+ * Suspending version of method [io.vertx.core.http.HttpClient.headNow]
  *
  * @param port the port
  * @param host the host
  * @param requestURI the relative URI
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.http.HttpClient original] using Vert.x codegen.
+ * @return [HttpClientResponse]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpClient] using Vert.x codegen.
  */
-suspend fun HttpClient.headNowAwait(port : Int, host : String, requestURI : String) : HttpClientResponse {
-  return awaitResult{
+suspend fun HttpClient.headNowAwait(port: Int, host: String, requestURI: String): HttpClientResponse {
+  return awaitResult {
     this.headNow(port, host, requestURI, it)
   }
 }
 
 /**
- * Sends an HTTP HEAD request to the server at the specified host and default port, specifying a response handler to receive
- * the response
+ * Suspending version of method [io.vertx.core.http.HttpClient.headNow]
  *
  * @param host the host
  * @param requestURI the relative URI
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.http.HttpClient original] using Vert.x codegen.
+ * @return [HttpClientResponse]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpClient] using Vert.x codegen.
  */
-suspend fun HttpClient.headNowAwait(host : String, requestURI : String) : HttpClientResponse {
-  return awaitResult{
+suspend fun HttpClient.headNowAwait(host: String, requestURI: String): HttpClientResponse {
+  return awaitResult {
     this.headNow(host, requestURI, it)
   }
 }
 
 /**
- * Sends an HTTP HEAD request  to the server at the default host and port, specifying a response handler to receive
- * the response
+ * Suspending version of method [io.vertx.core.http.HttpClient.headNow]
  *
  * @param requestURI the relative URI
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.http.HttpClient original] using Vert.x codegen.
+ * @return [HttpClientResponse]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpClient] using Vert.x codegen.
  */
-suspend fun HttpClient.headNowAwait(requestURI : String) : HttpClientResponse {
-  return awaitResult{
+suspend fun HttpClient.headNowAwait(requestURI: String): HttpClientResponse {
+  return awaitResult {
     this.headNow(requestURI, it)
   }
 }
 
 /**
- * Sends an HTTP OPTIONS request to the server with the specified options, specifying a response handler to receive
- * the response
+ * Suspending version of method [io.vertx.core.http.HttpClient.optionsNow]
  *
  * @param options the request options
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.http.HttpClient original] using Vert.x codegen.
+ * @return [HttpClientResponse]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpClient] using Vert.x codegen.
  */
-suspend fun HttpClient.optionsNowAwait(options : RequestOptions) : HttpClientResponse {
-  return awaitResult{
+suspend fun HttpClient.optionsNowAwait(options: RequestOptions): HttpClientResponse {
+  return awaitResult {
     this.optionsNow(options, it)
   }
 }
 
 /**
- * Sends an HTTP OPTIONS request to the server at the specified host and port, specifying a response handler to receive
- * the response
+ * Suspending version of method [io.vertx.core.http.HttpClient.optionsNow]
  *
  * @param port the port
  * @param host the host
  * @param requestURI the relative URI
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.http.HttpClient original] using Vert.x codegen.
+ * @return [HttpClientResponse]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpClient] using Vert.x codegen.
  */
-suspend fun HttpClient.optionsNowAwait(port : Int, host : String, requestURI : String) : HttpClientResponse {
-  return awaitResult{
+suspend fun HttpClient.optionsNowAwait(port: Int, host: String, requestURI: String): HttpClientResponse {
+  return awaitResult {
     this.optionsNow(port, host, requestURI, it)
   }
 }
 
 /**
- * Sends an HTTP OPTIONS request to the server at the specified host and default port, specifying a response handler to receive
- * the response
+ * Suspending version of method [io.vertx.core.http.HttpClient.optionsNow]
  *
  * @param host the host
  * @param requestURI the relative URI
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.http.HttpClient original] using Vert.x codegen.
+ * @return [HttpClientResponse]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpClient] using Vert.x codegen.
  */
-suspend fun HttpClient.optionsNowAwait(host : String, requestURI : String) : HttpClientResponse {
-  return awaitResult{
+suspend fun HttpClient.optionsNowAwait(host: String, requestURI: String): HttpClientResponse {
+  return awaitResult {
     this.optionsNow(host, requestURI, it)
   }
 }
 
 /**
- * Sends an HTTP OPTIONS request  to the server at the default host and port, specifying a response handler to receive
- * the response
+ * Suspending version of method [io.vertx.core.http.HttpClient.optionsNow]
  *
  * @param requestURI the relative URI
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.http.HttpClient original] using Vert.x codegen.
+ * @return [HttpClientResponse]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpClient] using Vert.x codegen.
  */
-suspend fun HttpClient.optionsNowAwait(requestURI : String) : HttpClientResponse {
-  return awaitResult{
+suspend fun HttpClient.optionsNowAwait(requestURI: String): HttpClientResponse {
+  return awaitResult {
     this.optionsNow(requestURI, it)
   }
 }

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/http/HttpConnection.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/http/HttpConnection.kt
@@ -6,34 +6,28 @@ import io.vertx.core.http.HttpConnection
 import io.vertx.kotlin.coroutines.awaitResult
 
 /**
- * Send to the remote endpoint an update of this endpoint settings
- * <p/>
- * The <code>completionHandler</code> will be notified when the remote endpoint has acknowledged the settings.
- * <p/>
- * This is not implemented for HTTP/1.x.
+ * Suspending version of method [io.vertx.core.http.HttpConnection.updateSettings]
  *
  * @param settings the new settings
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.http.HttpConnection original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpConnection] using Vert.x codegen.
  */
-suspend fun HttpConnection.updateSettingsAwait(settings : Http2Settings) : Unit {
-  return awaitResult{
-    this.updateSettings(settings, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun HttpConnection.updateSettingsAwait(settings: Http2Settings): Unit {
+  return awaitResult {
+    this.updateSettings(settings) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Send a  frame to the remote endpoint.
- * <p/>
- * This is not implemented for HTTP/1.x.
+ * Suspending version of method [io.vertx.core.http.HttpConnection.ping]
  *
  * @param data the 8 bytes data of the frame
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.http.HttpConnection original] using Vert.x codegen.
+ * @return [Buffer]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpConnection] using Vert.x codegen.
  */
-suspend fun HttpConnection.pingAwait(data : Buffer) : Buffer {
-  return awaitResult{
+suspend fun HttpConnection.pingAwait(data: Buffer): Buffer {
+  return awaitResult {
     this.ping(data, it)
   }
 }

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/http/HttpServer.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/http/HttpServer.kt
@@ -5,73 +5,70 @@ import io.vertx.core.net.SocketAddress
 import io.vertx.kotlin.coroutines.awaitResult
 
 /**
- * Like [io.vertx.core.http.HttpServer] but supplying a handler that will be called when the server is actually
- * listening (or has failed).
+ * Suspending version of method [io.vertx.core.http.HttpServer.listen]
  *
  * @param port the port to listen on
  * @param host the host to listen on
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.http.HttpServer original] using Vert.x codegen.
+ * @return [HttpServer]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpServer] using Vert.x codegen.
  */
-suspend fun HttpServer.listenAwait(port : Int, host : String) : HttpServer {
-  return awaitResult{
+suspend fun HttpServer.listenAwait(port: Int, host: String): HttpServer {
+  return awaitResult {
     this.listen(port, host, it)
   }
 }
 
 /**
- * Tell the server to start listening on the given address supplying
- * a handler that will be called when the server is actually
- * listening (or has failed).
+ * Suspending version of method [io.vertx.core.http.HttpServer.listen]
  *
  * @param address the address to listen on
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.http.HttpServer original] using Vert.x codegen.
+ * @return [HttpServer]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpServer] using Vert.x codegen.
  */
-suspend fun HttpServer.listenAwait(address : SocketAddress) : HttpServer {
-  return awaitResult{
+suspend fun HttpServer.listenAwait(address: SocketAddress): HttpServer {
+  return awaitResult {
     this.listen(address, it)
   }
 }
 
 /**
- * Like [io.vertx.core.http.HttpServer] but supplying a handler that will be called when the server is actually listening (or has failed).
+ * Suspending version of method [io.vertx.core.http.HttpServer.listen]
  *
  * @param port the port to listen on
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.http.HttpServer original] using Vert.x codegen.
+ * @return [HttpServer]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpServer] using Vert.x codegen.
  */
-suspend fun HttpServer.listenAwait(port : Int) : HttpServer {
-  return awaitResult{
+suspend fun HttpServer.listenAwait(port: Int): HttpServer {
+  return awaitResult {
     this.listen(port, it)
   }
 }
 
 /**
- * Like [io.vertx.core.http.HttpServer] but supplying a handler that will be called when the server is actually listening (or has failed).
+ * Suspending version of method [io.vertx.core.http.HttpServer.listen]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.http.HttpServer original] using Vert.x codegen.
+ * @return [HttpServer]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpServer] using Vert.x codegen.
  */
-suspend fun HttpServer.listenAwait() : HttpServer {
-  return awaitResult{
+suspend fun HttpServer.listenAwait(): HttpServer {
+  return awaitResult {
     this.listen(it)
   }
 }
 
 /**
- * Like [io.vertx.core.http.HttpServer] but supplying a handler that will be called when the server is actually closed (or has failed).
+ * Suspending version of method [io.vertx.core.http.HttpServer.close]
  *
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.http.HttpServer original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpServer] using Vert.x codegen.
  */
-suspend fun HttpServer.closeAwait() : Unit {
-  return awaitResult{
-    this.close({ ar -> it.handle(ar.mapEmpty()) })}
+suspend fun HttpServer.closeAwait(): Unit {
+  return awaitResult {
+    this.close { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/http/HttpServerResponse.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/http/HttpServerResponse.kt
@@ -6,118 +6,107 @@ import io.vertx.core.http.HttpServerResponse
 import io.vertx.kotlin.coroutines.awaitResult
 
 /**
- * Like [io.vertx.core.http.HttpServerResponse] but providing a handler which will be notified once the file has been completely
- * written to the wire.
+ * Suspending version of method [io.vertx.core.http.HttpServerResponse.sendFile]
  *
  * @param filename path to the file to serve
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.http.HttpServerResponse original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpServerResponse] using Vert.x codegen.
  */
-suspend fun HttpServerResponse.sendFileAwait(filename : String) : Unit {
-  return awaitResult{
-    this.sendFile(filename, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun HttpServerResponse.sendFileAwait(filename: String): Unit {
+  return awaitResult {
+    this.sendFile(filename) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Like [io.vertx.core.http.HttpServerResponse] but providing a handler which will be notified once the file has been completely
- * written to the wire.
+ * Suspending version of method [io.vertx.core.http.HttpServerResponse.sendFile]
  *
  * @param filename path to the file to serve
  * @param offset the offset to serve from
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.http.HttpServerResponse original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpServerResponse] using Vert.x codegen.
  */
-suspend fun HttpServerResponse.sendFileAwait(filename : String, offset : Long) : Unit {
-  return awaitResult{
-    this.sendFile(filename, offset, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun HttpServerResponse.sendFileAwait(filename: String, offset: Long): Unit {
+  return awaitResult {
+    this.sendFile(filename, offset) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Like [io.vertx.core.http.HttpServerResponse] but providing a handler which will be notified once the file has been
- * completely written to the wire.
+ * Suspending version of method [io.vertx.core.http.HttpServerResponse.sendFile]
  *
  * @param filename path to the file to serve
  * @param offset the offset to serve from
  * @param length the length to serve to
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.http.HttpServerResponse original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpServerResponse] using Vert.x codegen.
  */
-suspend fun HttpServerResponse.sendFileAwait(filename : String, offset : Long, length : Long) : Unit {
-  return awaitResult{
-    this.sendFile(filename, offset, length, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun HttpServerResponse.sendFileAwait(filename: String, offset: Long, length: Long): Unit {
+  return awaitResult {
+    this.sendFile(filename, offset, length) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Like [io.vertx.core.http.HttpServerResponse] with no headers.
+ * Suspending version of method [io.vertx.core.http.HttpServerResponse.push]
  *
  * @param method 
  * @param host 
  * @param path 
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.http.HttpServerResponse original] using Vert.x codegen.
+ * @return [HttpServerResponse]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpServerResponse] using Vert.x codegen.
  */
-suspend fun HttpServerResponse.pushAwait(method : HttpMethod, host : String, path : String) : HttpServerResponse {
-  return awaitResult{
+suspend fun HttpServerResponse.pushAwait(method: HttpMethod, host: String, path: String): HttpServerResponse {
+  return awaitResult {
     this.push(method, host, path, it)
   }
 }
 
 /**
- * Like [io.vertx.core.http.HttpServerResponse] with the host copied from the current request.
+ * Suspending version of method [io.vertx.core.http.HttpServerResponse.push]
  *
  * @param method 
  * @param path 
  * @param headers 
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.http.HttpServerResponse original] using Vert.x codegen.
+ * @return [HttpServerResponse]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpServerResponse] using Vert.x codegen.
  */
-suspend fun HttpServerResponse.pushAwait(method : HttpMethod, path : String, headers : MultiMap) : HttpServerResponse {
-  return awaitResult{
+suspend fun HttpServerResponse.pushAwait(method: HttpMethod, path: String, headers: MultiMap): HttpServerResponse {
+  return awaitResult {
     this.push(method, path, headers, it)
   }
 }
 
 /**
- * Like [io.vertx.core.http.HttpServerResponse] with the host copied from the current request.
+ * Suspending version of method [io.vertx.core.http.HttpServerResponse.push]
  *
  * @param method 
  * @param path 
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.http.HttpServerResponse original] using Vert.x codegen.
+ * @return [HttpServerResponse]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpServerResponse] using Vert.x codegen.
  */
-suspend fun HttpServerResponse.pushAwait(method : HttpMethod, path : String) : HttpServerResponse {
-  return awaitResult{
+suspend fun HttpServerResponse.pushAwait(method: HttpMethod, path: String): HttpServerResponse {
+  return awaitResult {
     this.push(method, path, it)
   }
 }
 
 /**
- * Push a response to the client.<p/>
- *
- * The <code>handler</code> will be notified with a <i>success</i> when the push can be sent and with
- * a <i>failure</i> when the client has disabled push or reset the push before it has been sent.<p/>
- *
- * The <code>handler</code> may be queued if the client has reduced the maximum number of streams the server can push
- * concurrently.<p/>
- *
- * Push can be sent only for peer initiated streams and if the response is not ended.
+ * Suspending version of method [io.vertx.core.http.HttpServerResponse.push]
  *
  * @param method the method of the promised request
  * @param host the host of the promised request
  * @param path the path of the promised request
  * @param headers the headers of the promised request
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.http.HttpServerResponse original] using Vert.x codegen.
+ * @return [HttpServerResponse]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpServerResponse] using Vert.x codegen.
  */
-suspend fun HttpServerResponse.pushAwait(method : HttpMethod, host : String, path : String, headers : MultiMap) : HttpServerResponse {
-  return awaitResult{
+suspend fun HttpServerResponse.pushAwait(method: HttpMethod, host: String, path: String, headers: MultiMap): HttpServerResponse {
+  return awaitResult {
     this.push(method, host, path, headers, it)
   }
 }

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/net/NetClient.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/net/NetClient.kt
@@ -6,71 +6,61 @@ import io.vertx.core.net.SocketAddress
 import io.vertx.kotlin.coroutines.awaitResult
 
 /**
- * Open a connection to a server at the specific <code>port</code> and <code>host</code>.
- * <p>
- * <code>host</code> can be a valid host name or IP address. The connect is done asynchronously and on success, a
- * [io.vertx.core.net.NetSocket] instance is supplied via the <code>connectHandler</code> instance
+ * Suspending version of method [io.vertx.core.net.NetClient.connect]
  *
  * @param port the port
  * @param host the host
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.net.NetClient original] using Vert.x codegen.
+ * @return [NetSocket]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.net.NetClient] using Vert.x codegen.
  */
-suspend fun NetClient.connectAwait(port : Int, host : String) : NetSocket {
-  return awaitResult{
+suspend fun NetClient.connectAwait(port: Int, host: String): NetSocket {
+  return awaitResult {
     this.connect(port, host, it)
   }
 }
 
 /**
- * Open a connection to a server at the specific <code>port</code> and <code>host</code>.
- * <p>
- * <code>host</code> can be a valid host name or IP address. The connect is done asynchronously and on success, a
- * [io.vertx.core.net.NetSocket] instance is supplied via the <code>connectHandler</code> instance
+ * Suspending version of method [io.vertx.core.net.NetClient.connect]
  *
  * @param port the port
  * @param host the host
  * @param serverName the SNI server name
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.net.NetClient original] using Vert.x codegen.
+ * @return [NetSocket]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.net.NetClient] using Vert.x codegen.
  */
-suspend fun NetClient.connectAwait(port : Int, host : String, serverName : String) : NetSocket {
-  return awaitResult{
+suspend fun NetClient.connectAwait(port: Int, host: String, serverName: String): NetSocket {
+  return awaitResult {
     this.connect(port, host, serverName, it)
   }
 }
 
 /**
- * Open a connection to a server at the specific <code>remoteAddress</code>.
- * <p>
- * The connect is done asynchronously and on success, a [io.vertx.core.net.NetSocket] instance is supplied via the <code>connectHandler</code> instance
+ * Suspending version of method [io.vertx.core.net.NetClient.connect]
  *
  * @param remoteAddress the remote address
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.net.NetClient original] using Vert.x codegen.
+ * @return [NetSocket]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.net.NetClient] using Vert.x codegen.
  */
-suspend fun NetClient.connectAwait(remoteAddress : SocketAddress) : NetSocket {
-  return awaitResult{
+suspend fun NetClient.connectAwait(remoteAddress: SocketAddress): NetSocket {
+  return awaitResult {
     this.connect(remoteAddress, it)
   }
 }
 
 /**
- * Open a connection to a server at the specific <code>remoteAddress</code>.
- * <p>
- * The connect is done asynchronously and on success, a [io.vertx.core.net.NetSocket] instance is supplied via the <code>connectHandler</code> instance
+ * Suspending version of method [io.vertx.core.net.NetClient.connect]
  *
  * @param remoteAddress the remote address
  * @param serverName the SNI server name
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.net.NetClient original] using Vert.x codegen.
+ * @return [NetSocket]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.net.NetClient] using Vert.x codegen.
  */
-suspend fun NetClient.connectAwait(remoteAddress : SocketAddress, serverName : String) : NetSocket {
-  return awaitResult{
+suspend fun NetClient.connectAwait(remoteAddress: SocketAddress, serverName: String): NetSocket {
+  return awaitResult {
     this.connect(remoteAddress, serverName, it)
   }
 }

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/net/NetServer.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/net/NetServer.kt
@@ -5,70 +5,70 @@ import io.vertx.core.net.SocketAddress
 import io.vertx.kotlin.coroutines.awaitResult
 
 /**
- * Like [io.vertx.core.net.NetServer] but providing a handler that will be notified when the server is listening, or fails.
+ * Suspending version of method [io.vertx.core.net.NetServer.listen]
  *
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.net.NetServer original] using Vert.x codegen.
+ * @return [NetServer]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.net.NetServer] using Vert.x codegen.
  */
-suspend fun NetServer.listenAwait() : NetServer {
-  return awaitResult{
+suspend fun NetServer.listenAwait(): NetServer {
+  return awaitResult {
     this.listen(it)
   }
 }
 
 /**
- * Like [io.vertx.core.net.NetServer] but providing a handler that will be notified when the server is listening, or fails.
+ * Suspending version of method [io.vertx.core.net.NetServer.listen]
  *
  * @param port the port to listen on
  * @param host the host to listen on
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.net.NetServer original] using Vert.x codegen.
+ * @return [NetServer]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.net.NetServer] using Vert.x codegen.
  */
-suspend fun NetServer.listenAwait(port : Int, host : String) : NetServer {
-  return awaitResult{
+suspend fun NetServer.listenAwait(port: Int, host: String): NetServer {
+  return awaitResult {
     this.listen(port, host, it)
   }
 }
 
 /**
- * Like [io.vertx.core.net.NetServer] but providing a handler that will be notified when the server is listening, or fails.
+ * Suspending version of method [io.vertx.core.net.NetServer.listen]
  *
  * @param port the port to listen on
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.net.NetServer original] using Vert.x codegen.
+ * @return [NetServer]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.net.NetServer] using Vert.x codegen.
  */
-suspend fun NetServer.listenAwait(port : Int) : NetServer {
-  return awaitResult{
+suspend fun NetServer.listenAwait(port: Int): NetServer {
+  return awaitResult {
     this.listen(port, it)
   }
 }
 
 /**
- * Like [io.vertx.core.net.NetServer] but providing a handler that will be notified when the server is listening, or fails.
+ * Suspending version of method [io.vertx.core.net.NetServer.listen]
  *
  * @param localAddress the local address to listen on
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.net.NetServer original] using Vert.x codegen.
+ * @return [NetServer]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.net.NetServer] using Vert.x codegen.
  */
-suspend fun NetServer.listenAwait(localAddress : SocketAddress) : NetServer {
-  return awaitResult{
+suspend fun NetServer.listenAwait(localAddress: SocketAddress): NetServer {
+  return awaitResult {
     this.listen(localAddress, it)
   }
 }
 
 /**
- * Like [io.vertx.core.net.NetServer] but supplying a handler that will be notified when close is complete.
+ * Suspending version of method [io.vertx.core.net.NetServer.close]
  *
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.net.NetServer original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.core.net.NetServer] using Vert.x codegen.
  */
-suspend fun NetServer.closeAwait() : Unit {
-  return awaitResult{
-    this.close({ ar -> it.handle(ar.mapEmpty()) })}
+suspend fun NetServer.closeAwait(): Unit {
+  return awaitResult {
+    this.close { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/net/NetSocket.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/net/NetSocket.kt
@@ -5,61 +5,57 @@ import io.vertx.core.net.NetSocket
 import io.vertx.kotlin.coroutines.awaitResult
 
 /**
- * Like  but with an <code>handler</code> called when the message has been written
- * or failed to be written.
+ * Suspending version of method [io.vertx.core.net.NetSocket.write]
  *
  * @param message 
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.net.NetSocket original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.net.NetSocket] using Vert.x codegen.
  */
-suspend fun NetSocket.writeAwait(message : Buffer) : Unit {
-  return awaitResult{
-    this.write(message, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun NetSocket.writeAwait(message: Buffer): Unit {
+  return awaitResult {
+    this.write(message) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Same as [io.vertx.core.net.NetSocket] but also takes a handler that will be called when the send has completed or
- * a failure has occurred
+ * Suspending version of method [io.vertx.core.net.NetSocket.sendFile]
  *
  * @param filename file name of the file to send
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.net.NetSocket original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.net.NetSocket] using Vert.x codegen.
  */
-suspend fun NetSocket.sendFileAwait(filename : String) : Unit {
-  return awaitResult{
-    this.sendFile(filename, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun NetSocket.sendFileAwait(filename: String): Unit {
+  return awaitResult {
+    this.sendFile(filename) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Same as [io.vertx.core.net.NetSocket] but also takes a handler that will be called when the send has completed or
- * a failure has occurred
+ * Suspending version of method [io.vertx.core.net.NetSocket.sendFile]
  *
  * @param filename file name of the file to send
  * @param offset offset
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.net.NetSocket original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.net.NetSocket] using Vert.x codegen.
  */
-suspend fun NetSocket.sendFileAwait(filename : String, offset : Long) : Unit {
-  return awaitResult{
-    this.sendFile(filename, offset, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun NetSocket.sendFileAwait(filename: String, offset: Long): Unit {
+  return awaitResult {
+    this.sendFile(filename, offset) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Same as [io.vertx.core.net.NetSocket] but also takes a handler that will be called when the send has completed or
- * a failure has occurred
+ * Suspending version of method [io.vertx.core.net.NetSocket.sendFile]
  *
  * @param filename file name of the file to send
  * @param offset offset
  * @param length length
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.net.NetSocket original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.core.net.NetSocket] using Vert.x codegen.
  */
-suspend fun NetSocket.sendFileAwait(filename : String, offset : Long, length : Long) : Unit {
-  return awaitResult{
-    this.sendFile(filename, offset, length, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun NetSocket.sendFileAwait(filename: String, offset: Long, length: Long): Unit {
+  return awaitResult {
+    this.sendFile(filename, offset, length) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/shareddata/AsyncMap.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/shareddata/AsyncMap.kt
@@ -4,163 +4,160 @@ import io.vertx.core.shareddata.AsyncMap
 import io.vertx.kotlin.coroutines.awaitResult
 
 /**
- * Get a value from the map, asynchronously.
+ * Suspending version of method [io.vertx.core.shareddata.AsyncMap.get]
  *
  * @param k the key
+ * @return [V?]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.shareddata.AsyncMap original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.core.shareddata.AsyncMap] using Vert.x codegen.
  */
-suspend fun <K,V> AsyncMap<K,V>.getAwait(k : K) : V? {
-  return awaitResult{
+suspend fun <K,V> AsyncMap<K,V>.getAwait(k: K): V? {
+  return awaitResult {
     this.get(k, it)
   }
 }
 
 /**
- * Put a value in the map, asynchronously.
+ * Suspending version of method [io.vertx.core.shareddata.AsyncMap.put]
  *
  * @param k the key
  * @param v the value
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.shareddata.AsyncMap original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.core.shareddata.AsyncMap] using Vert.x codegen.
  */
-suspend fun <K,V> AsyncMap<K,V>.putAwait(k : K, v : V) : Unit {
-  return awaitResult{
-    this.put(k, v, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun <K,V> AsyncMap<K,V>.putAwait(k: K, v: V): Unit {
+  return awaitResult {
+    this.put(k, v) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Like [io.vertx.core.shareddata.AsyncMap] but specifying a time to live for the entry. Entry will expire and get evicted after the
- * ttl.
+ * Suspending version of method [io.vertx.core.shareddata.AsyncMap.put]
  *
  * @param k the key
  * @param v the value
  * @param ttl The time to live (in ms) for the entry
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.shareddata.AsyncMap original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.core.shareddata.AsyncMap] using Vert.x codegen.
  */
-suspend fun <K,V> AsyncMap<K,V>.putAwait(k : K, v : V, ttl : Long) : Unit {
-  return awaitResult{
-    this.put(k, v, ttl, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun <K,V> AsyncMap<K,V>.putAwait(k: K, v: V, ttl: Long): Unit {
+  return awaitResult {
+    this.put(k, v, ttl) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Put the entry only if there is no entry with the key already present. If key already present then the existing
- * value will be returned to the handler, otherwise null.
+ * Suspending version of method [io.vertx.core.shareddata.AsyncMap.putIfAbsent]
  *
  * @param k the key
  * @param v the value
+ * @return [V?]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.shareddata.AsyncMap original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.core.shareddata.AsyncMap] using Vert.x codegen.
  */
-suspend fun <K,V> AsyncMap<K,V>.putIfAbsentAwait(k : K, v : V) : V? {
-  return awaitResult{
+suspend fun <K,V> AsyncMap<K,V>.putIfAbsentAwait(k: K, v: V): V? {
+  return awaitResult {
     this.putIfAbsent(k, v, it)
   }
 }
 
 /**
- * Link [io.vertx.core.shareddata.AsyncMap] but specifying a time to live for the entry. Entry will expire and get evicted
- * after the ttl.
+ * Suspending version of method [io.vertx.core.shareddata.AsyncMap.putIfAbsent]
  *
  * @param k the key
  * @param v the value
  * @param ttl The time to live (in ms) for the entry
+ * @return [V?]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.shareddata.AsyncMap original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.core.shareddata.AsyncMap] using Vert.x codegen.
  */
-suspend fun <K,V> AsyncMap<K,V>.putIfAbsentAwait(k : K, v : V, ttl : Long) : V? {
-  return awaitResult{
+suspend fun <K,V> AsyncMap<K,V>.putIfAbsentAwait(k: K, v: V, ttl: Long): V? {
+  return awaitResult {
     this.putIfAbsent(k, v, ttl, it)
   }
 }
 
 /**
- * Remove a value from the map, asynchronously.
+ * Suspending version of method [io.vertx.core.shareddata.AsyncMap.remove]
  *
  * @param k the key
+ * @return [V?]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.shareddata.AsyncMap original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.core.shareddata.AsyncMap] using Vert.x codegen.
  */
-suspend fun <K,V> AsyncMap<K,V>.removeAwait(k : K) : V? {
-  return awaitResult{
+suspend fun <K,V> AsyncMap<K,V>.removeAwait(k: K): V? {
+  return awaitResult {
     this.remove(k, it)
   }
 }
 
 /**
- * Remove a value from the map, only if entry already exists with same value.
+ * Suspending version of method [io.vertx.core.shareddata.AsyncMap.removeIfPresent]
  *
  * @param k the key
  * @param v the value
+ * @return [Boolean]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.shareddata.AsyncMap original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.core.shareddata.AsyncMap] using Vert.x codegen.
  */
-suspend fun <K,V> AsyncMap<K,V>.removeIfPresentAwait(k : K, v : V) : Boolean {
-  return awaitResult{
+suspend fun <K,V> AsyncMap<K,V>.removeIfPresentAwait(k: K, v: V): Boolean {
+  return awaitResult {
     this.removeIfPresent(k, v, it)
   }
 }
 
 /**
- * Replace the entry only if it is currently mapped to some value
+ * Suspending version of method [io.vertx.core.shareddata.AsyncMap.replace]
  *
  * @param k the key
  * @param v the new value
+ * @return [V?]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.shareddata.AsyncMap original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.core.shareddata.AsyncMap] using Vert.x codegen.
  */
-suspend fun <K,V> AsyncMap<K,V>.replaceAwait(k : K, v : V) : V? {
-  return awaitResult{
+suspend fun <K,V> AsyncMap<K,V>.replaceAwait(k: K, v: V): V? {
+  return awaitResult {
     this.replace(k, v, it)
   }
 }
 
 /**
- * Replace the entry only if it is currently mapped to a specific value
+ * Suspending version of method [io.vertx.core.shareddata.AsyncMap.replaceIfPresent]
  *
  * @param k the key
  * @param oldValue the existing value
  * @param newValue the new value
+ * @return [Boolean]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.shareddata.AsyncMap original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.core.shareddata.AsyncMap] using Vert.x codegen.
  */
-suspend fun <K,V> AsyncMap<K,V>.replaceIfPresentAwait(k : K, oldValue : V, newValue : V) : Boolean {
-  return awaitResult{
+suspend fun <K,V> AsyncMap<K,V>.replaceIfPresentAwait(k: K, oldValue: V, newValue: V): Boolean {
+  return awaitResult {
     this.replaceIfPresent(k, oldValue, newValue, it)
   }
 }
 
 /**
- * Clear all entries in the map
+ * Suspending version of method [io.vertx.core.shareddata.AsyncMap.clear]
  *
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.shareddata.AsyncMap original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.core.shareddata.AsyncMap] using Vert.x codegen.
  */
-suspend fun <K,V> AsyncMap<K,V>.clearAwait() : Unit {
-  return awaitResult{
-    this.clear({ ar -> it.handle(ar.mapEmpty()) })}
+suspend fun <K,V> AsyncMap<K,V>.clearAwait(): Unit {
+  return awaitResult {
+    this.clear { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Provide the number of entries in the map
+ * Suspending version of method [io.vertx.core.shareddata.AsyncMap.size]
  *
+ * @return [Int]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.shareddata.AsyncMap original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.core.shareddata.AsyncMap] using Vert.x codegen.
  */
-suspend fun <K,V> AsyncMap<K,V>.sizeAwait() : Int {
-  return awaitResult{
+suspend fun <K,V> AsyncMap<K,V>.sizeAwait(): Int {
+  return awaitResult {
     this.size(it)
   }
 }

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/shareddata/Counter.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/shareddata/Counter.kt
@@ -4,97 +4,96 @@ import io.vertx.core.shareddata.Counter
 import io.vertx.kotlin.coroutines.awaitResult
 
 /**
- * Get the current value of the counter
+ * Suspending version of method [io.vertx.core.shareddata.Counter.get]
  *
+ * @return [Long]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.shareddata.Counter original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.core.shareddata.Counter] using Vert.x codegen.
  */
-suspend fun Counter.getAwait() : Long {
-  return awaitResult{
+suspend fun Counter.getAwait(): Long {
+  return awaitResult {
     this.get(it)
   }
 }
 
 /**
- * Increment the counter atomically and return the new count
+ * Suspending version of method [io.vertx.core.shareddata.Counter.incrementAndGet]
  *
+ * @return [Long]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.shareddata.Counter original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.core.shareddata.Counter] using Vert.x codegen.
  */
-suspend fun Counter.incrementAndGetAwait() : Long {
-  return awaitResult{
+suspend fun Counter.incrementAndGetAwait(): Long {
+  return awaitResult {
     this.incrementAndGet(it)
   }
 }
 
 /**
- * Increment the counter atomically and return the value before the increment.
+ * Suspending version of method [io.vertx.core.shareddata.Counter.getAndIncrement]
  *
+ * @return [Long]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.shareddata.Counter original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.core.shareddata.Counter] using Vert.x codegen.
  */
-suspend fun Counter.getAndIncrementAwait() : Long {
-  return awaitResult{
+suspend fun Counter.getAndIncrementAwait(): Long {
+  return awaitResult {
     this.getAndIncrement(it)
   }
 }
 
 /**
- * Decrement the counter atomically and return the new count
+ * Suspending version of method [io.vertx.core.shareddata.Counter.decrementAndGet]
  *
+ * @return [Long]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.shareddata.Counter original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.core.shareddata.Counter] using Vert.x codegen.
  */
-suspend fun Counter.decrementAndGetAwait() : Long {
-  return awaitResult{
+suspend fun Counter.decrementAndGetAwait(): Long {
+  return awaitResult {
     this.decrementAndGet(it)
   }
 }
 
 /**
- * Add the value to the counter atomically and return the new count
+ * Suspending version of method [io.vertx.core.shareddata.Counter.addAndGet]
  *
  * @param value the value to add
+ * @return [Long]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.shareddata.Counter original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.core.shareddata.Counter] using Vert.x codegen.
  */
-suspend fun Counter.addAndGetAwait(value : Long) : Long {
-  return awaitResult{
+suspend fun Counter.addAndGetAwait(value: Long): Long {
+  return awaitResult {
     this.addAndGet(value, it)
   }
 }
 
 /**
- * Add the value to the counter atomically and return the value before the add
+ * Suspending version of method [io.vertx.core.shareddata.Counter.getAndAdd]
  *
  * @param value the value to add
+ * @return [Long]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.shareddata.Counter original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.core.shareddata.Counter] using Vert.x codegen.
  */
-suspend fun Counter.getAndAddAwait(value : Long) : Long {
-  return awaitResult{
+suspend fun Counter.getAndAddAwait(value: Long): Long {
+  return awaitResult {
     this.getAndAdd(value, it)
   }
 }
 
 /**
- * Set the counter to the specified value only if the current value is the expectec value. This happens
- * atomically.
+ * Suspending version of method [io.vertx.core.shareddata.Counter.compareAndSet]
  *
  * @param expected the expected value
  * @param value the new value
+ * @return [Boolean]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.shareddata.Counter original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.core.shareddata.Counter] using Vert.x codegen.
  */
-suspend fun Counter.compareAndSetAwait(expected : Long, value : Long) : Boolean {
-  return awaitResult{
+suspend fun Counter.compareAndSetAwait(expected: Long, value: Long): Boolean {
+  return awaitResult {
     this.compareAndSet(expected, value, it)
   }
 }

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/shareddata/SharedData.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/shareddata/SharedData.kt
@@ -7,87 +7,72 @@ import io.vertx.core.shareddata.SharedData
 import io.vertx.kotlin.coroutines.awaitResult
 
 /**
- * Get the cluster wide map with the specified name. The map is accessible to all nodes in the cluster and data
- * put into the map from any node is visible to to any other node.
+ * Suspending version of method [io.vertx.core.shareddata.SharedData.getClusterWideMap]
  *
  * @param name the name of the map
+ * @return [AsyncMap<K,V>]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.shareddata.SharedData original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.core.shareddata.SharedData] using Vert.x codegen.
  */
-suspend fun <K,V> SharedData.getClusterWideMapAwait(name : String) : AsyncMap<K,V> {
-  return awaitResult{
+suspend fun <K,V> SharedData.getClusterWideMapAwait(name: String): AsyncMap<K,V> {
+  return awaitResult {
     this.getClusterWideMap(name, it)
   }
 }
 
 /**
- * Get the [io.vertx.core.shareddata.AsyncMap] with the specified name. When clustered, the map is accessible to all nodes in the cluster
- * and data put into the map from any node is visible to to any other node.
- * <p>
- *   <strong>WARNING</strong>: In clustered mode, asynchronous shared maps rely on distributed data structures provided by the cluster manager.
- *   Beware that the latency relative to asynchronous shared maps operations can be much higher in clustered than in local mode.
- * </p>
+ * Suspending version of method [io.vertx.core.shareddata.SharedData.getAsyncMap]
  *
  * @param name the name of the map
+ * @return [AsyncMap<K,V>]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.shareddata.SharedData original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.core.shareddata.SharedData] using Vert.x codegen.
  */
-suspend fun <K,V> SharedData.getAsyncMapAwait(name : String) : AsyncMap<K,V> {
-  return awaitResult{
+suspend fun <K,V> SharedData.getAsyncMapAwait(name: String): AsyncMap<K,V> {
+  return awaitResult {
     this.getAsyncMap(name, it)
   }
 }
 
 /**
- * Get an asynchronous lock with the specified name. The lock will be passed to the handler when it is available.
- * <p>
- *   In general lock acquision is unordered, so that sequential attempts to acquire a lock,
- *   even from a single thread, can happen in non-sequential order.
- * </p>
+ * Suspending version of method [io.vertx.core.shareddata.SharedData.getLock]
  *
  * @param name the name of the lock
+ * @return [Lock]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.shareddata.SharedData original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.core.shareddata.SharedData] using Vert.x codegen.
  */
-suspend fun SharedData.getLockAwait(name : String) : Lock {
-  return awaitResult{
+suspend fun SharedData.getLockAwait(name: String): Lock {
+  return awaitResult {
     this.getLock(name, it)
   }
 }
 
 /**
- * Like [io.vertx.core.shareddata.SharedData] but specifying a timeout. If the lock is not obtained within the timeout
- * a failure will be sent to the handler.
- * <p>
- *   In general lock acquision is unordered, so that sequential attempts to acquire a lock,
- *   even from a single thread, can happen in non-sequential order.
- * </p>
+ * Suspending version of method [io.vertx.core.shareddata.SharedData.getLockWithTimeout]
  *
  * @param name the name of the lock
  * @param timeout the timeout in ms
+ * @return [Lock]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.shareddata.SharedData original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.core.shareddata.SharedData] using Vert.x codegen.
  */
-suspend fun SharedData.getLockWithTimeoutAwait(name : String, timeout : Long) : Lock {
-  return awaitResult{
+suspend fun SharedData.getLockWithTimeoutAwait(name: String, timeout: Long): Lock {
+  return awaitResult {
     this.getLockWithTimeout(name, timeout, it)
   }
 }
 
 /**
- * Get an asynchronous counter. The counter will be passed to the handler.
+ * Suspending version of method [io.vertx.core.shareddata.SharedData.getCounter]
  *
  * @param name the name of the counter.
+ * @return [Counter]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.core.shareddata.SharedData original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.core.shareddata.SharedData] using Vert.x codegen.
  */
-suspend fun SharedData.getCounterAwait(name : String) : Counter {
-  return awaitResult{
+suspend fun SharedData.getCounterAwait(name: String): Counter {
+  return awaitResult {
     this.getCounter(name, it)
   }
 }

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/auth/AuthProvider.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/auth/AuthProvider.kt
@@ -6,29 +6,15 @@ import io.vertx.ext.auth.User
 import io.vertx.kotlin.coroutines.awaitResult
 
 /**
- * Authenticate a user.
- * <p>
- * The first argument is a JSON object containing information for authenticating the user. What this actually contains
- * depends on the specific implementation. In the case of a simple username/password based
- * authentication it is likely to contain a JSON object with the following structure:
- * <pre>
- *   {
- *     "username": "tim",
- *     "password": "mypassword"
- *   }
- * </pre>
- * For other types of authentication it contain different information - for example a JWT token or OAuth bearer token.
- * <p>
- * If the user is successfully authenticated a [io.vertx.ext.auth.User] object is passed to the handler in an [io.vertx.core.AsyncResult].
- * The user object can then be used for authorisation.
+ * Suspending version of method [io.vertx.ext.auth.AuthProvider.authenticate]
  *
  * @param authInfo The auth information
+ * @return [User]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.auth.AuthProvider original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.ext.auth.AuthProvider] using Vert.x codegen.
  */
-suspend fun AuthProvider.authenticateAwait(authInfo : JsonObject) : User {
-  return awaitResult{
+suspend fun AuthProvider.authenticateAwait(authInfo: JsonObject): User {
+  return awaitResult {
     this.authenticate(authInfo, it)
   }
 }

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/auth/User.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/auth/User.kt
@@ -4,15 +4,15 @@ import io.vertx.ext.auth.User
 import io.vertx.kotlin.coroutines.awaitResult
 
 /**
- * Is the user authorised to
+ * Suspending version of method [io.vertx.ext.auth.User.isAuthorized]
  *
  * @param authority the authority - what this really means is determined by the specific implementation. It might represent a permission to access a resource e.g. `printers:printer34` or it might represent authority to a role in a roles based model, e.g. `role:admin`.
- * @return the User to enable fluent use *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.auth.User original] using Vert.x codegen.
+ * @return [Boolean]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.auth.User] using Vert.x codegen.
  */
-suspend fun User.isAuthorizedAwait(authority : String) : Boolean {
-  return awaitResult{
+suspend fun User.isAuthorizedAwait(authority: String): Boolean {
+  return awaitResult {
     this.isAuthorized(authority, it)
   }
 }

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/auth/mongo/MongoAuth.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/auth/mongo/MongoAuth.kt
@@ -4,18 +4,18 @@ import io.vertx.ext.auth.mongo.MongoAuth
 import io.vertx.kotlin.coroutines.awaitResult
 
 /**
- * Insert a new user into mongo in the convenient way
+ * Suspending version of method [io.vertx.ext.auth.mongo.MongoAuth.insertUser]
  *
  * @param username the username to be set
  * @param password the passsword in clear text, will be adapted following the definitions of the defined [io.vertx.ext.auth.mongo.HashStrategy]
  * @param roles a list of roles to be set
  * @param permissions a list of permissions to be set
+ * @return [String]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.auth.mongo.MongoAuth original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.ext.auth.mongo.MongoAuth] using Vert.x codegen.
  */
-suspend fun MongoAuth.insertUserAwait(username : String, password : String, roles : List<String>, permissions : List<String>) : String {
-  return awaitResult{
+suspend fun MongoAuth.insertUserAwait(username: String, password: String, roles: List<String>, permissions: List<String>): String {
+  return awaitResult {
     this.insertUser(username, password, roles, permissions, it)
   }
 }

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/auth/oauth2/AccessToken.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/auth/oauth2/AccessToken.kt
@@ -8,108 +8,107 @@ import io.vertx.ext.auth.oauth2.OAuth2Response
 import io.vertx.kotlin.coroutines.awaitResult
 
 /**
- * Refresh the access token
+ * Suspending version of method [io.vertx.ext.auth.oauth2.AccessToken.refresh]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.auth.oauth2.AccessToken original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.auth.oauth2.AccessToken] using Vert.x codegen.
  */
-suspend fun AccessToken.refreshAwait() : Unit {
-  return awaitResult{
-    this.refresh({ ar -> it.handle(ar.mapEmpty()) })}
+suspend fun AccessToken.refreshAwait(): Unit {
+  return awaitResult {
+    this.refresh { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Revoke access or refresh token
+ * Suspending version of method [io.vertx.ext.auth.oauth2.AccessToken.revoke]
  *
  * @param token_type - A String containing the type of token to revoke. Should be either "access_token" or "refresh_token".
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.auth.oauth2.AccessToken original] using Vert.x codegen.
- */
-suspend fun AccessToken.revokeAwait(token_type : String) : Unit {
-  return awaitResult{
-    this.revoke(token_type, { ar -> it.handle(ar.mapEmpty()) })}
-}
-
-/**
- * Revoke refresh token and calls the logout endpoint. This is a openid-connect extension and might not be
- * available on all providers.
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.auth.oauth2.AccessToken original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.ext.auth.oauth2.AccessToken] using Vert.x codegen.
  */
-suspend fun AccessToken.logoutAwait() : Unit {
-  return awaitResult{
-    this.logout({ ar -> it.handle(ar.mapEmpty()) })}
+suspend fun AccessToken.revokeAwait(token_type: String): Unit {
+  return awaitResult {
+    this.revoke(token_type) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Introspect access token. This is an OAuth2 extension that allow to verify if an access token is still valid.
+ * Suspending version of method [io.vertx.ext.auth.oauth2.AccessToken.logout]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.auth.oauth2.AccessToken original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.auth.oauth2.AccessToken] using Vert.x codegen.
  */
-suspend fun AccessToken.introspectAwait() : Unit {
-  return awaitResult{
-    this.introspect({ ar -> it.handle(ar.mapEmpty()) })}
+suspend fun AccessToken.logoutAwait(): Unit {
+  return awaitResult {
+    this.logout { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Introspect access token. This is an OAuth2 extension that allow to verify if an access token is still valid.
+ * Suspending version of method [io.vertx.ext.auth.oauth2.AccessToken.introspect]
+ *
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.auth.oauth2.AccessToken] using Vert.x codegen.
+ */
+suspend fun AccessToken.introspectAwait(): Unit {
+  return awaitResult {
+    this.introspect { ar -> it.handle(ar.mapEmpty()) }
+  }
+}
+
+/**
+ * Suspending version of method [io.vertx.ext.auth.oauth2.AccessToken.introspect]
  *
  * @param tokenType - A String containing the type of token to revoke. Should be either "access_token" or "refresh_token".
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.auth.oauth2.AccessToken original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.auth.oauth2.AccessToken] using Vert.x codegen.
  */
-suspend fun AccessToken.introspectAwait(tokenType : String) : Unit {
-  return awaitResult{
-    this.introspect(tokenType, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun AccessToken.introspectAwait(tokenType: String): Unit {
+  return awaitResult {
+    this.introspect(tokenType) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Load the user info as per OIDC spec.
+ * Suspending version of method [io.vertx.ext.auth.oauth2.AccessToken.userInfo]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.auth.oauth2.AccessToken original] using Vert.x codegen.
+ * @return [JsonObject]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.auth.oauth2.AccessToken] using Vert.x codegen.
  */
-suspend fun AccessToken.userInfoAwait() : JsonObject {
-  return awaitResult{
+suspend fun AccessToken.userInfoAwait(): JsonObject {
+  return awaitResult {
     this.userInfo(it)
   }
 }
 
 /**
- * Fetches a JSON resource using this Access Token.
+ * Suspending version of method [io.vertx.ext.auth.oauth2.AccessToken.fetch]
  *
  * @param resource - the resource to fetch.
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.auth.oauth2.AccessToken original] using Vert.x codegen.
+ * @return [OAuth2Response]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.auth.oauth2.AccessToken] using Vert.x codegen.
  */
-suspend fun AccessToken.fetchAwait(resource : String) : OAuth2Response {
-  return awaitResult{
+suspend fun AccessToken.fetchAwait(resource: String): OAuth2Response {
+  return awaitResult {
     this.fetch(resource, it)
   }
 }
 
 /**
- * Fetches a JSON resource using this Access Token.
+ * Suspending version of method [io.vertx.ext.auth.oauth2.AccessToken.fetch]
  *
  * @param method - the HTTP method to user.
  * @param resource - the resource to fetch.
  * @param headers - extra headers to pass to the request.
  * @param payload - payload to send to the server.
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.auth.oauth2.AccessToken original] using Vert.x codegen.
+ * @return [OAuth2Response]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.auth.oauth2.AccessToken] using Vert.x codegen.
  */
-suspend fun AccessToken.fetchAwait(method : HttpMethod, resource : String, headers : JsonObject, payload : Buffer) : OAuth2Response {
-  return awaitResult{
+suspend fun AccessToken.fetchAwait(method: HttpMethod, resource: String, headers: JsonObject, payload: Buffer): OAuth2Response {
+  return awaitResult {
     this.fetch(method, resource, headers, payload, it)
   }
 }

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/auth/oauth2/OAuth2Auth.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/auth/oauth2/OAuth2Auth.kt
@@ -5,47 +5,43 @@ import io.vertx.ext.auth.oauth2.OAuth2Auth
 import io.vertx.kotlin.coroutines.awaitResult
 
 /**
- * Query an OAuth 2.0 authorization server to determine the active state of an OAuth 2.0 token and to determine
- * meta-information about this token.
+ * Suspending version of method [io.vertx.ext.auth.oauth2.OAuth2Auth.introspectToken]
  *
  * @param token the access token (base64 string)
- * @return self *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.auth.oauth2.OAuth2Auth original] using Vert.x codegen.
+ * @return [AccessToken]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.auth.oauth2.OAuth2Auth] using Vert.x codegen.
  */
-suspend fun OAuth2Auth.introspectTokenAwait(token : String) : AccessToken {
-  return awaitResult{
+suspend fun OAuth2Auth.introspectTokenAwait(token: String): AccessToken {
+  return awaitResult {
     this.introspectToken(token, it)
   }
 }
 
 /**
- * Query an OAuth 2.0 authorization server to determine the active state of an OAuth 2.0 token and to determine
- * meta-information about this token.
+ * Suspending version of method [io.vertx.ext.auth.oauth2.OAuth2Auth.introspectToken]
  *
  * @param token the access token (base64 string)
  * @param tokenType hint to the token type e.g.: `access_token`
- * @return self *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.auth.oauth2.OAuth2Auth original] using Vert.x codegen.
+ * @return [AccessToken]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.auth.oauth2.OAuth2Auth] using Vert.x codegen.
  */
-suspend fun OAuth2Auth.introspectTokenAwait(token : String, tokenType : String) : AccessToken {
-  return awaitResult{
+suspend fun OAuth2Auth.introspectTokenAwait(token: String, tokenType: String): AccessToken {
+  return awaitResult {
     this.introspectToken(token, tokenType, it)
   }
 }
 
 /**
- * Loads a JWK Set from the remote provider.
+ * Suspending version of method [io.vertx.ext.auth.oauth2.OAuth2Auth.loadJWK]
  *
- * When calling this method several times, the loaded JWKs are updated in the underlying JWT object.
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.auth.oauth2.OAuth2Auth original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.ext.auth.oauth2.OAuth2Auth] using Vert.x codegen.
  */
-suspend fun OAuth2Auth.loadJWKAwait() : Unit {
-  return awaitResult{
-    this.loadJWK({ ar -> it.handle(ar.mapEmpty()) })}
+suspend fun OAuth2Auth.loadJWKAwait(): Unit {
+  return awaitResult {
+    this.loadJWK { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/auth/oauth2/OAuth2RBAC.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/auth/oauth2/OAuth2RBAC.kt
@@ -5,19 +5,16 @@ import io.vertx.ext.auth.oauth2.OAuth2RBAC
 import io.vertx.kotlin.coroutines.awaitResult
 
 /**
- * This method should verify if the user has the given authority and return either a boolean value or an error.
- *
- * Note that false and errors are not the same. A user might not have a given authority but that doesn't mean that
- * there was an error during the call.
+ * Suspending version of method [io.vertx.ext.auth.oauth2.OAuth2RBAC.isAuthorized]
  *
  * @param user the given user to assert on
  * @param authority the authority to lookup
+ * @return [Boolean]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.auth.oauth2.OAuth2RBAC original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.ext.auth.oauth2.OAuth2RBAC] using Vert.x codegen.
  */
-suspend fun OAuth2RBAC.isAuthorizedAwait(user : AccessToken, authority : String) : Boolean {
-  return awaitResult{
+suspend fun OAuth2RBAC.isAuthorizedAwait(user: AccessToken, authority: String): Boolean {
+  return awaitResult {
     this.isAuthorized(user, authority, it)
   }
 }

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/auth/oauth2/providers/AzureADAuth.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/auth/oauth2/providers/AzureADAuth.kt
@@ -8,21 +8,16 @@ import io.vertx.kotlin.coroutines.awaitResult
 
 object AzureADAuth {
   /**
-   * Create a OAuth2Auth provider for OpenID Connect Discovery. The discovery will use the default site in the
-   * configuration options and attempt to load the well known descriptor. If a site is provided (for example when
-   * running on a custom instance) that site will be used to do the lookup.
-   * <p>
-   * If the discovered config includes a json web key url, it will be also fetched and the JWKs will be loaded
-   * into the OAuth provider so tokens can be decoded.
+   * Suspending version of method [io.vertx.ext.auth.oauth2.providers.AzureADAuth.discover]
    *
    * @param vertx the vertx instance
    * @param config the initial config
+   * @return [OAuth2Auth]
    *
-   * <p/>
-   * NOTE: This function has been automatically generated from the [io.vertx.ext.auth.oauth2.providers.AzureADAuth original] using Vert.x codegen.
+   * NOTE: This function has been automatically generated from [io.vertx.ext.auth.oauth2.providers.AzureADAuth] using Vert.x codegen.
    */
-  suspend fun discoverAwait(vertx : Vertx, config : OAuth2ClientOptions) : OAuth2Auth {
-    return awaitResult{
+  suspend fun discoverAwait(vertx: Vertx, config: OAuth2ClientOptions): OAuth2Auth {
+    return awaitResult {
       AzureADAuthVertxAlias.discover(vertx, config, it)
     }
   }

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/auth/oauth2/providers/GoogleAuth.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/auth/oauth2/providers/GoogleAuth.kt
@@ -8,21 +8,16 @@ import io.vertx.kotlin.coroutines.awaitResult
 
 object GoogleAuth {
   /**
-   * Create a OAuth2Auth provider for OpenID Connect Discovery. The discovery will use the default site in the
-   * configuration options and attempt to load the well known descriptor. If a site is provided (for example when
-   * running on a custom instance) that site will be used to do the lookup.
-   * <p>
-   * If the discovered config includes a json web key url, it will be also fetched and the JWKs will be loaded
-   * into the OAuth provider so tokens can be decoded.
+   * Suspending version of method [io.vertx.ext.auth.oauth2.providers.GoogleAuth.discover]
    *
    * @param vertx the vertx instance
    * @param config the initial config
+   * @return [OAuth2Auth]
    *
-   * <p/>
-   * NOTE: This function has been automatically generated from the [io.vertx.ext.auth.oauth2.providers.GoogleAuth original] using Vert.x codegen.
+   * NOTE: This function has been automatically generated from [io.vertx.ext.auth.oauth2.providers.GoogleAuth] using Vert.x codegen.
    */
-  suspend fun discoverAwait(vertx : Vertx, config : OAuth2ClientOptions) : OAuth2Auth {
-    return awaitResult{
+  suspend fun discoverAwait(vertx: Vertx, config: OAuth2ClientOptions): OAuth2Auth {
+    return awaitResult {
       GoogleAuthVertxAlias.discover(vertx, config, it)
     }
   }

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/auth/oauth2/providers/KeycloakAuth.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/auth/oauth2/providers/KeycloakAuth.kt
@@ -8,21 +8,16 @@ import io.vertx.kotlin.coroutines.awaitResult
 
 object KeycloakAuth {
   /**
-   * Create a OAuth2Auth provider for OpenID Connect Discovery. The discovery will use the default site in the
-   * configuration options and attempt to load the well known descriptor. If a site is provided (for example when
-   * running on a custom instance) that site will be used to do the lookup.
-   * <p>
-   * If the discovered config includes a json web key url, it will be also fetched and the JWKs will be loaded
-   * into the OAuth provider so tokens can be decoded.
+   * Suspending version of method [io.vertx.ext.auth.oauth2.providers.KeycloakAuth.discover]
    *
    * @param vertx the vertx instance
    * @param config the initial config
+   * @return [OAuth2Auth]
    *
-   * <p/>
-   * NOTE: This function has been automatically generated from the [io.vertx.ext.auth.oauth2.providers.KeycloakAuth original] using Vert.x codegen.
+   * NOTE: This function has been automatically generated from [io.vertx.ext.auth.oauth2.providers.KeycloakAuth] using Vert.x codegen.
    */
-  suspend fun discoverAwait(vertx : Vertx, config : OAuth2ClientOptions) : OAuth2Auth {
-    return awaitResult{
+  suspend fun discoverAwait(vertx: Vertx, config: OAuth2ClientOptions): OAuth2Auth {
+    return awaitResult {
       KeycloakAuthVertxAlias.discover(vertx, config, it)
     }
   }

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/auth/oauth2/providers/OpenIDConnectAuth.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/auth/oauth2/providers/OpenIDConnectAuth.kt
@@ -8,20 +8,16 @@ import io.vertx.kotlin.coroutines.awaitResult
 
 object OpenIDConnectAuth {
   /**
-   * Create a OAuth2Auth provider for OpenID Connect Discovery. The discovery will use the given site in the
-   * configuration options and attempt to load the well known descriptor.
-   *
-   * If the discovered config includes a json web key url, it will be also fetched and the JWKs will be loaded
-   * into the OAuth provider so tokens can be decoded.
+   * Suspending version of method [io.vertx.ext.auth.oauth2.providers.OpenIDConnectAuth.discover]
    *
    * @param vertx the vertx instance
    * @param config the initial config, it should contain a site url
+   * @return [OAuth2Auth]
    *
-   * <p/>
-   * NOTE: This function has been automatically generated from the [io.vertx.ext.auth.oauth2.providers.OpenIDConnectAuth original] using Vert.x codegen.
+   * NOTE: This function has been automatically generated from [io.vertx.ext.auth.oauth2.providers.OpenIDConnectAuth] using Vert.x codegen.
    */
-  suspend fun discoverAwait(vertx : Vertx, config : OAuth2ClientOptions) : OAuth2Auth {
-    return awaitResult{
+  suspend fun discoverAwait(vertx: Vertx, config: OAuth2ClientOptions): OAuth2Auth {
+    return awaitResult {
       OpenIDConnectAuthVertxAlias.discover(vertx, config, it)
     }
   }

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/auth/oauth2/providers/SalesforceAuth.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/auth/oauth2/providers/SalesforceAuth.kt
@@ -8,21 +8,16 @@ import io.vertx.kotlin.coroutines.awaitResult
 
 object SalesforceAuth {
   /**
-   * Create a OAuth2Auth provider for OpenID Connect Discovery. The discovery will use the default site in the
-   * configuration options and attempt to load the well known descriptor. If a site is provided (for example when
-   * running on a custom instance) that site will be used to do the lookup.
-   * <p>
-   * If the discovered config includes a json web key url, it will be also fetched and the JWKs will be loaded
-   * into the OAuth provider so tokens can be decoded.
+   * Suspending version of method [io.vertx.ext.auth.oauth2.providers.SalesforceAuth.discover]
    *
    * @param vertx the vertx instance
    * @param config the initial config
+   * @return [OAuth2Auth]
    *
-   * <p/>
-   * NOTE: This function has been automatically generated from the [io.vertx.ext.auth.oauth2.providers.SalesforceAuth original] using Vert.x codegen.
+   * NOTE: This function has been automatically generated from [io.vertx.ext.auth.oauth2.providers.SalesforceAuth] using Vert.x codegen.
    */
-  suspend fun discoverAwait(vertx : Vertx, config : OAuth2ClientOptions) : OAuth2Auth {
-    return awaitResult{
+  suspend fun discoverAwait(vertx: Vertx, config: OAuth2ClientOptions): OAuth2Auth {
+    return awaitResult {
       SalesforceAuthVertxAlias.discover(vertx, config, it)
     }
   }

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/bridge/BaseBridgeEvent.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/bridge/BaseBridgeEvent.kt
@@ -4,17 +4,14 @@ import io.vertx.ext.bridge.BaseBridgeEvent
 import io.vertx.kotlin.coroutines.awaitResult
 
 /**
- * Set a handler for the result.
- * <p>
- * If the future has already been completed it will be called immediately. Otherwise it will be called when the
- * future is completed.
+ * Suspending version of method [io.vertx.ext.bridge.BaseBridgeEvent.setHandler]
  *
- * @return a reference to this, so it can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.bridge.BaseBridgeEvent original] using Vert.x codegen.
+ * @return [Boolean]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.bridge.BaseBridgeEvent] using Vert.x codegen.
  */
-suspend fun BaseBridgeEvent.setHandlerAwait() : Boolean {
-  return awaitResult{
+suspend fun BaseBridgeEvent.setHandlerAwait(): Boolean {
+  return awaitResult {
     this.setHandler(it)
   }
 }

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/consul/ConsulClient.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/consul/ConsulClient.kt
@@ -38,1048 +38,1026 @@ import io.vertx.ext.consul.TxnResponse
 import io.vertx.kotlin.coroutines.awaitResult
 
 /**
- * Returns the configuration and member information of the local agent
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.agentInfo]
  *
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ * @return [JsonObject]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.agentInfoAwait() : JsonObject {
-  return awaitResult{
+suspend fun ConsulClient.agentInfoAwait(): JsonObject {
+  return awaitResult {
     this.agentInfo(it)
   }
 }
 
 /**
- * Returns the LAN network coordinates for all nodes in a given DC
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.coordinateNodes]
  *
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ * @return [CoordinateList]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.coordinateNodesAwait() : CoordinateList {
-  return awaitResult{
+suspend fun ConsulClient.coordinateNodesAwait(): CoordinateList {
+  return awaitResult {
     this.coordinateNodes(it)
   }
 }
 
 /**
- * Returns the LAN network coordinates for all nodes in a given DC
- * This is blocking query unlike [io.vertx.ext.consul.ConsulClient]
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.coordinateNodesWithOptions]
  *
  * @param options the blocking options
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ * @return [CoordinateList]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.coordinateNodesWithOptionsAwait(options : BlockingQueryOptions) : CoordinateList {
-  return awaitResult{
+suspend fun ConsulClient.coordinateNodesWithOptionsAwait(options: BlockingQueryOptions): CoordinateList {
+  return awaitResult {
     this.coordinateNodesWithOptions(options, it)
   }
 }
 
 /**
- * Returns the WAN network coordinates for all Consul servers, organized by DCs
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.coordinateDatacenters]
  *
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ * @return [List<DcCoordinates>]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.coordinateDatacentersAwait() : List<DcCoordinates> {
-  return awaitResult{
+suspend fun ConsulClient.coordinateDatacentersAwait(): List<DcCoordinates> {
+  return awaitResult {
     this.coordinateDatacenters(it)
   }
 }
 
 /**
- * Returns the list of keys that corresponding to the specified key prefix.
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.getKeys]
  *
  * @param keyPrefix the prefix
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ * @return [List<String>]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.getKeysAwait(keyPrefix : String) : List<String> {
-  return awaitResult{
+suspend fun ConsulClient.getKeysAwait(keyPrefix: String): List<String> {
+  return awaitResult {
     this.getKeys(keyPrefix, it)
   }
 }
 
 /**
- * Returns the list of keys that corresponding to the specified key prefix.
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.getKeysWithOptions]
  *
  * @param keyPrefix the prefix
  * @param options the blocking options
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ * @return [List<String>]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.getKeysWithOptionsAwait(keyPrefix : String, options : BlockingQueryOptions) : List<String> {
-  return awaitResult{
+suspend fun ConsulClient.getKeysWithOptionsAwait(keyPrefix: String, options: BlockingQueryOptions): List<String> {
+  return awaitResult {
     this.getKeysWithOptions(keyPrefix, options, it)
   }
 }
 
 /**
- * Returns key/value pair that corresponding to the specified key.
- * An empty [io.vertx.ext.consul.KeyValue] object will be returned if no such key is found.
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.getValue]
  *
  * @param key the key
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ * @return [KeyValue]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.getValueAwait(key : String) : KeyValue {
-  return awaitResult{
+suspend fun ConsulClient.getValueAwait(key: String): KeyValue {
+  return awaitResult {
     this.getValue(key, it)
   }
 }
 
 /**
- * Returns key/value pair that corresponding to the specified key.
- * An empty [io.vertx.ext.consul.KeyValue] object will be returned if no such key is found.
- * This is blocking query unlike [io.vertx.ext.consul.ConsulClient]
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.getValueWithOptions]
  *
  * @param key the key
  * @param options the blocking options
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ * @return [KeyValue]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.getValueWithOptionsAwait(key : String, options : BlockingQueryOptions) : KeyValue {
-  return awaitResult{
+suspend fun ConsulClient.getValueWithOptionsAwait(key: String, options: BlockingQueryOptions): KeyValue {
+  return awaitResult {
     this.getValueWithOptions(key, options, it)
   }
 }
 
 /**
- * Remove the key/value pair that corresponding to the specified key
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.deleteValue]
  *
  * @param key the key
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.deleteValueAwait(key : String) : Unit {
-  return awaitResult{
-    this.deleteValue(key, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun ConsulClient.deleteValueAwait(key: String): Unit {
+  return awaitResult {
+    this.deleteValue(key) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Returns the list of key/value pairs that corresponding to the specified key prefix.
- * An empty [io.vertx.ext.consul.KeyValueList] object will be returned if no such key prefix is found.
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.getValues]
  *
  * @param keyPrefix the prefix
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ * @return [KeyValueList]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.getValuesAwait(keyPrefix : String) : KeyValueList {
-  return awaitResult{
+suspend fun ConsulClient.getValuesAwait(keyPrefix: String): KeyValueList {
+  return awaitResult {
     this.getValues(keyPrefix, it)
   }
 }
 
 /**
- * Returns the list of key/value pairs that corresponding to the specified key prefix.
- * An empty [io.vertx.ext.consul.KeyValueList] object will be returned if no such key prefix is found.
- * This is blocking query unlike [io.vertx.ext.consul.ConsulClient]
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.getValuesWithOptions]
  *
  * @param keyPrefix the prefix
  * @param options the blocking options
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ * @return [KeyValueList]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.getValuesWithOptionsAwait(keyPrefix : String, options : BlockingQueryOptions) : KeyValueList {
-  return awaitResult{
+suspend fun ConsulClient.getValuesWithOptionsAwait(keyPrefix: String, options: BlockingQueryOptions): KeyValueList {
+  return awaitResult {
     this.getValuesWithOptions(keyPrefix, options, it)
   }
 }
 
 /**
- * Removes all the key/value pair that corresponding to the specified key prefix
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.deleteValues]
  *
  * @param keyPrefix the prefix
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.deleteValuesAwait(keyPrefix : String) : Unit {
-  return awaitResult{
-    this.deleteValues(keyPrefix, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun ConsulClient.deleteValuesAwait(keyPrefix: String): Unit {
+  return awaitResult {
+    this.deleteValues(keyPrefix) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Adds specified key/value pair
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.putValue]
  *
  * @param key the key
  * @param value the value
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ * @return [Boolean]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.putValueAwait(key : String, value : String) : Boolean {
-  return awaitResult{
+suspend fun ConsulClient.putValueAwait(key: String, value: String): Boolean {
+  return awaitResult {
     this.putValue(key, value, it)
   }
 }
 
 /**
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.putValueWithOptions]
  *
  * @param key the key
  * @param value the value
  * @param options options used to push pair
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ * @return [Boolean]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.putValueWithOptionsAwait(key : String, value : String, options : KeyValueOptions) : Boolean {
-  return awaitResult{
+suspend fun ConsulClient.putValueWithOptionsAwait(key: String, value: String, options: KeyValueOptions): Boolean {
+  return awaitResult {
     this.putValueWithOptions(key, value, options, it)
   }
 }
 
 /**
- * Manages multiple operations inside a single, atomic transaction.
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.transaction]
  *
  * @param request transaction request
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ * @return [TxnResponse]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.transactionAwait(request : TxnRequest) : TxnResponse {
-  return awaitResult{
+suspend fun ConsulClient.transactionAwait(request: TxnRequest): TxnResponse {
+  return awaitResult {
     this.transaction(request, it)
   }
 }
 
 /**
- * Create new Acl token
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.createAclToken]
  *
  * @param token properties of the token
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.createAclTokenAwait(token : AclToken) : String {
-  return awaitResult{
+suspend fun ConsulClient.createAclTokenAwait(token: AclToken): String {
+  return awaitResult {
     this.createAclToken(token, it)
   }
 }
 
 /**
- * Update Acl token
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.updateAclToken]
  *
  * @param token properties of the token to be updated
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.updateAclTokenAwait(token : AclToken) : String {
-  return awaitResult{
+suspend fun ConsulClient.updateAclTokenAwait(token: AclToken): String {
+  return awaitResult {
     this.updateAclToken(token, it)
   }
 }
 
 /**
- * Clone Acl token
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.cloneAclToken]
  *
  * @param id the ID of token to be cloned
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.cloneAclTokenAwait(id : String) : String {
-  return awaitResult{
+suspend fun ConsulClient.cloneAclTokenAwait(id: String): String {
+  return awaitResult {
     this.cloneAclToken(id, it)
   }
 }
 
 /**
- * Get list of Acl token
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.listAclTokens]
  *
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ * @return [List<AclToken>]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.listAclTokensAwait() : List<AclToken> {
-  return awaitResult{
+suspend fun ConsulClient.listAclTokensAwait(): List<AclToken> {
+  return awaitResult {
     this.listAclTokens(it)
   }
 }
 
 /**
- * Get info of Acl token
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.infoAclToken]
  *
  * @param id the ID of token
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ * @return [AclToken]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.infoAclTokenAwait(id : String) : AclToken {
-  return awaitResult{
+suspend fun ConsulClient.infoAclTokenAwait(id: String): AclToken {
+  return awaitResult {
     this.infoAclToken(id, it)
   }
 }
 
 /**
- * Destroy Acl token
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.destroyAclToken]
  *
  * @param id the ID of token
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.destroyAclTokenAwait(id : String) : Unit {
-  return awaitResult{
-    this.destroyAclToken(id, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun ConsulClient.destroyAclTokenAwait(id: String): Unit {
+  return awaitResult {
+    this.destroyAclToken(id) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Fires a new user event
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.fireEvent]
  *
  * @param name name of event
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ * @return [Event]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.fireEventAwait(name : String) : Event {
-  return awaitResult{
+suspend fun ConsulClient.fireEventAwait(name: String): Event {
+  return awaitResult {
     this.fireEvent(name, it)
   }
 }
 
 /**
- * Fires a new user event
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.fireEventWithOptions]
  *
  * @param name name of event
  * @param options options used to create event
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ * @return [Event]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.fireEventWithOptionsAwait(name : String, options : EventOptions) : Event {
-  return awaitResult{
+suspend fun ConsulClient.fireEventWithOptionsAwait(name: String, options: EventOptions): Event {
+  return awaitResult {
     this.fireEventWithOptions(name, options, it)
   }
 }
 
 /**
- * Returns the most recent events known by the agent
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.listEvents]
  *
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ * @return [EventList]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.listEventsAwait() : EventList {
-  return awaitResult{
+suspend fun ConsulClient.listEventsAwait(): EventList {
+  return awaitResult {
     this.listEvents(it)
   }
 }
 
 /**
- * Returns the most recent events known by the agent.
- * This is blocking query unlike [io.vertx.ext.consul.ConsulClient]. However, the semantics of this endpoint
- * are slightly different. Most blocking queries provide a monotonic index and block until a newer index is available.
- * This can be supported as a consequence of the total ordering of the consensus protocol. With gossip,
- * there is no ordering, and instead <code>X-Consul-Index</code> maps to the newest event that matches the query.
- * <p>
- * In practice, this means the index is only useful when used against a single agent and has no meaning globally.
- * Because Consul defines the index as being opaque, clients should not be expecting a natural ordering either.
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.listEventsWithOptions]
  *
  * @param options the blocking options
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ * @return [EventList]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.listEventsWithOptionsAwait(options : EventListOptions) : EventList {
-  return awaitResult{
+suspend fun ConsulClient.listEventsWithOptionsAwait(options: EventListOptions): EventList {
+  return awaitResult {
     this.listEventsWithOptions(options, it)
   }
 }
 
 /**
- * Adds a new service, with an optional health check, to the local agent.
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.registerService]
  *
  * @param serviceOptions the options of new service
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.registerServiceAwait(serviceOptions : ServiceOptions) : Unit {
-  return awaitResult{
-    this.registerService(serviceOptions, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun ConsulClient.registerServiceAwait(serviceOptions: ServiceOptions): Unit {
+  return awaitResult {
+    this.registerService(serviceOptions) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Places a given service into "maintenance mode"
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.maintenanceService]
  *
  * @param maintenanceOptions the maintenance options
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.maintenanceServiceAwait(maintenanceOptions : MaintenanceOptions) : Unit {
-  return awaitResult{
-    this.maintenanceService(maintenanceOptions, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun ConsulClient.maintenanceServiceAwait(maintenanceOptions: MaintenanceOptions): Unit {
+  return awaitResult {
+    this.maintenanceService(maintenanceOptions) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Remove a service from the local agent. The agent will take care of deregistering the service with the Catalog.
- * If there is an associated check, that is also deregistered.
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.deregisterService]
  *
  * @param id the ID of service
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.deregisterServiceAwait(id : String) : Unit {
-  return awaitResult{
-    this.deregisterService(id, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun ConsulClient.deregisterServiceAwait(id: String): Unit {
+  return awaitResult {
+    this.deregisterService(id) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Returns the nodes providing a service
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.catalogServiceNodes]
  *
  * @param service name of service
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ * @return [ServiceList]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.catalogServiceNodesAwait(service : String) : ServiceList {
-  return awaitResult{
+suspend fun ConsulClient.catalogServiceNodesAwait(service: String): ServiceList {
+  return awaitResult {
     this.catalogServiceNodes(service, it)
   }
 }
 
 /**
- * Returns the nodes providing a service
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.catalogServiceNodesWithOptions]
  *
  * @param service name of service
  * @param options options used to request services
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ * @return [ServiceList]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.catalogServiceNodesWithOptionsAwait(service : String, options : ServiceQueryOptions) : ServiceList {
-  return awaitResult{
+suspend fun ConsulClient.catalogServiceNodesWithOptionsAwait(service: String, options: ServiceQueryOptions): ServiceList {
+  return awaitResult {
     this.catalogServiceNodesWithOptions(service, options, it)
   }
 }
 
 /**
- * Return all the datacenters that are known by the Consul server
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.catalogDatacenters]
  *
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ * @return [List<String>]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.catalogDatacentersAwait() : List<String> {
-  return awaitResult{
+suspend fun ConsulClient.catalogDatacentersAwait(): List<String> {
+  return awaitResult {
     this.catalogDatacenters(it)
   }
 }
 
 /**
- * Returns the nodes registered in a datacenter
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.catalogNodes]
  *
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ * @return [NodeList]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.catalogNodesAwait() : NodeList {
-  return awaitResult{
+suspend fun ConsulClient.catalogNodesAwait(): NodeList {
+  return awaitResult {
     this.catalogNodes(it)
   }
 }
 
 /**
- * Returns the nodes registered in a datacenter
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.catalogNodesWithOptions]
  *
  * @param options options used to request nodes
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ * @return [NodeList]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.catalogNodesWithOptionsAwait(options : NodeQueryOptions) : NodeList {
-  return awaitResult{
+suspend fun ConsulClient.catalogNodesWithOptionsAwait(options: NodeQueryOptions): NodeList {
+  return awaitResult {
     this.catalogNodesWithOptions(options, it)
   }
 }
 
 /**
- * Returns the checks associated with the service
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.healthChecks]
  *
  * @param service the service name
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ * @return [CheckList]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.healthChecksAwait(service : String) : CheckList {
-  return awaitResult{
+suspend fun ConsulClient.healthChecksAwait(service: String): CheckList {
+  return awaitResult {
     this.healthChecks(service, it)
   }
 }
 
 /**
- * Returns the checks associated with the service
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.healthChecksWithOptions]
  *
  * @param service the service name
  * @param options options used to request checks
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ * @return [CheckList]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.healthChecksWithOptionsAwait(service : String, options : CheckQueryOptions) : CheckList {
-  return awaitResult{
+suspend fun ConsulClient.healthChecksWithOptionsAwait(service: String, options: CheckQueryOptions): CheckList {
+  return awaitResult {
     this.healthChecksWithOptions(service, options, it)
   }
 }
 
 /**
- * Returns the checks in the specified status
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.healthState]
  *
  * @param healthState the health state
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ * @return [CheckList]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.healthStateAwait(healthState : HealthState) : CheckList {
-  return awaitResult{
+suspend fun ConsulClient.healthStateAwait(healthState: HealthState): CheckList {
+  return awaitResult {
     this.healthState(healthState, it)
   }
 }
 
 /**
- * Returns the checks in the specified status
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.healthStateWithOptions]
  *
  * @param healthState the health state
  * @param options options used to request checks
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ * @return [CheckList]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.healthStateWithOptionsAwait(healthState : HealthState, options : CheckQueryOptions) : CheckList {
-  return awaitResult{
+suspend fun ConsulClient.healthStateWithOptionsAwait(healthState: HealthState, options: CheckQueryOptions): CheckList {
+  return awaitResult {
     this.healthStateWithOptions(healthState, options, it)
   }
 }
 
 /**
- * Returns the nodes providing the service. This endpoint is very similar to the [io.vertx.ext.consul.ConsulClient] endpoint;
- * however, this endpoint automatically returns the status of the associated health check as well as any system level health checks.
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.healthServiceNodes]
  *
  * @param service the service name
  * @param passing if true, filter results to only nodes with all checks in the passing state
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ * @return [ServiceEntryList]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.healthServiceNodesAwait(service : String, passing : Boolean) : ServiceEntryList {
-  return awaitResult{
+suspend fun ConsulClient.healthServiceNodesAwait(service: String, passing: Boolean): ServiceEntryList {
+  return awaitResult {
     this.healthServiceNodes(service, passing, it)
   }
 }
 
 /**
- * Returns the nodes providing the service. This endpoint is very similar to the [io.vertx.ext.consul.ConsulClient] endpoint;
- * however, this endpoint automatically returns the status of the associated health check as well as any system level health checks.
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.healthServiceNodesWithOptions]
  *
  * @param service the service name
  * @param passing if true, filter results to only nodes with all checks in the passing state
  * @param options options used to request services
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ * @return [ServiceEntryList]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.healthServiceNodesWithOptionsAwait(service : String, passing : Boolean, options : ServiceQueryOptions) : ServiceEntryList {
-  return awaitResult{
+suspend fun ConsulClient.healthServiceNodesWithOptionsAwait(service: String, passing: Boolean, options: ServiceQueryOptions): ServiceEntryList {
+  return awaitResult {
     this.healthServiceNodesWithOptions(service, passing, options, it)
   }
 }
 
 /**
- * Returns the services registered in a datacenter
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.catalogServices]
  *
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ * @return [ServiceList]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.catalogServicesAwait() : ServiceList {
-  return awaitResult{
+suspend fun ConsulClient.catalogServicesAwait(): ServiceList {
+  return awaitResult {
     this.catalogServices(it)
   }
 }
 
 /**
- * Returns the services registered in a datacenter
- * This is blocking query unlike [io.vertx.ext.consul.ConsulClient]
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.catalogServicesWithOptions]
  *
  * @param options the blocking options
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ * @return [ServiceList]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.catalogServicesWithOptionsAwait(options : BlockingQueryOptions) : ServiceList {
-  return awaitResult{
+suspend fun ConsulClient.catalogServicesWithOptionsAwait(options: BlockingQueryOptions): ServiceList {
+  return awaitResult {
     this.catalogServicesWithOptions(options, it)
   }
 }
 
 /**
- * Returns the node's registered services
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.catalogNodeServices]
  *
  * @param node node name
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ * @return [ServiceList]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.catalogNodeServicesAwait(node : String) : ServiceList {
-  return awaitResult{
+suspend fun ConsulClient.catalogNodeServicesAwait(node: String): ServiceList {
+  return awaitResult {
     this.catalogNodeServices(node, it)
   }
 }
 
 /**
- * Returns the node's registered services
- * This is blocking query unlike [io.vertx.ext.consul.ConsulClient]
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.catalogNodeServicesWithOptions]
  *
  * @param node node name
  * @param options the blocking options
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ * @return [ServiceList]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.catalogNodeServicesWithOptionsAwait(node : String, options : BlockingQueryOptions) : ServiceList {
-  return awaitResult{
+suspend fun ConsulClient.catalogNodeServicesWithOptionsAwait(node: String, options: BlockingQueryOptions): ServiceList {
+  return awaitResult {
     this.catalogNodeServicesWithOptions(node, options, it)
   }
 }
 
 /**
- * Returns list of services registered with the local agent.
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.localServices]
  *
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ * @return [List<Service>]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.localServicesAwait() : List<Service> {
-  return awaitResult{
+suspend fun ConsulClient.localServicesAwait(): List<Service> {
+  return awaitResult {
     this.localServices(it)
   }
 }
 
 /**
- * Return all the checks that are registered with the local agent.
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.localChecks]
  *
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ * @return [List<Check>]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.localChecksAwait() : List<Check> {
-  return awaitResult{
+suspend fun ConsulClient.localChecksAwait(): List<Check> {
+  return awaitResult {
     this.localChecks(it)
   }
 }
 
 /**
- * Add a new check to the local agent. The agent is responsible for managing the status of the check
- * and keeping the Catalog in sync.
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.registerCheck]
  *
  * @param checkOptions options used to register new check
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.registerCheckAwait(checkOptions : CheckOptions) : Unit {
-  return awaitResult{
-    this.registerCheck(checkOptions, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun ConsulClient.registerCheckAwait(checkOptions: CheckOptions): Unit {
+  return awaitResult {
+    this.registerCheck(checkOptions) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Remove a check from the local agent. The agent will take care of deregistering the check from the Catalog.
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.deregisterCheck]
  *
  * @param checkId the ID of check
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.deregisterCheckAwait(checkId : String) : Unit {
-  return awaitResult{
-    this.deregisterCheck(checkId, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun ConsulClient.deregisterCheckAwait(checkId: String): Unit {
+  return awaitResult {
+    this.deregisterCheck(checkId) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Set status of the check to "passing". Used with a check that is of the TTL type. The TTL clock will be reset.
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.passCheck]
  *
  * @param checkId the ID of check
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
- */
-suspend fun ConsulClient.passCheckAwait(checkId : String) : Unit {
-  return awaitResult{
-    this.passCheck(checkId, { ar -> it.handle(ar.mapEmpty()) })}
-}
-
-/**
- * Set status of the check to "passing". Used with a check that is of the TTL type. The TTL clock will be reset.
  *
- * @param checkId the ID of check
- * @param note specifies a human-readable message. This will be passed through to the check's <code>Output</code> field.
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.passCheckWithNoteAwait(checkId : String, note : String) : Unit {
-  return awaitResult{
-    this.passCheckWithNote(checkId, note, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun ConsulClient.passCheckAwait(checkId: String): Unit {
+  return awaitResult {
+    this.passCheck(checkId) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Set status of the check to "warning". Used with a check that is of the TTL type. The TTL clock will be reset.
- *
- * @param checkId the ID of check
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
- */
-suspend fun ConsulClient.warnCheckAwait(checkId : String) : Unit {
-  return awaitResult{
-    this.warnCheck(checkId, { ar -> it.handle(ar.mapEmpty()) })}
-}
-
-/**
- * Set status of the check to "warning". Used with a check that is of the TTL type. The TTL clock will be reset.
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.passCheckWithNote]
  *
  * @param checkId the ID of check
  * @param note specifies a human-readable message. This will be passed through to the check's <code>Output</code> field.
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.warnCheckWithNoteAwait(checkId : String, note : String) : Unit {
-  return awaitResult{
-    this.warnCheckWithNote(checkId, note, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun ConsulClient.passCheckWithNoteAwait(checkId: String, note: String): Unit {
+  return awaitResult {
+    this.passCheckWithNote(checkId, note) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Set status of the check to "critical". Used with a check that is of the TTL type. The TTL clock will be reset.
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.warnCheck]
  *
  * @param checkId the ID of check
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.failCheckAwait(checkId : String) : Unit {
-  return awaitResult{
-    this.failCheck(checkId, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun ConsulClient.warnCheckAwait(checkId: String): Unit {
+  return awaitResult {
+    this.warnCheck(checkId) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Set status of the check to "critical". Used with a check that is of the TTL type. The TTL clock will be reset.
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.warnCheckWithNote]
  *
  * @param checkId the ID of check
  * @param note specifies a human-readable message. This will be passed through to the check's <code>Output</code> field.
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.failCheckWithNoteAwait(checkId : String, note : String) : Unit {
-  return awaitResult{
-    this.failCheckWithNote(checkId, note, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun ConsulClient.warnCheckWithNoteAwait(checkId: String, note: String): Unit {
+  return awaitResult {
+    this.warnCheckWithNote(checkId, note) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Set status of the check to given status. Used with a check that is of the TTL type. The TTL clock will be reset.
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.failCheck]
+ *
+ * @param checkId the ID of check
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
+ */
+suspend fun ConsulClient.failCheckAwait(checkId: String): Unit {
+  return awaitResult {
+    this.failCheck(checkId) { ar -> it.handle(ar.mapEmpty()) }
+  }
+}
+
+/**
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.failCheckWithNote]
+ *
+ * @param checkId the ID of check
+ * @param note specifies a human-readable message. This will be passed through to the check's <code>Output</code> field.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
+ */
+suspend fun ConsulClient.failCheckWithNoteAwait(checkId: String, note: String): Unit {
+  return awaitResult {
+    this.failCheckWithNote(checkId, note) { ar -> it.handle(ar.mapEmpty()) }
+  }
+}
+
+/**
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.updateCheck]
  *
  * @param checkId the ID of check
  * @param status new status of check
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.updateCheckAwait(checkId : String, status : CheckStatus) : Unit {
-  return awaitResult{
-    this.updateCheck(checkId, status, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun ConsulClient.updateCheckAwait(checkId: String, status: CheckStatus): Unit {
+  return awaitResult {
+    this.updateCheck(checkId, status) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Set status of the check to given status. Used with a check that is of the TTL type. The TTL clock will be reset.
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.updateCheckWithNote]
  *
  * @param checkId the ID of check
  * @param status new status of check
  * @param note specifies a human-readable message. This will be passed through to the check's <code>Output</code> field.
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.updateCheckWithNoteAwait(checkId : String, status : CheckStatus, note : String) : Unit {
-  return awaitResult{
-    this.updateCheckWithNote(checkId, status, note, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun ConsulClient.updateCheckWithNoteAwait(checkId: String, status: CheckStatus, note: String): Unit {
+  return awaitResult {
+    this.updateCheckWithNote(checkId, status, note) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Get the Raft leader for the datacenter in which the agent is running.
- * It returns an address in format "<code>10.1.10.12:8300</code>"
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.leaderStatus]
  *
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.leaderStatusAwait() : String {
-  return awaitResult{
+suspend fun ConsulClient.leaderStatusAwait(): String {
+  return awaitResult {
     this.leaderStatus(it)
   }
 }
 
 /**
- * Retrieves the Raft peers for the datacenter in which the the agent is running.
- * It returns a list of addresses "<code>10.1.10.12:8300</code>", "<code>10.1.10.13:8300</code>"
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.peersStatus]
  *
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ * @return [List<String>]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.peersStatusAwait() : List<String> {
-  return awaitResult{
+suspend fun ConsulClient.peersStatusAwait(): List<String> {
+  return awaitResult {
     this.peersStatus(it)
   }
 }
 
 /**
- * Initialize a new session
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.createSession]
  *
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.createSessionAwait() : String {
-  return awaitResult{
+suspend fun ConsulClient.createSessionAwait(): String {
+  return awaitResult {
     this.createSession(it)
   }
 }
 
 /**
- * Initialize a new session
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.createSessionWithOptions]
  *
  * @param options options used to create session
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.createSessionWithOptionsAwait(options : SessionOptions) : String {
-  return awaitResult{
+suspend fun ConsulClient.createSessionWithOptionsAwait(options: SessionOptions): String {
+  return awaitResult {
     this.createSessionWithOptions(options, it)
   }
 }
 
 /**
- * Returns the requested session information
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.infoSession]
  *
  * @param id the ID of requested session
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ * @return [Session]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.infoSessionAwait(id : String) : Session {
-  return awaitResult{
+suspend fun ConsulClient.infoSessionAwait(id: String): Session {
+  return awaitResult {
     this.infoSession(id, it)
   }
 }
 
 /**
- * Returns the requested session information
- * This is blocking query unlike [io.vertx.ext.consul.ConsulClient]
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.infoSessionWithOptions]
  *
  * @param id the ID of requested session
  * @param options the blocking options
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ * @return [Session]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.infoSessionWithOptionsAwait(id : String, options : BlockingQueryOptions) : Session {
-  return awaitResult{
+suspend fun ConsulClient.infoSessionWithOptionsAwait(id: String, options: BlockingQueryOptions): Session {
+  return awaitResult {
     this.infoSessionWithOptions(id, options, it)
   }
 }
 
 /**
- * Renews the given session. This is used with sessions that have a TTL, and it extends the expiration by the TTL
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.renewSession]
  *
  * @param id the ID of session that should be renewed
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ * @return [Session]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.renewSessionAwait(id : String) : Session {
-  return awaitResult{
+suspend fun ConsulClient.renewSessionAwait(id: String): Session {
+  return awaitResult {
     this.renewSession(id, it)
   }
 }
 
 /**
- * Returns the active sessions
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.listSessions]
  *
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ * @return [SessionList]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.listSessionsAwait() : SessionList {
-  return awaitResult{
+suspend fun ConsulClient.listSessionsAwait(): SessionList {
+  return awaitResult {
     this.listSessions(it)
   }
 }
 
 /**
- * Returns the active sessions
- * This is blocking query unlike [io.vertx.ext.consul.ConsulClient]
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.listSessionsWithOptions]
  *
  * @param options the blocking options
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ * @return [SessionList]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.listSessionsWithOptionsAwait(options : BlockingQueryOptions) : SessionList {
-  return awaitResult{
+suspend fun ConsulClient.listSessionsWithOptionsAwait(options: BlockingQueryOptions): SessionList {
+  return awaitResult {
     this.listSessionsWithOptions(options, it)
   }
 }
 
 /**
- * Returns the active sessions for a given node
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.listNodeSessions]
  *
  * @param nodeId the ID of node
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ * @return [SessionList]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.listNodeSessionsAwait(nodeId : String) : SessionList {
-  return awaitResult{
+suspend fun ConsulClient.listNodeSessionsAwait(nodeId: String): SessionList {
+  return awaitResult {
     this.listNodeSessions(nodeId, it)
   }
 }
 
 /**
- * Returns the active sessions for a given node
- * This is blocking query unlike [io.vertx.ext.consul.ConsulClient]
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.listNodeSessionsWithOptions]
  *
  * @param nodeId the ID of node
  * @param options the blocking options
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ * @return [SessionList]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.listNodeSessionsWithOptionsAwait(nodeId : String, options : BlockingQueryOptions) : SessionList {
-  return awaitResult{
+suspend fun ConsulClient.listNodeSessionsWithOptionsAwait(nodeId: String, options: BlockingQueryOptions): SessionList {
+  return awaitResult {
     this.listNodeSessionsWithOptions(nodeId, options, it)
   }
 }
 
 /**
- * Destroys the given session
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.destroySession]
  *
  * @param id the ID of session
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.destroySessionAwait(id : String) : Unit {
-  return awaitResult{
-    this.destroySession(id, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun ConsulClient.destroySessionAwait(id: String): Unit {
+  return awaitResult {
+    this.destroySession(id) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.createPreparedQuery]
  *
  * @param definition definition of the prepare query
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.createPreparedQueryAwait(definition : PreparedQueryDefinition) : String {
-  return awaitResult{
+suspend fun ConsulClient.createPreparedQueryAwait(definition: PreparedQueryDefinition): String {
+  return awaitResult {
     this.createPreparedQuery(definition, it)
   }
 }
 
 /**
- * Returns an existing prepared query
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.getPreparedQuery]
  *
  * @param id the id of the query to read
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ * @return [PreparedQueryDefinition]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.getPreparedQueryAwait(id : String) : PreparedQueryDefinition {
-  return awaitResult{
+suspend fun ConsulClient.getPreparedQueryAwait(id: String): PreparedQueryDefinition {
+  return awaitResult {
     this.getPreparedQuery(id, it)
   }
 }
 
 /**
- * Returns a list of all prepared queries.
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.getAllPreparedQueries]
  *
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ * @return [List<PreparedQueryDefinition>]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.getAllPreparedQueriesAwait() : List<PreparedQueryDefinition> {
-  return awaitResult{
+suspend fun ConsulClient.getAllPreparedQueriesAwait(): List<PreparedQueryDefinition> {
+  return awaitResult {
     this.getAllPreparedQueries(it)
   }
 }
 
 /**
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.updatePreparedQuery]
  *
  * @param definition definition of the prepare query
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.updatePreparedQueryAwait(definition : PreparedQueryDefinition) : Unit {
-  return awaitResult{
-    this.updatePreparedQuery(definition, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun ConsulClient.updatePreparedQueryAwait(definition: PreparedQueryDefinition): Unit {
+  return awaitResult {
+    this.updatePreparedQuery(definition) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Deletes an existing prepared query
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.deletePreparedQuery]
  *
  * @param id the id of the query to delete
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.deletePreparedQueryAwait(id : String) : Unit {
-  return awaitResult{
-    this.deletePreparedQuery(id, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun ConsulClient.deletePreparedQueryAwait(id: String): Unit {
+  return awaitResult {
+    this.deletePreparedQuery(id) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Executes an existing prepared query.
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.executePreparedQuery]
  *
  * @param query the ID of the query to execute. This can also be the name of an existing prepared query, or a name that matches a prefix name for a prepared query template.
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ * @return [PreparedQueryExecuteResponse]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.executePreparedQueryAwait(query : String) : PreparedQueryExecuteResponse {
-  return awaitResult{
+suspend fun ConsulClient.executePreparedQueryAwait(query: String): PreparedQueryExecuteResponse {
+  return awaitResult {
     this.executePreparedQuery(query, it)
   }
 }
 
 /**
- * Executes an existing prepared query.
+ * Suspending version of method [io.vertx.ext.consul.ConsulClient.executePreparedQueryWithOptions]
  *
  * @param query the ID of the query to execute. This can also be the name of an existing prepared query, or a name that matches a prefix name for a prepared query template.
  * @param options the options used to execute prepared query
- * @return reference to this, for fluency *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.ConsulClient original] using Vert.x codegen.
+ * @return [PreparedQueryExecuteResponse]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-suspend fun ConsulClient.executePreparedQueryWithOptionsAwait(query : String, options : PreparedQueryExecuteOptions) : PreparedQueryExecuteResponse {
-  return awaitResult{
+suspend fun ConsulClient.executePreparedQueryWithOptionsAwait(query: String, options: PreparedQueryExecuteOptions): PreparedQueryExecuteResponse {
+  return awaitResult {
     this.executePreparedQueryWithOptions(query, options, it)
   }
 }

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/eventbus/bridge/tcp/BridgeEvent.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/eventbus/bridge/tcp/BridgeEvent.kt
@@ -4,17 +4,14 @@ import io.vertx.ext.eventbus.bridge.tcp.BridgeEvent
 import io.vertx.kotlin.coroutines.awaitResult
 
 /**
- * Set a handler for the result.
- * <p>
- * If the future has already been completed it will be called immediately. Otherwise it will be called when the
- * future is completed.
+ * Suspending version of method [io.vertx.ext.eventbus.bridge.tcp.BridgeEvent.setHandler]
  *
- * @return a reference to this, so it can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.eventbus.bridge.tcp.BridgeEvent original] using Vert.x codegen.
+ * @return [Boolean]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.eventbus.bridge.tcp.BridgeEvent] using Vert.x codegen.
  */
-suspend fun BridgeEvent.setHandlerAwait() : Boolean {
-  return awaitResult{
+suspend fun BridgeEvent.setHandlerAwait(): Boolean {
+  return awaitResult {
     this.setHandler(it)
   }
 }

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/eventbus/bridge/tcp/TcpEventBusBridge.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/eventbus/bridge/tcp/TcpEventBusBridge.kt
@@ -4,56 +4,56 @@ import io.vertx.ext.eventbus.bridge.tcp.TcpEventBusBridge
 import io.vertx.kotlin.coroutines.awaitResult
 
 /**
- * Listen on default port 7000 with a handler to report the state of the socket listen operation.
+ * Suspending version of method [io.vertx.ext.eventbus.bridge.tcp.TcpEventBusBridge.listen]
  *
- * @return self *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.eventbus.bridge.tcp.TcpEventBusBridge original] using Vert.x codegen.
+ * @return [TcpEventBusBridge]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.eventbus.bridge.tcp.TcpEventBusBridge] using Vert.x codegen.
  */
-suspend fun TcpEventBusBridge.listenAwait() : TcpEventBusBridge {
-  return awaitResult{
+suspend fun TcpEventBusBridge.listenAwait(): TcpEventBusBridge {
+  return awaitResult {
     this.listen(it)
   }
 }
 
 /**
- * Listen on specific port and bind to specific address
+ * Suspending version of method [io.vertx.ext.eventbus.bridge.tcp.TcpEventBusBridge.listen]
  *
  * @param port tcp port
  * @param address tcp address to the bind
- * @return self *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.eventbus.bridge.tcp.TcpEventBusBridge original] using Vert.x codegen.
+ * @return [TcpEventBusBridge]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.eventbus.bridge.tcp.TcpEventBusBridge] using Vert.x codegen.
  */
-suspend fun TcpEventBusBridge.listenAwait(port : Int, address : String) : TcpEventBusBridge {
-  return awaitResult{
+suspend fun TcpEventBusBridge.listenAwait(port: Int, address: String): TcpEventBusBridge {
+  return awaitResult {
     this.listen(port, address, it)
   }
 }
 
 /**
- * Listen on specific port
+ * Suspending version of method [io.vertx.ext.eventbus.bridge.tcp.TcpEventBusBridge.listen]
  *
  * @param port tcp port
- * @return self *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.eventbus.bridge.tcp.TcpEventBusBridge original] using Vert.x codegen.
+ * @return [TcpEventBusBridge]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.eventbus.bridge.tcp.TcpEventBusBridge] using Vert.x codegen.
  */
-suspend fun TcpEventBusBridge.listenAwait(port : Int) : TcpEventBusBridge {
-  return awaitResult{
+suspend fun TcpEventBusBridge.listenAwait(port: Int): TcpEventBusBridge {
+  return awaitResult {
     this.listen(port, it)
   }
 }
 
 /**
- * Close the current socket.
+ * Suspending version of method [io.vertx.ext.eventbus.bridge.tcp.TcpEventBusBridge.close]
  *
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.eventbus.bridge.tcp.TcpEventBusBridge original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.ext.eventbus.bridge.tcp.TcpEventBusBridge] using Vert.x codegen.
  */
-suspend fun TcpEventBusBridge.closeAwait() : Unit {
-  return awaitResult{
-    this.close({ ar -> it.handle(ar.mapEmpty()) })}
+suspend fun TcpEventBusBridge.closeAwait(): Unit {
+  return awaitResult {
+    this.close { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/healthchecks/HealthChecks.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/healthchecks/HealthChecks.kt
@@ -5,16 +5,15 @@ import io.vertx.ext.healthchecks.HealthChecks
 import io.vertx.kotlin.coroutines.awaitResult
 
 /**
- * Invokes the registered procedure with the given name and sub-procedures. It computes the overall
- * outcome.
+ * Suspending version of method [io.vertx.ext.healthchecks.HealthChecks.invoke]
  *
  * @param name 
- * @return the current [io.vertx.ext.healthchecks.HealthChecks] *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.healthchecks.HealthChecks original] using Vert.x codegen.
+ * @return [JsonObject]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.healthchecks.HealthChecks] using Vert.x codegen.
  */
-suspend fun HealthChecks.invokeAwait(name : String) : JsonObject {
-  return awaitResult{
+suspend fun HealthChecks.invokeAwait(name: String): JsonObject {
+  return awaitResult {
     this.invoke(name, it)
   }
 }

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/jdbc/JDBCClient.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/jdbc/JDBCClient.kt
@@ -5,34 +5,30 @@ import io.vertx.ext.jdbc.JDBCClient
 import io.vertx.kotlin.coroutines.awaitResult
 
 /**
- * Execute a one shot SQL statement that returns a single SQL row. This method will reduce the boilerplate code by
- * getting a connection from the pool (this object) and return it back after the execution. Only the first result
- * from the result set is returned.
+ * Suspending version of method [io.vertx.ext.jdbc.JDBCClient.querySingle]
  *
  * @param sql the statement to execute
- * @return self *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.jdbc.JDBCClient original] using Vert.x codegen.
+ * @return [JsonArray?]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.jdbc.JDBCClient] using Vert.x codegen.
  */
-suspend fun JDBCClient.querySingleAwait(sql : String) : JsonArray? {
-  return awaitResult{
+suspend fun JDBCClient.querySingleAwait(sql: String): JsonArray? {
+  return awaitResult {
     this.querySingle(sql, it)
   }
 }
 
 /**
- * Execute a one shot SQL statement with arguments that returns a single SQL row. This method will reduce the
- * boilerplate code by getting a connection from the pool (this object) and return it back after the execution.
- * Only the first result from the result set is returned.
+ * Suspending version of method [io.vertx.ext.jdbc.JDBCClient.querySingleWithParams]
  *
  * @param sql the statement to execute
  * @param arguments the arguments
- * @return self *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.jdbc.JDBCClient original] using Vert.x codegen.
+ * @return [JsonArray?]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.jdbc.JDBCClient] using Vert.x codegen.
  */
-suspend fun JDBCClient.querySingleWithParamsAwait(sql : String, arguments : JsonArray) : JsonArray? {
-  return awaitResult{
+suspend fun JDBCClient.querySingleWithParamsAwait(sql: String, arguments: JsonArray): JsonArray? {
+  return awaitResult {
     this.querySingleWithParams(sql, arguments, it)
   }
 }

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/mail/MailClient.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/mail/MailClient.kt
@@ -6,15 +6,15 @@ import io.vertx.ext.mail.MailResult
 import io.vertx.kotlin.coroutines.awaitResult
 
 /**
- * send a single mail via MailClient
+ * Suspending version of method [io.vertx.ext.mail.MailClient.sendMail]
  *
  * @param email MailMessage object containing the mail text, from/to, attachments etc
- * @return this MailClient instance so the method can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.mail.MailClient original] using Vert.x codegen.
+ * @return [MailResult]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.mail.MailClient] using Vert.x codegen.
  */
-suspend fun MailClient.sendMailAwait(email : MailMessage) : MailResult {
-  return awaitResult{
+suspend fun MailClient.sendMailAwait(email: MailMessage): MailResult {
+  return awaitResult {
     this.sendMail(email, it)
   }
 }

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/mongo/MongoClient.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/mongo/MongoClient.kt
@@ -15,552 +15,527 @@ import io.vertx.ext.mongo.WriteOption
 import io.vertx.kotlin.coroutines.awaitResult
 
 /**
- * Save a document in the specified collection
- * <p>
- * This operation might change <i>_id</i> field of <i>document</i> parameter
+ * Suspending version of method [io.vertx.ext.mongo.MongoClient.save]
  *
  * @param collection the collection
  * @param document the document
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.mongo.MongoClient original] using Vert.x codegen.
+ * @return [String?]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-suspend fun MongoClient.saveAwait(collection : String, document : JsonObject) : String? {
-  return awaitResult{
+suspend fun MongoClient.saveAwait(collection: String, document: JsonObject): String? {
+  return awaitResult {
     this.save(collection, document, it)
   }
 }
 
 /**
- * Save a document in the specified collection with the specified write option
- * <p>
- * This operation might change <i>_id</i> field of <i>document</i> parameter
+ * Suspending version of method [io.vertx.ext.mongo.MongoClient.saveWithOptions]
  *
  * @param collection the collection
  * @param document the document
  * @param writeOption the write option to use
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.mongo.MongoClient original] using Vert.x codegen.
+ * @return [String?]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-suspend fun MongoClient.saveWithOptionsAwait(collection : String, document : JsonObject, writeOption : WriteOption) : String? {
-  return awaitResult{
+suspend fun MongoClient.saveWithOptionsAwait(collection: String, document: JsonObject, writeOption: WriteOption): String? {
+  return awaitResult {
     this.saveWithOptions(collection, document, writeOption, it)
   }
 }
 
 /**
- * Insert a document in the specified collection
- * <p>
- * This operation might change <i>_id</i> field of <i>document</i> parameter
+ * Suspending version of method [io.vertx.ext.mongo.MongoClient.insert]
  *
  * @param collection the collection
  * @param document the document
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.mongo.MongoClient original] using Vert.x codegen.
+ * @return [String?]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-suspend fun MongoClient.insertAwait(collection : String, document : JsonObject) : String? {
-  return awaitResult{
+suspend fun MongoClient.insertAwait(collection: String, document: JsonObject): String? {
+  return awaitResult {
     this.insert(collection, document, it)
   }
 }
 
 /**
- * Insert a document in the specified collection with the specified write option
- * <p>
- * This operation might change <i>_id</i> field of <i>document</i> parameter
+ * Suspending version of method [io.vertx.ext.mongo.MongoClient.insertWithOptions]
  *
  * @param collection the collection
  * @param document the document
  * @param writeOption the write option to use
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.mongo.MongoClient original] using Vert.x codegen.
+ * @return [String?]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-suspend fun MongoClient.insertWithOptionsAwait(collection : String, document : JsonObject, writeOption : WriteOption) : String? {
-  return awaitResult{
+suspend fun MongoClient.insertWithOptionsAwait(collection: String, document: JsonObject, writeOption: WriteOption): String? {
+  return awaitResult {
     this.insertWithOptions(collection, document, writeOption, it)
   }
 }
 
 /**
- * Update matching documents in the specified collection and return the handler with MongoClientUpdateResult result
+ * Suspending version of method [io.vertx.ext.mongo.MongoClient.updateCollection]
  *
  * @param collection the collection
  * @param query query used to match the documents
  * @param update used to describe how the documents will be updated
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.mongo.MongoClient original] using Vert.x codegen.
+ * @return [MongoClientUpdateResult]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-suspend fun MongoClient.updateCollectionAwait(collection : String, query : JsonObject, update : JsonObject) : MongoClientUpdateResult {
-  return awaitResult{
+suspend fun MongoClient.updateCollectionAwait(collection: String, query: JsonObject, update: JsonObject): MongoClientUpdateResult {
+  return awaitResult {
     this.updateCollection(collection, query, update, it)
   }
 }
 
 /**
- * Update matching documents in the specified collection, specifying options and return the handler with MongoClientUpdateResult result
+ * Suspending version of method [io.vertx.ext.mongo.MongoClient.updateCollectionWithOptions]
  *
  * @param collection the collection
  * @param query query used to match the documents
  * @param update used to describe how the documents will be updated
  * @param options options to configure the update
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.mongo.MongoClient original] using Vert.x codegen.
+ * @return [MongoClientUpdateResult]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-suspend fun MongoClient.updateCollectionWithOptionsAwait(collection : String, query : JsonObject, update : JsonObject, options : UpdateOptions) : MongoClientUpdateResult {
-  return awaitResult{
+suspend fun MongoClient.updateCollectionWithOptionsAwait(collection: String, query: JsonObject, update: JsonObject, options: UpdateOptions): MongoClientUpdateResult {
+  return awaitResult {
     this.updateCollectionWithOptions(collection, query, update, options, it)
   }
 }
 
 /**
- * Replace matching documents in the specified collection and return the handler with MongoClientUpdateResult result
+ * Suspending version of method [io.vertx.ext.mongo.MongoClient.replaceDocuments]
  *
  * @param collection the collection
  * @param query query used to match the documents
  * @param replace all matching documents will be replaced with this
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.mongo.MongoClient original] using Vert.x codegen.
+ * @return [MongoClientUpdateResult]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-suspend fun MongoClient.replaceDocumentsAwait(collection : String, query : JsonObject, replace : JsonObject) : MongoClientUpdateResult {
-  return awaitResult{
+suspend fun MongoClient.replaceDocumentsAwait(collection: String, query: JsonObject, replace: JsonObject): MongoClientUpdateResult {
+  return awaitResult {
     this.replaceDocuments(collection, query, replace, it)
   }
 }
 
 /**
- * Replace matching documents in the specified collection, specifying options and return the handler with MongoClientUpdateResult result
+ * Suspending version of method [io.vertx.ext.mongo.MongoClient.replaceDocumentsWithOptions]
  *
  * @param collection the collection
  * @param query query used to match the documents
  * @param replace all matching documents will be replaced with this
  * @param options options to configure the replace
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.mongo.MongoClient original] using Vert.x codegen.
+ * @return [MongoClientUpdateResult]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-suspend fun MongoClient.replaceDocumentsWithOptionsAwait(collection : String, query : JsonObject, replace : JsonObject, options : UpdateOptions) : MongoClientUpdateResult {
-  return awaitResult{
+suspend fun MongoClient.replaceDocumentsWithOptionsAwait(collection: String, query: JsonObject, replace: JsonObject, options: UpdateOptions): MongoClientUpdateResult {
+  return awaitResult {
     this.replaceDocumentsWithOptions(collection, query, replace, options, it)
   }
 }
 
 /**
- * Execute a bulk operation. Can insert, update, replace, and/or delete multiple documents with one request.
+ * Suspending version of method [io.vertx.ext.mongo.MongoClient.bulkWrite]
  *
  * @param collection the collection
  * @param operations the operations to execute
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.mongo.MongoClient original] using Vert.x codegen.
+ * @return [MongoClientBulkWriteResult]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-suspend fun MongoClient.bulkWriteAwait(collection : String, operations : List<BulkOperation>) : MongoClientBulkWriteResult {
-  return awaitResult{
+suspend fun MongoClient.bulkWriteAwait(collection: String, operations: List<BulkOperation>): MongoClientBulkWriteResult {
+  return awaitResult {
     this.bulkWrite(collection, operations, it)
   }
 }
 
 /**
- * Execute a bulk operation with the specified write options. Can insert, update, replace, and/or delete multiple
- * documents with one request.
+ * Suspending version of method [io.vertx.ext.mongo.MongoClient.bulkWriteWithOptions]
  *
  * @param collection the collection
  * @param operations the operations to execute
  * @param bulkWriteOptions the write options
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.mongo.MongoClient original] using Vert.x codegen.
+ * @return [MongoClientBulkWriteResult]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-suspend fun MongoClient.bulkWriteWithOptionsAwait(collection : String, operations : List<BulkOperation>, bulkWriteOptions : BulkWriteOptions) : MongoClientBulkWriteResult {
-  return awaitResult{
+suspend fun MongoClient.bulkWriteWithOptionsAwait(collection: String, operations: List<BulkOperation>, bulkWriteOptions: BulkWriteOptions): MongoClientBulkWriteResult {
+  return awaitResult {
     this.bulkWriteWithOptions(collection, operations, bulkWriteOptions, it)
   }
 }
 
 /**
- * Find matching documents in the specified collection
+ * Suspending version of method [io.vertx.ext.mongo.MongoClient.find]
  *
  * @param collection the collection
  * @param query query used to match documents
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.mongo.MongoClient original] using Vert.x codegen.
+ * @return [List<JsonObject>]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-suspend fun MongoClient.findAwait(collection : String, query : JsonObject) : List<JsonObject> {
-  return awaitResult{
+suspend fun MongoClient.findAwait(collection: String, query: JsonObject): List<JsonObject> {
+  return awaitResult {
     this.find(collection, query, it)
   }
 }
 
 /**
- * Find matching documents in the specified collection, specifying options
+ * Suspending version of method [io.vertx.ext.mongo.MongoClient.findWithOptions]
  *
  * @param collection the collection
  * @param query query used to match documents
  * @param options options to configure the find
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.mongo.MongoClient original] using Vert.x codegen.
+ * @return [List<JsonObject>]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-suspend fun MongoClient.findWithOptionsAwait(collection : String, query : JsonObject, options : FindOptions) : List<JsonObject> {
-  return awaitResult{
+suspend fun MongoClient.findWithOptionsAwait(collection: String, query: JsonObject, options: FindOptions): List<JsonObject> {
+  return awaitResult {
     this.findWithOptions(collection, query, options, it)
   }
 }
 
 /**
- * Find a single matching document in the specified collection
- * <p>
- * This operation might change <i>_id</i> field of <i>query</i> parameter
+ * Suspending version of method [io.vertx.ext.mongo.MongoClient.findOne]
  *
  * @param collection the collection
  * @param query the query used to match the document
  * @param fields the fields
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.mongo.MongoClient original] using Vert.x codegen.
+ * @return [JsonObject?]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-suspend fun MongoClient.findOneAwait(collection : String, query : JsonObject, fields : JsonObject) : JsonObject? {
-  return awaitResult{
+suspend fun MongoClient.findOneAwait(collection: String, query: JsonObject, fields: JsonObject): JsonObject? {
+  return awaitResult {
     this.findOne(collection, query, fields, it)
   }
 }
 
 /**
- * Find a single matching document in the specified collection and update it.
- * <p>
- * This operation might change <i>_id</i> field of <i>query</i> parameter
+ * Suspending version of method [io.vertx.ext.mongo.MongoClient.findOneAndUpdate]
  *
  * @param collection the collection
  * @param query the query used to match the document
  * @param update used to describe how the documents will be updated
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.mongo.MongoClient original] using Vert.x codegen.
+ * @return [JsonObject?]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-suspend fun MongoClient.findOneAndUpdateAwait(collection : String, query : JsonObject, update : JsonObject) : JsonObject? {
-  return awaitResult{
+suspend fun MongoClient.findOneAndUpdateAwait(collection: String, query: JsonObject, update: JsonObject): JsonObject? {
+  return awaitResult {
     this.findOneAndUpdate(collection, query, update, it)
   }
 }
 
 /**
- * Find a single matching document in the specified collection and update it.
- * <p>
- * This operation might change <i>_id</i> field of <i>query</i> parameter
+ * Suspending version of method [io.vertx.ext.mongo.MongoClient.findOneAndUpdateWithOptions]
  *
  * @param collection the collection
  * @param query the query used to match the document
  * @param update used to describe how the documents will be updated
  * @param findOptions options to configure the find
  * @param updateOptions options to configure the update
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.mongo.MongoClient original] using Vert.x codegen.
+ * @return [JsonObject?]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-suspend fun MongoClient.findOneAndUpdateWithOptionsAwait(collection : String, query : JsonObject, update : JsonObject, findOptions : FindOptions, updateOptions : UpdateOptions) : JsonObject? {
-  return awaitResult{
+suspend fun MongoClient.findOneAndUpdateWithOptionsAwait(collection: String, query: JsonObject, update: JsonObject, findOptions: FindOptions, updateOptions: UpdateOptions): JsonObject? {
+  return awaitResult {
     this.findOneAndUpdateWithOptions(collection, query, update, findOptions, updateOptions, it)
   }
 }
 
 /**
- * Find a single matching document in the specified collection and replace it.
- * <p>
- * This operation might change <i>_id</i> field of <i>query</i> parameter
+ * Suspending version of method [io.vertx.ext.mongo.MongoClient.findOneAndReplace]
  *
  * @param collection the collection
  * @param query the query used to match the document
  * @param replace the replacement document
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.mongo.MongoClient original] using Vert.x codegen.
+ * @return [JsonObject?]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-suspend fun MongoClient.findOneAndReplaceAwait(collection : String, query : JsonObject, replace : JsonObject) : JsonObject? {
-  return awaitResult{
+suspend fun MongoClient.findOneAndReplaceAwait(collection: String, query: JsonObject, replace: JsonObject): JsonObject? {
+  return awaitResult {
     this.findOneAndReplace(collection, query, replace, it)
   }
 }
 
 /**
- * Find a single matching document in the specified collection and replace it.
- * <p>
- * This operation might change <i>_id</i> field of <i>query</i> parameter
+ * Suspending version of method [io.vertx.ext.mongo.MongoClient.findOneAndReplaceWithOptions]
  *
  * @param collection the collection
  * @param query the query used to match the document
  * @param replace the replacement document
  * @param findOptions options to configure the find
  * @param updateOptions options to configure the update
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.mongo.MongoClient original] using Vert.x codegen.
+ * @return [JsonObject?]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-suspend fun MongoClient.findOneAndReplaceWithOptionsAwait(collection : String, query : JsonObject, replace : JsonObject, findOptions : FindOptions, updateOptions : UpdateOptions) : JsonObject? {
-  return awaitResult{
+suspend fun MongoClient.findOneAndReplaceWithOptionsAwait(collection: String, query: JsonObject, replace: JsonObject, findOptions: FindOptions, updateOptions: UpdateOptions): JsonObject? {
+  return awaitResult {
     this.findOneAndReplaceWithOptions(collection, query, replace, findOptions, updateOptions, it)
   }
 }
 
 /**
- * Find a single matching document in the specified collection and delete it.
- * <p>
- * This operation might change <i>_id</i> field of <i>query</i> parameter
+ * Suspending version of method [io.vertx.ext.mongo.MongoClient.findOneAndDelete]
  *
  * @param collection the collection
  * @param query the query used to match the document
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.mongo.MongoClient original] using Vert.x codegen.
+ * @return [JsonObject?]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-suspend fun MongoClient.findOneAndDeleteAwait(collection : String, query : JsonObject) : JsonObject? {
-  return awaitResult{
+suspend fun MongoClient.findOneAndDeleteAwait(collection: String, query: JsonObject): JsonObject? {
+  return awaitResult {
     this.findOneAndDelete(collection, query, it)
   }
 }
 
 /**
- * Find a single matching document in the specified collection and delete it.
- * <p>
- * This operation might change <i>_id</i> field of <i>query</i> parameter
+ * Suspending version of method [io.vertx.ext.mongo.MongoClient.findOneAndDeleteWithOptions]
  *
  * @param collection the collection
  * @param query the query used to match the document
  * @param findOptions options to configure the find
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.mongo.MongoClient original] using Vert.x codegen.
+ * @return [JsonObject?]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-suspend fun MongoClient.findOneAndDeleteWithOptionsAwait(collection : String, query : JsonObject, findOptions : FindOptions) : JsonObject? {
-  return awaitResult{
+suspend fun MongoClient.findOneAndDeleteWithOptionsAwait(collection: String, query: JsonObject, findOptions: FindOptions): JsonObject? {
+  return awaitResult {
     this.findOneAndDeleteWithOptions(collection, query, findOptions, it)
   }
 }
 
 /**
- * Count matching documents in a collection.
+ * Suspending version of method [io.vertx.ext.mongo.MongoClient.count]
  *
  * @param collection the collection
  * @param query query used to match documents
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.mongo.MongoClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-suspend fun MongoClient.countAwait(collection : String, query : JsonObject) : Long {
-  return awaitResult{
+suspend fun MongoClient.countAwait(collection: String, query: JsonObject): Long {
+  return awaitResult {
     this.count(collection, query, it)
   }
 }
 
 /**
- * Remove matching documents from a collection and return the handler with MongoClientDeleteResult result
+ * Suspending version of method [io.vertx.ext.mongo.MongoClient.removeDocuments]
  *
  * @param collection the collection
  * @param query query used to match documents
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.mongo.MongoClient original] using Vert.x codegen.
+ * @return [MongoClientDeleteResult]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-suspend fun MongoClient.removeDocumentsAwait(collection : String, query : JsonObject) : MongoClientDeleteResult {
-  return awaitResult{
+suspend fun MongoClient.removeDocumentsAwait(collection: String, query: JsonObject): MongoClientDeleteResult {
+  return awaitResult {
     this.removeDocuments(collection, query, it)
   }
 }
 
 /**
- * Remove matching documents from a collection with the specified write option and return the handler with MongoClientDeleteResult result
+ * Suspending version of method [io.vertx.ext.mongo.MongoClient.removeDocumentsWithOptions]
  *
  * @param collection the collection
  * @param query query used to match documents
  * @param writeOption the write option to use
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.mongo.MongoClient original] using Vert.x codegen.
+ * @return [MongoClientDeleteResult]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-suspend fun MongoClient.removeDocumentsWithOptionsAwait(collection : String, query : JsonObject, writeOption : WriteOption) : MongoClientDeleteResult {
-  return awaitResult{
+suspend fun MongoClient.removeDocumentsWithOptionsAwait(collection: String, query: JsonObject, writeOption: WriteOption): MongoClientDeleteResult {
+  return awaitResult {
     this.removeDocumentsWithOptions(collection, query, writeOption, it)
   }
 }
 
 /**
- * Remove a single matching document from a collection and return the handler with MongoClientDeleteResult result
+ * Suspending version of method [io.vertx.ext.mongo.MongoClient.removeDocument]
  *
  * @param collection the collection
  * @param query query used to match document
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.mongo.MongoClient original] using Vert.x codegen.
+ * @return [MongoClientDeleteResult]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-suspend fun MongoClient.removeDocumentAwait(collection : String, query : JsonObject) : MongoClientDeleteResult {
-  return awaitResult{
+suspend fun MongoClient.removeDocumentAwait(collection: String, query: JsonObject): MongoClientDeleteResult {
+  return awaitResult {
     this.removeDocument(collection, query, it)
   }
 }
 
 /**
- * Remove a single matching document from a collection with the specified write option and return the handler with MongoClientDeleteResult result
+ * Suspending version of method [io.vertx.ext.mongo.MongoClient.removeDocumentWithOptions]
  *
  * @param collection the collection
  * @param query query used to match document
  * @param writeOption the write option to use
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.mongo.MongoClient original] using Vert.x codegen.
+ * @return [MongoClientDeleteResult]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-suspend fun MongoClient.removeDocumentWithOptionsAwait(collection : String, query : JsonObject, writeOption : WriteOption) : MongoClientDeleteResult {
-  return awaitResult{
+suspend fun MongoClient.removeDocumentWithOptionsAwait(collection: String, query: JsonObject, writeOption: WriteOption): MongoClientDeleteResult {
+  return awaitResult {
     this.removeDocumentWithOptions(collection, query, writeOption, it)
   }
 }
 
 /**
- * Create a new collection
+ * Suspending version of method [io.vertx.ext.mongo.MongoClient.createCollection]
  *
  * @param collectionName the name of the collection
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.mongo.MongoClient original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-suspend fun MongoClient.createCollectionAwait(collectionName : String) : Unit {
-  return awaitResult{
-    this.createCollection(collectionName, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun MongoClient.createCollectionAwait(collectionName: String): Unit {
+  return awaitResult {
+    this.createCollection(collectionName) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Get a list of all collections in the database.
+ * Suspending version of method [io.vertx.ext.mongo.MongoClient.getCollections]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.mongo.MongoClient original] using Vert.x codegen.
+ * @return [List<String>]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-suspend fun MongoClient.getCollectionsAwait() : List<String> {
-  return awaitResult{
+suspend fun MongoClient.getCollectionsAwait(): List<String> {
+  return awaitResult {
     this.getCollections(it)
   }
 }
 
 /**
- * Drop a collection
+ * Suspending version of method [io.vertx.ext.mongo.MongoClient.dropCollection]
  *
  * @param collection the collection
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.mongo.MongoClient original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-suspend fun MongoClient.dropCollectionAwait(collection : String) : Unit {
-  return awaitResult{
-    this.dropCollection(collection, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun MongoClient.dropCollectionAwait(collection: String): Unit {
+  return awaitResult {
+    this.dropCollection(collection) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Creates an index.
+ * Suspending version of method [io.vertx.ext.mongo.MongoClient.createIndex]
  *
  * @param collection the collection
  * @param key A document that contains the field and value pairs where the field is the index key and the value describes the type of index for that field. For an ascending index on a field, specify a value of 1; for descending index, specify a value of -1.
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.mongo.MongoClient original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-suspend fun MongoClient.createIndexAwait(collection : String, key : JsonObject) : Unit {
-  return awaitResult{
-    this.createIndex(collection, key, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun MongoClient.createIndexAwait(collection: String, key: JsonObject): Unit {
+  return awaitResult {
+    this.createIndex(collection, key) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Creates an index.
+ * Suspending version of method [io.vertx.ext.mongo.MongoClient.createIndexWithOptions]
  *
  * @param collection the collection
  * @param key A document that contains the field and value pairs where the field is the index key and the value describes the type of index for that field. For an ascending index on a field, specify a value of 1; for descending index, specify a value of -1.
  * @param options the options for the index
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.mongo.MongoClient original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-suspend fun MongoClient.createIndexWithOptionsAwait(collection : String, key : JsonObject, options : IndexOptions) : Unit {
-  return awaitResult{
-    this.createIndexWithOptions(collection, key, options, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun MongoClient.createIndexWithOptionsAwait(collection: String, key: JsonObject, options: IndexOptions): Unit {
+  return awaitResult {
+    this.createIndexWithOptions(collection, key, options) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Get all the indexes in this collection.
+ * Suspending version of method [io.vertx.ext.mongo.MongoClient.listIndexes]
  *
  * @param collection the collection
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.mongo.MongoClient original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-suspend fun MongoClient.listIndexesAwait(collection : String) : JsonArray {
-  return awaitResult{
+suspend fun MongoClient.listIndexesAwait(collection: String): JsonArray {
+  return awaitResult {
     this.listIndexes(collection, it)
   }
 }
 
 /**
- * Drops the index given its name.
+ * Suspending version of method [io.vertx.ext.mongo.MongoClient.dropIndex]
  *
  * @param collection the collection
  * @param indexName the name of the index to remove
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.mongo.MongoClient original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-suspend fun MongoClient.dropIndexAwait(collection : String, indexName : String) : Unit {
-  return awaitResult{
-    this.dropIndex(collection, indexName, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun MongoClient.dropIndexAwait(collection: String, indexName: String): Unit {
+  return awaitResult {
+    this.dropIndex(collection, indexName) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Run an arbitrary MongoDB command.
+ * Suspending version of method [io.vertx.ext.mongo.MongoClient.runCommand]
  *
  * @param commandName the name of the command
  * @param command the command
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.mongo.MongoClient original] using Vert.x codegen.
+ * @return [JsonObject]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-suspend fun MongoClient.runCommandAwait(commandName : String, command : JsonObject) : JsonObject {
-  return awaitResult{
+suspend fun MongoClient.runCommandAwait(commandName: String, command: JsonObject): JsonObject {
+  return awaitResult {
     this.runCommand(commandName, command, it)
   }
 }
 
 /**
- * Gets the distinct values of the specified field name.
- * Return a JsonArray containing distinct values (eg: [ 1 , 89 ])
+ * Suspending version of method [io.vertx.ext.mongo.MongoClient.distinct]
  *
  * @param collection the collection
  * @param fieldName the field name
  * @param resultClassname 
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.mongo.MongoClient original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-suspend fun MongoClient.distinctAwait(collection : String, fieldName : String, resultClassname : String) : JsonArray {
-  return awaitResult{
+suspend fun MongoClient.distinctAwait(collection: String, fieldName: String, resultClassname: String): JsonArray {
+  return awaitResult {
     this.distinct(collection, fieldName, resultClassname, it)
   }
 }
 
 /**
- * Gets the distinct values of the specified field name filtered by specified query.
- * Return a JsonArray containing distinct values (eg: [ 1 , 89 ])
+ * Suspending version of method [io.vertx.ext.mongo.MongoClient.distinctWithQuery]
  *
  * @param collection the collection
  * @param fieldName the field name
  * @param resultClassname 
  * @param query the query
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.mongo.MongoClient original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-suspend fun MongoClient.distinctWithQueryAwait(collection : String, fieldName : String, resultClassname : String, query : JsonObject) : JsonArray {
-  return awaitResult{
+suspend fun MongoClient.distinctWithQueryAwait(collection: String, fieldName: String, resultClassname: String, query: JsonObject): JsonArray {
+  return awaitResult {
     this.distinctWithQuery(collection, fieldName, resultClassname, query, it)
   }
 }

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/shell/ShellServer.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/shell/ShellServer.kt
@@ -4,26 +4,26 @@ import io.vertx.ext.shell.ShellServer
 import io.vertx.kotlin.coroutines.awaitResult
 
 /**
- * Start the shell service, this is an asynchronous start.
+ * Suspending version of method [io.vertx.ext.shell.ShellServer.listen]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.shell.ShellServer original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.shell.ShellServer] using Vert.x codegen.
  */
-suspend fun ShellServer.listenAwait() : Unit {
-  return awaitResult{
-    this.listen({ ar -> it.handle(ar.mapEmpty()) })}
+suspend fun ShellServer.listenAwait(): Unit {
+  return awaitResult {
+    this.listen { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Close the shell server, this is an asynchronous close.
+ * Suspending version of method [io.vertx.ext.shell.ShellServer.close]
  *
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.shell.ShellServer original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.ext.shell.ShellServer] using Vert.x codegen.
  */
-suspend fun ShellServer.closeAwait() : Unit {
-  return awaitResult{
-    this.close({ ar -> it.handle(ar.mapEmpty()) })}
+suspend fun ShellServer.closeAwait(): Unit {
+  return awaitResult {
+    this.close { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/shell/ShellService.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/shell/ShellService.kt
@@ -4,26 +4,26 @@ import io.vertx.ext.shell.ShellService
 import io.vertx.kotlin.coroutines.awaitResult
 
 /**
- * Start the shell service, this is an asynchronous start.
+ * Suspending version of method [io.vertx.ext.shell.ShellService.start]
  *
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.shell.ShellService original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.ext.shell.ShellService] using Vert.x codegen.
  */
-suspend fun ShellService.startAwait() : Unit {
-  return awaitResult{
-    this.start({ ar -> it.handle(ar.mapEmpty()) })}
+suspend fun ShellService.startAwait(): Unit {
+  return awaitResult {
+    this.start { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Stop the shell service, this is an asynchronous start.
+ * Suspending version of method [io.vertx.ext.shell.ShellService.stop]
  *
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.shell.ShellService original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.ext.shell.ShellService] using Vert.x codegen.
  */
-suspend fun ShellService.stopAwait() : Unit {
-  return awaitResult{
-    this.stop({ ar -> it.handle(ar.mapEmpty()) })}
+suspend fun ShellService.stopAwait(): Unit {
+  return awaitResult {
+    this.stop { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/shell/command/CommandRegistry.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/shell/command/CommandRegistry.kt
@@ -5,43 +5,43 @@ import io.vertx.ext.shell.command.CommandRegistry
 import io.vertx.kotlin.coroutines.awaitResult
 
 /**
- * Register a command
+ * Suspending version of method [io.vertx.ext.shell.command.CommandRegistry.registerCommand]
  *
  * @param command the command to register
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.shell.command.CommandRegistry original] using Vert.x codegen.
+ * @return [Command]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.shell.command.CommandRegistry] using Vert.x codegen.
  */
-suspend fun CommandRegistry.registerCommandAwait(command : Command) : Command {
-  return awaitResult{
+suspend fun CommandRegistry.registerCommandAwait(command: Command): Command {
+  return awaitResult {
     this.registerCommand(command, it)
   }
 }
 
 /**
- * Register a list of commands.
+ * Suspending version of method [io.vertx.ext.shell.command.CommandRegistry.registerCommands]
  *
  * @param commands the commands to register
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.shell.command.CommandRegistry original] using Vert.x codegen.
+ * @return [List<Command>]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.shell.command.CommandRegistry] using Vert.x codegen.
  */
-suspend fun CommandRegistry.registerCommandsAwait(commands : List<Command>) : List<Command> {
-  return awaitResult{
+suspend fun CommandRegistry.registerCommandsAwait(commands: List<Command>): List<Command> {
+  return awaitResult {
     this.registerCommands(commands, it)
   }
 }
 
 /**
- * Unregister a command.
+ * Suspending version of method [io.vertx.ext.shell.command.CommandRegistry.unregisterCommand]
  *
  * @param commandName the command name
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.shell.command.CommandRegistry original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.shell.command.CommandRegistry] using Vert.x codegen.
  */
-suspend fun CommandRegistry.unregisterCommandAwait(commandName : String) : Unit {
-  return awaitResult{
-    this.unregisterCommand(commandName, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun CommandRegistry.unregisterCommandAwait(commandName: String): Unit {
+  return awaitResult {
+    this.unregisterCommand(commandName) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/shell/term/TermServer.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/shell/term/TermServer.kt
@@ -4,27 +4,27 @@ import io.vertx.ext.shell.term.TermServer
 import io.vertx.kotlin.coroutines.awaitResult
 
 /**
- * Bind the term server, the [io.vertx.ext.shell.term.TermServer] must be set before.
+ * Suspending version of method [io.vertx.ext.shell.term.TermServer.listen]
  *
- * @return this object *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.shell.term.TermServer original] using Vert.x codegen.
+ * @return [TermServer]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.shell.term.TermServer] using Vert.x codegen.
  */
-suspend fun TermServer.listenAwait() : TermServer {
-  return awaitResult{
+suspend fun TermServer.listenAwait(): TermServer {
+  return awaitResult {
     this.listen(it)
   }
 }
 
 /**
- * Like [io.vertx.ext.shell.term.TermServer] but supplying a handler that will be notified when close is complete.
+ * Suspending version of method [io.vertx.ext.shell.term.TermServer.close]
  *
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.shell.term.TermServer original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.ext.shell.term.TermServer] using Vert.x codegen.
  */
-suspend fun TermServer.closeAwait() : Unit {
-  return awaitResult{
-    this.close({ ar -> it.handle(ar.mapEmpty()) })}
+suspend fun TermServer.closeAwait(): Unit {
+  return awaitResult {
+    this.close { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/sql/SQLClient.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/sql/SQLClient.kt
@@ -9,190 +9,172 @@ import io.vertx.ext.sql.UpdateResult
 import io.vertx.kotlin.coroutines.awaitResult
 
 /**
- * Execute a one shot SQL statement that returns a single SQL row. This method will reduce the boilerplate code by
- * getting a connection from the pool (this object) and return it back after the execution. Only the first result
- * from the result set is returned.
+ * Suspending version of method [io.vertx.ext.sql.SQLClient.querySingle]
  *
  * @param sql the statement to execute
- * @return self *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.sql.SQLClient original] using Vert.x codegen.
+ * @return [JsonArray?]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLClient] using Vert.x codegen.
  */
-suspend fun SQLClient.querySingleAwait(sql : String) : JsonArray? {
-  return awaitResult{
+suspend fun SQLClient.querySingleAwait(sql: String): JsonArray? {
+  return awaitResult {
     this.querySingle(sql, it)
   }
 }
 
 /**
- * Execute a one shot SQL statement with arguments that returns a single SQL row. This method will reduce the
- * boilerplate code by getting a connection from the pool (this object) and return it back after the execution.
- * Only the first result from the result set is returned.
+ * Suspending version of method [io.vertx.ext.sql.SQLClient.querySingleWithParams]
  *
  * @param sql the statement to execute
  * @param arguments the arguments
- * @return self *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.sql.SQLClient original] using Vert.x codegen.
+ * @return [JsonArray?]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLClient] using Vert.x codegen.
  */
-suspend fun SQLClient.querySingleWithParamsAwait(sql : String, arguments : JsonArray) : JsonArray? {
-  return awaitResult{
+suspend fun SQLClient.querySingleWithParamsAwait(sql: String, arguments: JsonArray): JsonArray? {
+  return awaitResult {
     this.querySingleWithParams(sql, arguments, it)
   }
 }
 
 /**
- * Returns a connection that can be used to perform SQL operations on. It's important to remember
- * to close the connection when you are done, so it is returned to the pool.
+ * Suspending version of method [io.vertx.ext.sql.SQLClient.getConnection]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.sql.SQLClient original] using Vert.x codegen.
+ * @return [SQLConnection]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLClient] using Vert.x codegen.
  */
-suspend fun SQLClient.getConnectionAwait() : SQLConnection {
-  return awaitResult{
+suspend fun SQLClient.getConnectionAwait(): SQLConnection {
+  return awaitResult {
     this.getConnection(it)
   }
 }
 
 /**
- * Close the client and release all resources.
- * Call the handler when close is complete.
+ * Suspending version of method [io.vertx.ext.sql.SQLClient.close]
  *
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.sql.SQLClient original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLClient] using Vert.x codegen.
  */
-suspend fun SQLClient.closeAwait() : Unit {
-  return awaitResult{
-    this.close({ ar -> it.handle(ar.mapEmpty()) })}
+suspend fun SQLClient.closeAwait(): Unit {
+  return awaitResult {
+    this.close { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Execute a single SQL statement, this method acquires a connection from the the pool and executes the SQL
- * statement and returns it back after the execution.
+ * Suspending version of method [io.vertx.ext.sql.SQLClient.query]
  *
  * @param sql the statement to execute
- * @return self *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.sql.SQLClient original] using Vert.x codegen.
+ * @return [ResultSet]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLClient] using Vert.x codegen.
  */
-suspend fun SQLClient.queryAwait(sql : String) : ResultSet {
-  return awaitResult{
+suspend fun SQLClient.queryAwait(sql: String): ResultSet {
+  return awaitResult {
     this.query(sql, it)
   }
 }
 
 /**
- * Executes the given SQL <code>SELECT</code> statement which returns the results of the query as a read stream.
+ * Suspending version of method [io.vertx.ext.sql.SQLClient.queryStream]
  *
  * @param sql the SQL to execute. For example <code>SELECT * FROM table ...</code>.
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.sql.SQLClient original] using Vert.x codegen.
+ * @return [SQLRowStream]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLClient] using Vert.x codegen.
  */
-suspend fun SQLClient.queryStreamAwait(sql : String) : SQLRowStream {
-  return awaitResult{
+suspend fun SQLClient.queryStreamAwait(sql: String): SQLRowStream {
+  return awaitResult {
     this.queryStream(sql, it)
   }
 }
 
 /**
- * Executes the given SQL <code>SELECT</code> statement which returns the results of the query as a read stream.
+ * Suspending version of method [io.vertx.ext.sql.SQLClient.queryStreamWithParams]
  *
  * @param sql the SQL to execute. For example <code>SELECT * FROM table ...</code>.
  * @param params these are the parameters to fill the statement.
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.sql.SQLClient original] using Vert.x codegen.
+ * @return [SQLRowStream]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLClient] using Vert.x codegen.
  */
-suspend fun SQLClient.queryStreamWithParamsAwait(sql : String, params : JsonArray) : SQLRowStream {
-  return awaitResult{
+suspend fun SQLClient.queryStreamWithParamsAwait(sql: String, params: JsonArray): SQLRowStream {
+  return awaitResult {
     this.queryStreamWithParams(sql, params, it)
   }
 }
 
 /**
- * Execute a single SQL prepared statement, this method acquires a connection from the the pool and executes the SQL
- * prepared statement and returns it back after the execution.
+ * Suspending version of method [io.vertx.ext.sql.SQLClient.queryWithParams]
  *
  * @param sql the statement to execute
  * @param arguments the arguments to the statement
- * @return self *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.sql.SQLClient original] using Vert.x codegen.
+ * @return [ResultSet]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLClient] using Vert.x codegen.
  */
-suspend fun SQLClient.queryWithParamsAwait(sql : String, arguments : JsonArray) : ResultSet {
-  return awaitResult{
+suspend fun SQLClient.queryWithParamsAwait(sql: String, arguments: JsonArray): ResultSet {
+  return awaitResult {
     this.queryWithParams(sql, arguments, it)
   }
 }
 
 /**
- * Executes the given SQL statement which may be an <code>INSERT</code>, <code>UPDATE</code>, or <code>DELETE</code>
- * statement.
+ * Suspending version of method [io.vertx.ext.sql.SQLClient.update]
  *
  * @param sql the SQL to execute. For example <code>INSERT INTO table ...</code>
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.sql.SQLClient original] using Vert.x codegen.
+ * @return [UpdateResult]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLClient] using Vert.x codegen.
  */
-suspend fun SQLClient.updateAwait(sql : String) : UpdateResult {
-  return awaitResult{
+suspend fun SQLClient.updateAwait(sql: String): UpdateResult {
+  return awaitResult {
     this.update(sql, it)
   }
 }
 
 /**
- * Executes the given prepared statement which may be an <code>INSERT</code>, <code>UPDATE</code>, or <code>DELETE</code>
- * statement with the given parameters
+ * Suspending version of method [io.vertx.ext.sql.SQLClient.updateWithParams]
  *
  * @param sql the SQL to execute. For example <code>INSERT INTO table ...</code>
  * @param params these are the parameters to fill the statement.
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.sql.SQLClient original] using Vert.x codegen.
+ * @return [UpdateResult]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLClient] using Vert.x codegen.
  */
-suspend fun SQLClient.updateWithParamsAwait(sql : String, params : JsonArray) : UpdateResult {
-  return awaitResult{
+suspend fun SQLClient.updateWithParamsAwait(sql: String, params: JsonArray): UpdateResult {
+  return awaitResult {
     this.updateWithParams(sql, params, it)
   }
 }
 
 /**
- * Calls the given SQL <code>PROCEDURE</code> which returns the result from the procedure.
+ * Suspending version of method [io.vertx.ext.sql.SQLClient.call]
  *
  * @param sql the SQL to execute. For example <code>{call getEmpName}</code>.
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.sql.SQLClient original] using Vert.x codegen.
+ * @return [ResultSet]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLClient] using Vert.x codegen.
  */
-suspend fun SQLClient.callAwait(sql : String) : ResultSet {
-  return awaitResult{
+suspend fun SQLClient.callAwait(sql: String): ResultSet {
+  return awaitResult {
     this.call(sql, it)
   }
 }
 
 /**
- * Calls the given SQL <code>PROCEDURE</code> which returns the result from the procedure.
- *
- * The index of params and outputs are important for both arrays, for example when dealing with a prodecure that
- * takes the first 2 arguments as input values and the 3 arg as an output then the arrays should be like:
- *
- * <pre>
- *   params = [VALUE1, VALUE2, null]
- *   outputs = [null, null, "VARCHAR"]
- * </pre>
+ * Suspending version of method [io.vertx.ext.sql.SQLClient.callWithParams]
  *
  * @param sql the SQL to execute. For example <code>{call getEmpName (?, ?)}</code>.
  * @param params these are the parameters to fill the statement.
  * @param outputs these are the outputs to fill the statement.
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.sql.SQLClient original] using Vert.x codegen.
+ * @return [ResultSet]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLClient] using Vert.x codegen.
  */
-suspend fun SQLClient.callWithParamsAwait(sql : String, params : JsonArray, outputs : JsonArray) : ResultSet {
-  return awaitResult{
+suspend fun SQLClient.callWithParamsAwait(sql: String, params: JsonArray, outputs: JsonArray): ResultSet {
+  return awaitResult {
     this.callWithParams(sql, params, outputs, it)
   }
 }

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/sql/SQLConnection.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/sql/SQLConnection.kt
@@ -9,299 +9,280 @@ import io.vertx.ext.sql.UpdateResult
 import io.vertx.kotlin.coroutines.awaitResult
 
 /**
- * Execute a one shot SQL statement that returns a single SQL row. This method will reduce the boilerplate code by
- * getting a connection from the pool (this object) and return it back after the execution. Only the first result
- * from the result set is returned.
+ * Suspending version of method [io.vertx.ext.sql.SQLConnection.querySingle]
  *
  * @param sql the statement to execute
- * @return self *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.sql.SQLConnection original] using Vert.x codegen.
+ * @return [JsonArray?]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLConnection] using Vert.x codegen.
  */
-suspend fun SQLConnection.querySingleAwait(sql : String) : JsonArray? {
-  return awaitResult{
+suspend fun SQLConnection.querySingleAwait(sql: String): JsonArray? {
+  return awaitResult {
     this.querySingle(sql, it)
   }
 }
 
 /**
- * Execute a one shot SQL statement with arguments that returns a single SQL row. This method will reduce the
- * boilerplate code by getting a connection from the pool (this object) and return it back after the execution.
- * Only the first result from the result set is returned.
+ * Suspending version of method [io.vertx.ext.sql.SQLConnection.querySingleWithParams]
  *
  * @param sql the statement to execute
  * @param arguments the arguments
- * @return self *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.sql.SQLConnection original] using Vert.x codegen.
+ * @return [JsonArray?]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLConnection] using Vert.x codegen.
  */
-suspend fun SQLConnection.querySingleWithParamsAwait(sql : String, arguments : JsonArray) : JsonArray? {
-  return awaitResult{
+suspend fun SQLConnection.querySingleWithParamsAwait(sql: String, arguments: JsonArray): JsonArray? {
+  return awaitResult {
     this.querySingleWithParams(sql, arguments, it)
   }
 }
 
 /**
- * Sets the auto commit flag for this connection. True by default.
+ * Suspending version of method [io.vertx.ext.sql.SQLConnection.setAutoCommit]
  *
  * @param autoCommit the autoCommit flag, true by default.
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.sql.SQLConnection original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLConnection] using Vert.x codegen.
  */
-suspend fun SQLConnection.setAutoCommitAwait(autoCommit : Boolean) : Unit {
-  return awaitResult{
-    this.setAutoCommit(autoCommit, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun SQLConnection.setAutoCommitAwait(autoCommit: Boolean): Unit {
+  return awaitResult {
+    this.setAutoCommit(autoCommit) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Executes the given SQL statement
+ * Suspending version of method [io.vertx.ext.sql.SQLConnection.execute]
  *
  * @param sql the SQL to execute. For example <code>CREATE TABLE IF EXISTS table ...</code>
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.sql.SQLConnection original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLConnection] using Vert.x codegen.
  */
-suspend fun SQLConnection.executeAwait(sql : String) : Unit {
-  return awaitResult{
-    this.execute(sql, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun SQLConnection.executeAwait(sql: String): Unit {
+  return awaitResult {
+    this.execute(sql) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Executes the given SQL <code>SELECT</code> statement which returns the results of the query.
+ * Suspending version of method [io.vertx.ext.sql.SQLConnection.query]
  *
  * @param sql the SQL to execute. For example <code>SELECT * FROM table ...</code>.
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.sql.SQLConnection original] using Vert.x codegen.
+ * @return [ResultSet]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLConnection] using Vert.x codegen.
  */
-suspend fun SQLConnection.queryAwait(sql : String) : ResultSet {
-  return awaitResult{
+suspend fun SQLConnection.queryAwait(sql: String): ResultSet {
+  return awaitResult {
     this.query(sql, it)
   }
 }
 
 /**
- * Executes the given SQL <code>SELECT</code> statement which returns the results of the query as a read stream.
+ * Suspending version of method [io.vertx.ext.sql.SQLConnection.queryStream]
  *
  * @param sql the SQL to execute. For example <code>SELECT * FROM table ...</code>.
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.sql.SQLConnection original] using Vert.x codegen.
+ * @return [SQLRowStream]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLConnection] using Vert.x codegen.
  */
-suspend fun SQLConnection.queryStreamAwait(sql : String) : SQLRowStream {
-  return awaitResult{
+suspend fun SQLConnection.queryStreamAwait(sql: String): SQLRowStream {
+  return awaitResult {
     this.queryStream(sql, it)
   }
 }
 
 /**
- * Executes the given SQL <code>SELECT</code> prepared statement which returns the results of the query.
+ * Suspending version of method [io.vertx.ext.sql.SQLConnection.queryWithParams]
  *
  * @param sql the SQL to execute. For example <code>SELECT * FROM table ...</code>.
  * @param params these are the parameters to fill the statement.
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.sql.SQLConnection original] using Vert.x codegen.
+ * @return [ResultSet]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLConnection] using Vert.x codegen.
  */
-suspend fun SQLConnection.queryWithParamsAwait(sql : String, params : JsonArray) : ResultSet {
-  return awaitResult{
+suspend fun SQLConnection.queryWithParamsAwait(sql: String, params: JsonArray): ResultSet {
+  return awaitResult {
     this.queryWithParams(sql, params, it)
   }
 }
 
 /**
- * Executes the given SQL <code>SELECT</code> statement which returns the results of the query as a read stream.
+ * Suspending version of method [io.vertx.ext.sql.SQLConnection.queryStreamWithParams]
  *
  * @param sql the SQL to execute. For example <code>SELECT * FROM table ...</code>.
  * @param params these are the parameters to fill the statement.
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.sql.SQLConnection original] using Vert.x codegen.
+ * @return [SQLRowStream]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLConnection] using Vert.x codegen.
  */
-suspend fun SQLConnection.queryStreamWithParamsAwait(sql : String, params : JsonArray) : SQLRowStream {
-  return awaitResult{
+suspend fun SQLConnection.queryStreamWithParamsAwait(sql: String, params: JsonArray): SQLRowStream {
+  return awaitResult {
     this.queryStreamWithParams(sql, params, it)
   }
 }
 
 /**
- * Executes the given SQL statement which may be an <code>INSERT</code>, <code>UPDATE</code>, or <code>DELETE</code>
- * statement.
+ * Suspending version of method [io.vertx.ext.sql.SQLConnection.update]
  *
  * @param sql the SQL to execute. For example <code>INSERT INTO table ...</code>
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.sql.SQLConnection original] using Vert.x codegen.
+ * @return [UpdateResult]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLConnection] using Vert.x codegen.
  */
-suspend fun SQLConnection.updateAwait(sql : String) : UpdateResult {
-  return awaitResult{
+suspend fun SQLConnection.updateAwait(sql: String): UpdateResult {
+  return awaitResult {
     this.update(sql, it)
   }
 }
 
 /**
- * Executes the given prepared statement which may be an <code>INSERT</code>, <code>UPDATE</code>, or <code>DELETE</code>
- * statement with the given parameters
+ * Suspending version of method [io.vertx.ext.sql.SQLConnection.updateWithParams]
  *
  * @param sql the SQL to execute. For example <code>INSERT INTO table ...</code>
  * @param params these are the parameters to fill the statement.
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.sql.SQLConnection original] using Vert.x codegen.
+ * @return [UpdateResult]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLConnection] using Vert.x codegen.
  */
-suspend fun SQLConnection.updateWithParamsAwait(sql : String, params : JsonArray) : UpdateResult {
-  return awaitResult{
+suspend fun SQLConnection.updateWithParamsAwait(sql: String, params: JsonArray): UpdateResult {
+  return awaitResult {
     this.updateWithParams(sql, params, it)
   }
 }
 
 /**
- * Calls the given SQL <code>PROCEDURE</code> which returns the result from the procedure.
+ * Suspending version of method [io.vertx.ext.sql.SQLConnection.call]
  *
  * @param sql the SQL to execute. For example <code>{call getEmpName}</code>.
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.sql.SQLConnection original] using Vert.x codegen.
+ * @return [ResultSet]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLConnection] using Vert.x codegen.
  */
-suspend fun SQLConnection.callAwait(sql : String) : ResultSet {
-  return awaitResult{
+suspend fun SQLConnection.callAwait(sql: String): ResultSet {
+  return awaitResult {
     this.call(sql, it)
   }
 }
 
 /**
- * Calls the given SQL <code>PROCEDURE</code> which returns the result from the procedure.
- *
- * The index of params and outputs are important for both arrays, for example when dealing with a prodecure that
- * takes the first 2 arguments as input values and the 3 arg as an output then the arrays should be like:
- *
- * <pre>
- *   params = [VALUE1, VALUE2, null]
- *   outputs = [null, null, "VARCHAR"]
- * </pre>
+ * Suspending version of method [io.vertx.ext.sql.SQLConnection.callWithParams]
  *
  * @param sql the SQL to execute. For example <code>{call getEmpName (?, ?)}</code>.
  * @param params these are the parameters to fill the statement.
  * @param outputs these are the outputs to fill the statement.
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.sql.SQLConnection original] using Vert.x codegen.
+ * @return [ResultSet]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLConnection] using Vert.x codegen.
  */
-suspend fun SQLConnection.callWithParamsAwait(sql : String, params : JsonArray, outputs : JsonArray) : ResultSet {
-  return awaitResult{
+suspend fun SQLConnection.callWithParamsAwait(sql: String, params: JsonArray, outputs: JsonArray): ResultSet {
+  return awaitResult {
     this.callWithParams(sql, params, outputs, it)
   }
 }
 
 /**
- * Closes the connection. Important to always close the connection when you are done so it's returned to the pool.
+ * Suspending version of method [io.vertx.ext.sql.SQLConnection.close]
  *
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.sql.SQLConnection original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLConnection] using Vert.x codegen.
  */
-suspend fun SQLConnection.closeAwait() : Unit {
-  return awaitResult{
-    this.close({ ar -> it.handle(ar.mapEmpty()) })}
+suspend fun SQLConnection.closeAwait(): Unit {
+  return awaitResult {
+    this.close { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Commits all changes made since the previous commit/rollback.
+ * Suspending version of method [io.vertx.ext.sql.SQLConnection.commit]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.sql.SQLConnection original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLConnection] using Vert.x codegen.
  */
-suspend fun SQLConnection.commitAwait() : Unit {
-  return awaitResult{
-    this.commit({ ar -> it.handle(ar.mapEmpty()) })}
+suspend fun SQLConnection.commitAwait(): Unit {
+  return awaitResult {
+    this.commit { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Rolls back all changes made since the previous commit/rollback.
+ * Suspending version of method [io.vertx.ext.sql.SQLConnection.rollback]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.sql.SQLConnection original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLConnection] using Vert.x codegen.
  */
-suspend fun SQLConnection.rollbackAwait() : Unit {
-  return awaitResult{
-    this.rollback({ ar -> it.handle(ar.mapEmpty()) })}
+suspend fun SQLConnection.rollbackAwait(): Unit {
+  return awaitResult {
+    this.rollback { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Batch simple SQL strings and execute the batch where the async result contains a array of Integers.
+ * Suspending version of method [io.vertx.ext.sql.SQLConnection.batch]
  *
  * @param sqlStatements sql statement
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.sql.SQLConnection original] using Vert.x codegen.
+ * @return [List<Int>]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLConnection] using Vert.x codegen.
  */
-suspend fun SQLConnection.batchAwait(sqlStatements : List<String>) : List<Int> {
-  return awaitResult{
+suspend fun SQLConnection.batchAwait(sqlStatements: List<String>): List<Int> {
+  return awaitResult {
     this.batch(sqlStatements, it)
   }
 }
 
 /**
- * Batch a prepared statement with all entries from the args list. Each entry is a batch.
- * The operation completes with the execution of the batch where the async result contains a array of Integers.
+ * Suspending version of method [io.vertx.ext.sql.SQLConnection.batchWithParams]
  *
  * @param sqlStatement sql statement
  * @param args the prepared statement arguments
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.sql.SQLConnection original] using Vert.x codegen.
+ * @return [List<Int>]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLConnection] using Vert.x codegen.
  */
-suspend fun SQLConnection.batchWithParamsAwait(sqlStatement : String, args : List<JsonArray>) : List<Int> {
-  return awaitResult{
+suspend fun SQLConnection.batchWithParamsAwait(sqlStatement: String, args: List<JsonArray>): List<Int> {
+  return awaitResult {
     this.batchWithParams(sqlStatement, args, it)
   }
 }
 
 /**
- * Batch a callable statement with all entries from the args list. Each entry is a batch.
- * The size of the lists inArgs and outArgs MUST be the equal.
- * The operation completes with the execution of the batch where the async result contains a array of Integers.
+ * Suspending version of method [io.vertx.ext.sql.SQLConnection.batchCallableWithParams]
  *
  * @param sqlStatement sql statement
  * @param inArgs the callable statement input arguments
  * @param outArgs the callable statement output arguments
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.sql.SQLConnection original] using Vert.x codegen.
+ * @return [List<Int>]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLConnection] using Vert.x codegen.
  */
-suspend fun SQLConnection.batchCallableWithParamsAwait(sqlStatement : String, inArgs : List<JsonArray>, outArgs : List<JsonArray>) : List<Int> {
-  return awaitResult{
+suspend fun SQLConnection.batchCallableWithParamsAwait(sqlStatement: String, inArgs: List<JsonArray>, outArgs: List<JsonArray>): List<Int> {
+  return awaitResult {
     this.batchCallableWithParams(sqlStatement, inArgs, outArgs, it)
   }
 }
 
 /**
- * Attempts to change the transaction isolation level for this Connection object to the one given.
- *
- * The constants defined in the interface Connection are the possible transaction isolation levels.
+ * Suspending version of method [io.vertx.ext.sql.SQLConnection.setTransactionIsolation]
  *
  * @param isolation the level of isolation
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.sql.SQLConnection original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLConnection] using Vert.x codegen.
  */
-suspend fun SQLConnection.setTransactionIsolationAwait(isolation : TransactionIsolation) : Unit {
-  return awaitResult{
-    this.setTransactionIsolation(isolation, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun SQLConnection.setTransactionIsolationAwait(isolation: TransactionIsolation): Unit {
+  return awaitResult {
+    this.setTransactionIsolation(isolation) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Attempts to return the transaction isolation level for this Connection object to the one given.
+ * Suspending version of method [io.vertx.ext.sql.SQLConnection.getTransactionIsolation]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.sql.SQLConnection original] using Vert.x codegen.
+ * @return [TransactionIsolation]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLConnection] using Vert.x codegen.
  */
-suspend fun SQLConnection.getTransactionIsolationAwait() : TransactionIsolation {
-  return awaitResult{
+suspend fun SQLConnection.getTransactionIsolationAwait(): TransactionIsolation {
+  return awaitResult {
     this.getTransactionIsolation(it)
   }
 }

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/sql/SQLOperations.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/sql/SQLOperations.kt
@@ -8,161 +8,147 @@ import io.vertx.ext.sql.UpdateResult
 import io.vertx.kotlin.coroutines.awaitResult
 
 /**
- * Executes the given SQL <code>SELECT</code> statement which returns the results of the query.
+ * Suspending version of method [io.vertx.ext.sql.SQLOperations.query]
  *
  * @param sql the SQL to execute. For example <code>SELECT * FROM table ...</code>.
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.sql.SQLOperations original] using Vert.x codegen.
+ * @return [ResultSet]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLOperations] using Vert.x codegen.
  */
-suspend fun SQLOperations.queryAwait(sql : String) : ResultSet {
-  return awaitResult{
+suspend fun SQLOperations.queryAwait(sql: String): ResultSet {
+  return awaitResult {
     this.query(sql, it)
   }
 }
 
 /**
- * Executes the given SQL <code>SELECT</code> prepared statement which returns the results of the query.
+ * Suspending version of method [io.vertx.ext.sql.SQLOperations.queryWithParams]
  *
  * @param sql the SQL to execute. For example <code>SELECT * FROM table ...</code>.
  * @param params these are the parameters to fill the statement.
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.sql.SQLOperations original] using Vert.x codegen.
+ * @return [ResultSet]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLOperations] using Vert.x codegen.
  */
-suspend fun SQLOperations.queryWithParamsAwait(sql : String, params : JsonArray) : ResultSet {
-  return awaitResult{
+suspend fun SQLOperations.queryWithParamsAwait(sql: String, params: JsonArray): ResultSet {
+  return awaitResult {
     this.queryWithParams(sql, params, it)
   }
 }
 
 /**
- * Executes the given SQL <code>SELECT</code> statement which returns the results of the query as a read stream.
+ * Suspending version of method [io.vertx.ext.sql.SQLOperations.queryStream]
  *
  * @param sql the SQL to execute. For example <code>SELECT * FROM table ...</code>.
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.sql.SQLOperations original] using Vert.x codegen.
+ * @return [SQLRowStream]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLOperations] using Vert.x codegen.
  */
-suspend fun SQLOperations.queryStreamAwait(sql : String) : SQLRowStream {
-  return awaitResult{
+suspend fun SQLOperations.queryStreamAwait(sql: String): SQLRowStream {
+  return awaitResult {
     this.queryStream(sql, it)
   }
 }
 
 /**
- * Executes the given SQL <code>SELECT</code> statement which returns the results of the query as a read stream.
+ * Suspending version of method [io.vertx.ext.sql.SQLOperations.queryStreamWithParams]
  *
  * @param sql the SQL to execute. For example <code>SELECT * FROM table ...</code>.
  * @param params these are the parameters to fill the statement.
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.sql.SQLOperations original] using Vert.x codegen.
+ * @return [SQLRowStream]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLOperations] using Vert.x codegen.
  */
-suspend fun SQLOperations.queryStreamWithParamsAwait(sql : String, params : JsonArray) : SQLRowStream {
-  return awaitResult{
+suspend fun SQLOperations.queryStreamWithParamsAwait(sql: String, params: JsonArray): SQLRowStream {
+  return awaitResult {
     this.queryStreamWithParams(sql, params, it)
   }
 }
 
 /**
- * Execute a one shot SQL statement that returns a single SQL row. This method will reduce the boilerplate code by
- * getting a connection from the pool (this object) and return it back after the execution. Only the first result
- * from the result set is returned.
+ * Suspending version of method [io.vertx.ext.sql.SQLOperations.querySingle]
  *
  * @param sql the statement to execute
- * @return self *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.sql.SQLOperations original] using Vert.x codegen.
+ * @return [JsonArray?]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLOperations] using Vert.x codegen.
  */
-suspend fun SQLOperations.querySingleAwait(sql : String) : JsonArray? {
-  return awaitResult{
+suspend fun SQLOperations.querySingleAwait(sql: String): JsonArray? {
+  return awaitResult {
     this.querySingle(sql, it)
   }
 }
 
 /**
- * Execute a one shot SQL statement with arguments that returns a single SQL row. This method will reduce the
- * boilerplate code by getting a connection from the pool (this object) and return it back after the execution.
- * Only the first result from the result set is returned.
+ * Suspending version of method [io.vertx.ext.sql.SQLOperations.querySingleWithParams]
  *
  * @param sql the statement to execute
  * @param arguments the arguments
- * @return self *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.sql.SQLOperations original] using Vert.x codegen.
+ * @return [JsonArray?]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLOperations] using Vert.x codegen.
  */
-suspend fun SQLOperations.querySingleWithParamsAwait(sql : String, arguments : JsonArray) : JsonArray? {
-  return awaitResult{
+suspend fun SQLOperations.querySingleWithParamsAwait(sql: String, arguments: JsonArray): JsonArray? {
+  return awaitResult {
     this.querySingleWithParams(sql, arguments, it)
   }
 }
 
 /**
- * Executes the given SQL statement which may be an <code>INSERT</code>, <code>UPDATE</code>, or <code>DELETE</code>
- * statement.
+ * Suspending version of method [io.vertx.ext.sql.SQLOperations.update]
  *
  * @param sql the SQL to execute. For example <code>INSERT INTO table ...</code>
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.sql.SQLOperations original] using Vert.x codegen.
+ * @return [UpdateResult]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLOperations] using Vert.x codegen.
  */
-suspend fun SQLOperations.updateAwait(sql : String) : UpdateResult {
-  return awaitResult{
+suspend fun SQLOperations.updateAwait(sql: String): UpdateResult {
+  return awaitResult {
     this.update(sql, it)
   }
 }
 
 /**
- * Executes the given prepared statement which may be an <code>INSERT</code>, <code>UPDATE</code>, or <code>DELETE</code>
- * statement with the given parameters
+ * Suspending version of method [io.vertx.ext.sql.SQLOperations.updateWithParams]
  *
  * @param sql the SQL to execute. For example <code>INSERT INTO table ...</code>
  * @param params these are the parameters to fill the statement.
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.sql.SQLOperations original] using Vert.x codegen.
+ * @return [UpdateResult]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLOperations] using Vert.x codegen.
  */
-suspend fun SQLOperations.updateWithParamsAwait(sql : String, params : JsonArray) : UpdateResult {
-  return awaitResult{
+suspend fun SQLOperations.updateWithParamsAwait(sql: String, params: JsonArray): UpdateResult {
+  return awaitResult {
     this.updateWithParams(sql, params, it)
   }
 }
 
 /**
- * Calls the given SQL <code>PROCEDURE</code> which returns the result from the procedure.
+ * Suspending version of method [io.vertx.ext.sql.SQLOperations.call]
  *
  * @param sql the SQL to execute. For example <code>{call getEmpName}</code>.
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.sql.SQLOperations original] using Vert.x codegen.
+ * @return [ResultSet]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLOperations] using Vert.x codegen.
  */
-suspend fun SQLOperations.callAwait(sql : String) : ResultSet {
-  return awaitResult{
+suspend fun SQLOperations.callAwait(sql: String): ResultSet {
+  return awaitResult {
     this.call(sql, it)
   }
 }
 
 /**
- * Calls the given SQL <code>PROCEDURE</code> which returns the result from the procedure.
- *
- * The index of params and outputs are important for both arrays, for example when dealing with a prodecure that
- * takes the first 2 arguments as input values and the 3 arg as an output then the arrays should be like:
- *
- * <pre>
- *   params = [VALUE1, VALUE2, null]
- *   outputs = [null, null, "VARCHAR"]
- * </pre>
+ * Suspending version of method [io.vertx.ext.sql.SQLOperations.callWithParams]
  *
  * @param sql the SQL to execute. For example <code>{call getEmpName (?, ?)}</code>.
  * @param params these are the parameters to fill the statement.
  * @param outputs these are the outputs to fill the statement.
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.sql.SQLOperations original] using Vert.x codegen.
+ * @return [ResultSet]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLOperations] using Vert.x codegen.
  */
-suspend fun SQLOperations.callWithParamsAwait(sql : String, params : JsonArray, outputs : JsonArray) : ResultSet {
-  return awaitResult{
+suspend fun SQLOperations.callWithParamsAwait(sql: String, params: JsonArray, outputs: JsonArray): ResultSet {
+  return awaitResult {
     this.callWithParams(sql, params, outputs, it)
   }
 }

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/sql/SQLRowStream.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/sql/SQLRowStream.kt
@@ -4,14 +4,14 @@ import io.vertx.ext.sql.SQLRowStream
 import io.vertx.kotlin.coroutines.awaitResult
 
 /**
- * Closes the stream/underlying cursor(s). The actual close happens asynchronously.
+ * Suspending version of method [io.vertx.ext.sql.SQLRowStream.close]
  *
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.sql.SQLRowStream original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLRowStream] using Vert.x codegen.
  */
-suspend fun SQLRowStream.closeAwait() : Unit {
-  return awaitResult{
-    this.close({ ar -> it.handle(ar.mapEmpty()) })}
+suspend fun SQLRowStream.closeAwait(): Unit {
+  return awaitResult {
+    this.close { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/stomp/StompClient.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/stomp/StompClient.kt
@@ -6,59 +6,59 @@ import io.vertx.ext.stomp.StompClientConnection
 import io.vertx.kotlin.coroutines.awaitResult
 
 /**
- * Connects to the server.
+ * Suspending version of method [io.vertx.ext.stomp.StompClient.connect]
  *
  * @param port the server port
  * @param host the server host
- * @return the current [io.vertx.ext.stomp.StompClient] *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.stomp.StompClient original] using Vert.x codegen.
+ * @return [StompClientConnection]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.stomp.StompClient] using Vert.x codegen.
  */
-suspend fun StompClient.connectAwait(port : Int, host : String) : StompClientConnection {
-  return awaitResult{
+suspend fun StompClient.connectAwait(port: Int, host: String): StompClientConnection {
+  return awaitResult {
     this.connect(port, host, it)
   }
 }
 
 /**
- * Connects to the server.
+ * Suspending version of method [io.vertx.ext.stomp.StompClient.connect]
  *
  * @param net the NET client to use
- * @return the current [io.vertx.ext.stomp.StompClient] *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.stomp.StompClient original] using Vert.x codegen.
+ * @return [StompClientConnection]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.stomp.StompClient] using Vert.x codegen.
  */
-suspend fun StompClient.connectAwait(net : NetClient) : StompClientConnection {
-  return awaitResult{
+suspend fun StompClient.connectAwait(net: NetClient): StompClientConnection {
+  return awaitResult {
     this.connect(net, it)
   }
 }
 
 /**
- * Connects to the server.
+ * Suspending version of method [io.vertx.ext.stomp.StompClient.connect]
  *
  * @param port the server port
  * @param host the server host
  * @param net the NET client to use
- * @return the current [io.vertx.ext.stomp.StompClient] *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.stomp.StompClient original] using Vert.x codegen.
+ * @return [StompClientConnection]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.stomp.StompClient] using Vert.x codegen.
  */
-suspend fun StompClient.connectAwait(port : Int, host : String, net : NetClient) : StompClientConnection {
-  return awaitResult{
+suspend fun StompClient.connectAwait(port: Int, host: String, net: NetClient): StompClientConnection {
+  return awaitResult {
     this.connect(port, host, net, it)
   }
 }
 
 /**
- * Connects to the server using the host and port configured in the client's options.
+ * Suspending version of method [io.vertx.ext.stomp.StompClient.connect]
  *
- * @return the current [io.vertx.ext.stomp.StompClient] *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.stomp.StompClient original] using Vert.x codegen.
+ * @return [StompClientConnection]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.stomp.StompClient] using Vert.x codegen.
  */
-suspend fun StompClient.connectAwait() : StompClientConnection {
-  return awaitResult{
+suspend fun StompClient.connectAwait(): StompClientConnection {
+  return awaitResult {
     this.connect(it)
   }
 }

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/stomp/StompServer.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/stomp/StompServer.kt
@@ -4,59 +4,56 @@ import io.vertx.ext.stomp.StompServer
 import io.vertx.kotlin.coroutines.awaitResult
 
 /**
- * Connects the STOMP server default port (61613) and network interface (<code>0.0.0.0</code>). Once the socket
- * it bounds calls the given handler with the result. The result may be a failure if the socket is already used.
+ * Suspending version of method [io.vertx.ext.stomp.StompServer.listen]
  *
- * @return the current [io.vertx.ext.stomp.StompServer] *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.stomp.StompServer original] using Vert.x codegen.
+ * @return [StompServer]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.stomp.StompServer] using Vert.x codegen.
  */
-suspend fun StompServer.listenAwait() : StompServer {
-  return awaitResult{
+suspend fun StompServer.listenAwait(): StompServer {
+  return awaitResult {
     this.listen(it)
   }
 }
 
 /**
- * Connects the STOMP server to the given port. This method use the default host (<code>0.0.0.0</code>). Once the socket
- * it bounds calls the given handler with the result. The result may be a failure if the socket is already used.
+ * Suspending version of method [io.vertx.ext.stomp.StompServer.listen]
  *
  * @param port the port
- * @return the current [io.vertx.ext.stomp.StompServer] *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.stomp.StompServer original] using Vert.x codegen.
+ * @return [StompServer]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.stomp.StompServer] using Vert.x codegen.
  */
-suspend fun StompServer.listenAwait(port : Int) : StompServer {
-  return awaitResult{
+suspend fun StompServer.listenAwait(port: Int): StompServer {
+  return awaitResult {
     this.listen(port, it)
   }
 }
 
 /**
- * Connects the STOMP server to the given port / interface. Once the socket it bounds calls the given handler with
- * the result. The result may be a failure if the socket is already used.
+ * Suspending version of method [io.vertx.ext.stomp.StompServer.listen]
  *
  * @param port the port
  * @param host the host / interface
- * @return the current [io.vertx.ext.stomp.StompServer] *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.stomp.StompServer original] using Vert.x codegen.
+ * @return [StompServer]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.stomp.StompServer] using Vert.x codegen.
  */
-suspend fun StompServer.listenAwait(port : Int, host : String) : StompServer {
-  return awaitResult{
+suspend fun StompServer.listenAwait(port: Int, host: String): StompServer {
+  return awaitResult {
     this.listen(port, host, it)
   }
 }
 
 /**
- * Closes the server.
+ * Suspending version of method [io.vertx.ext.stomp.StompServer.close]
  *
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.stomp.StompServer original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.ext.stomp.StompServer] using Vert.x codegen.
  */
-suspend fun StompServer.closeAwait() : Unit {
-  return awaitResult{
-    this.close({ ar -> it.handle(ar.mapEmpty()) })}
+suspend fun StompServer.closeAwait(): Unit {
+  return awaitResult {
+    this.close { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/stomp/StompServerHandler.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/stomp/StompServerHandler.kt
@@ -5,18 +5,17 @@ import io.vertx.ext.stomp.StompServerHandler
 import io.vertx.kotlin.coroutines.awaitResult
 
 /**
- * Called when the client connects to a server requiring authentication. It invokes the  configured
- * using [io.vertx.ext.stomp.StompServerHandler].
+ * Suspending version of method [io.vertx.ext.stomp.StompServerHandler.onAuthenticationRequest]
  *
  * @param connection server connection that contains session ID
  * @param login the login
  * @param passcode the password
- * @return the current [io.vertx.ext.stomp.StompServerHandler] *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.stomp.StompServerHandler original] using Vert.x codegen.
+ * @return [Boolean]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.stomp.StompServerHandler] using Vert.x codegen.
  */
-suspend fun StompServerHandler.onAuthenticationRequestAwait(connection : StompServerConnection, login : String, passcode : String) : Boolean {
-  return awaitResult{
+suspend fun StompServerHandler.onAuthenticationRequestAwait(connection: StompServerConnection, login: String, passcode: String): Boolean {
+  return awaitResult {
     this.onAuthenticationRequest(connection, login, passcode, it)
   }
 }

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/unit/Async.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/unit/Async.kt
@@ -4,14 +4,15 @@ import io.vertx.ext.unit.Async
 import io.vertx.kotlin.coroutines.awaitResult
 
 /**
- * Completion handler to receive a completion signal when this completions completes.
+ * Suspending version of method [io.vertx.ext.unit.Async.handler]
  *
+ * @return [Unit?]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.unit.Async original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.ext.unit.Async] using Vert.x codegen.
  */
-suspend fun Async.handlerAwait() : Unit? {
-  return awaitResult{
-    this.handler({ ar -> it.handle(ar.mapEmpty()) })}
+suspend fun Async.handlerAwait(): Unit? {
+  return awaitResult {
+    this.handler { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/unit/Completion.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/unit/Completion.kt
@@ -4,14 +4,14 @@ import io.vertx.ext.unit.Completion
 import io.vertx.kotlin.coroutines.awaitResult
 
 /**
- * Completion handler to receive a completion signal when this completions completes.
+ * Suspending version of method [io.vertx.ext.unit.Completion.handler]
  *
+ * @return [T?]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.unit.Completion original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.ext.unit.Completion] using Vert.x codegen.
  */
-suspend fun <T> Completion<T>.handlerAwait() : T? {
-  return awaitResult{
+suspend fun <T> Completion<T>.handlerAwait(): T? {
+  return awaitResult {
     this.handler(it)
   }
 }

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/unit/TestCompletion.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/unit/TestCompletion.kt
@@ -4,14 +4,15 @@ import io.vertx.ext.unit.TestCompletion
 import io.vertx.kotlin.coroutines.awaitResult
 
 /**
- * Completion handler to receive a completion signal when this completions completes.
+ * Suspending version of method [io.vertx.ext.unit.TestCompletion.handler]
  *
+ * @return [Unit?]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.unit.TestCompletion original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.ext.unit.TestCompletion] using Vert.x codegen.
  */
-suspend fun TestCompletion.handlerAwait() : Unit? {
-  return awaitResult{
-    this.handler({ ar -> it.handle(ar.mapEmpty()) })}
+suspend fun TestCompletion.handlerAwait(): Unit? {
+  return awaitResult {
+    this.handler { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/web/api/contract/openapi3/OpenAPI3RouterFactory.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/web/api/contract/openapi3/OpenAPI3RouterFactory.kt
@@ -7,32 +7,32 @@ import io.vertx.kotlin.coroutines.awaitResult
 
 object OpenAPI3RouterFactory {
   /**
-   * Create a new OpenAPI3RouterFactory
+   * Suspending version of method [io.vertx.ext.web.api.contract.openapi3.OpenAPI3RouterFactory.create]
    *
    * @param vertx 
    * @param url location of your spec. It can be an absolute path, a local path or remote url (with HTTP protocol)
+   * @return [OpenAPI3RouterFactoryVertxAlias]
    *
-   * <p/>
-   * NOTE: This function has been automatically generated from the [io.vertx.ext.web.api.contract.openapi3.OpenAPI3RouterFactory original] using Vert.x codegen.
+   * NOTE: This function has been automatically generated from [io.vertx.ext.web.api.contract.openapi3.OpenAPI3RouterFactory] using Vert.x codegen.
    */
-  suspend fun createAwait(vertx : Vertx, url : String) : OpenAPI3RouterFactoryVertxAlias {
-    return awaitResult{
+  suspend fun createAwait(vertx: Vertx, url: String): OpenAPI3RouterFactoryVertxAlias {
+    return awaitResult {
       OpenAPI3RouterFactoryVertxAlias.create(vertx, url, it)
     }
   }
 
   /**
-   * Create a new OpenAPI3RouterFactory
+   * Suspending version of method [io.vertx.ext.web.api.contract.openapi3.OpenAPI3RouterFactory.create]
    *
    * @param vertx 
    * @param url location of your spec. It can be an absolute path, a local path or remote url (with HTTP protocol)
    * @param auth list of authorization values needed to access the remote url. Each item should be json representation of an 
+   * @return [OpenAPI3RouterFactoryVertxAlias]
    *
-   * <p/>
-   * NOTE: This function has been automatically generated from the [io.vertx.ext.web.api.contract.openapi3.OpenAPI3RouterFactory original] using Vert.x codegen.
+   * NOTE: This function has been automatically generated from [io.vertx.ext.web.api.contract.openapi3.OpenAPI3RouterFactory] using Vert.x codegen.
    */
-  suspend fun createAwait(vertx : Vertx, url : String, auth : List<JsonObject>) : OpenAPI3RouterFactoryVertxAlias {
-    return awaitResult{
+  suspend fun createAwait(vertx: Vertx, url: String, auth: List<JsonObject>): OpenAPI3RouterFactoryVertxAlias {
+    return awaitResult {
       OpenAPI3RouterFactoryVertxAlias.create(vertx, url, auth, it)
     }
   }

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/web/client/HttpRequest.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/web/client/HttpRequest.kt
@@ -10,104 +10,98 @@ import io.vertx.ext.web.multipart.MultipartForm
 import io.vertx.kotlin.coroutines.awaitResult
 
 /**
- * Like [io.vertx.ext.web.client.HttpRequest] but with an HTTP request <code>body</code> stream.
+ * Suspending version of method [io.vertx.ext.web.client.HttpRequest.sendStream]
  *
  * @param body the body
+ * @return [HttpResponse<T>]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.web.client.HttpRequest original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.ext.web.client.HttpRequest] using Vert.x codegen.
  */
-suspend fun <T> HttpRequest<T>.sendStreamAwait(body : ReadStream<Buffer>) : HttpResponse<T> {
-  return awaitResult{
+suspend fun <T> HttpRequest<T>.sendStreamAwait(body: ReadStream<Buffer>): HttpResponse<T> {
+  return awaitResult {
     this.sendStream(body, it)
   }
 }
 
 /**
- * Like [io.vertx.ext.web.client.HttpRequest] but with an HTTP request <code>body</code> buffer.
+ * Suspending version of method [io.vertx.ext.web.client.HttpRequest.sendBuffer]
  *
  * @param body the body
+ * @return [HttpResponse<T>]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.web.client.HttpRequest original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.ext.web.client.HttpRequest] using Vert.x codegen.
  */
-suspend fun <T> HttpRequest<T>.sendBufferAwait(body : Buffer) : HttpResponse<T> {
-  return awaitResult{
+suspend fun <T> HttpRequest<T>.sendBufferAwait(body: Buffer): HttpResponse<T> {
+  return awaitResult {
     this.sendBuffer(body, it)
   }
 }
 
 /**
- * Like [io.vertx.ext.web.client.HttpRequest] but with an HTTP request <code>body</code> object encoded as json and the content type
- * set to <code>application/json</code>.
+ * Suspending version of method [io.vertx.ext.web.client.HttpRequest.sendJsonObject]
  *
  * @param body the body
+ * @return [HttpResponse<T>]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.web.client.HttpRequest original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.ext.web.client.HttpRequest] using Vert.x codegen.
  */
-suspend fun <T> HttpRequest<T>.sendJsonObjectAwait(body : JsonObject) : HttpResponse<T> {
-  return awaitResult{
+suspend fun <T> HttpRequest<T>.sendJsonObjectAwait(body: JsonObject): HttpResponse<T> {
+  return awaitResult {
     this.sendJsonObject(body, it)
   }
 }
 
 /**
- * Like [io.vertx.ext.web.client.HttpRequest] but with an HTTP request <code>body</code> object encoded as json and the content type
- * set to <code>application/json</code>.
+ * Suspending version of method [io.vertx.ext.web.client.HttpRequest.sendJson]
  *
  * @param body the body
+ * @return [HttpResponse<T>]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.web.client.HttpRequest original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.ext.web.client.HttpRequest] using Vert.x codegen.
  */
-suspend fun <T> HttpRequest<T>.sendJsonAwait(body : Any) : HttpResponse<T> {
-  return awaitResult{
+suspend fun <T> HttpRequest<T>.sendJsonAwait(body: Any): HttpResponse<T> {
+  return awaitResult {
     this.sendJson(body, it)
   }
 }
 
 /**
- * Like [io.vertx.ext.web.client.HttpRequest] but with an HTTP request <code>body</code> multimap encoded as form and the content type
- * set to <code>application/x-www-form-urlencoded</code>.
- * <p>
- * When the content type header is previously set to <code>multipart/form-data</code> it will be used instead.
+ * Suspending version of method [io.vertx.ext.web.client.HttpRequest.sendForm]
  *
  * @param body the body
+ * @return [HttpResponse<T>]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.web.client.HttpRequest original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.ext.web.client.HttpRequest] using Vert.x codegen.
  */
-suspend fun <T> HttpRequest<T>.sendFormAwait(body : MultiMap) : HttpResponse<T> {
-  return awaitResult{
+suspend fun <T> HttpRequest<T>.sendFormAwait(body: MultiMap): HttpResponse<T> {
+  return awaitResult {
     this.sendForm(body, it)
   }
 }
 
 /**
- * Like [io.vertx.ext.web.client.HttpRequest] but with an HTTP request <code>body</code> multimap encoded as form and the content type
- * set to <code>multipart/form-data</code>. You may use this method to send attributes and upload files.
+ * Suspending version of method [io.vertx.ext.web.client.HttpRequest.sendMultipartForm]
  *
  * @param body the body
+ * @return [HttpResponse<T>]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.web.client.HttpRequest original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.ext.web.client.HttpRequest] using Vert.x codegen.
  */
-suspend fun <T> HttpRequest<T>.sendMultipartFormAwait(body : MultipartForm) : HttpResponse<T> {
-  return awaitResult{
+suspend fun <T> HttpRequest<T>.sendMultipartFormAwait(body: MultipartForm): HttpResponse<T> {
+  return awaitResult {
     this.sendMultipartForm(body, it)
   }
 }
 
 /**
- * Send a request, the <code>handler</code> will receive the response as an [io.vertx.ext.web.client.HttpResponse].
+ * Suspending version of method [io.vertx.ext.web.client.HttpRequest.send]
  *
+ * @return [HttpResponse<T>]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.web.client.HttpRequest original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.ext.web.client.HttpRequest] using Vert.x codegen.
  */
-suspend fun <T> HttpRequest<T>.sendAwait() : HttpResponse<T> {
-  return awaitResult{
+suspend fun <T> HttpRequest<T>.sendAwait(): HttpResponse<T> {
+  return awaitResult {
     this.send(it)
   }
 }

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/web/common/template/TemplateEngine.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/web/common/template/TemplateEngine.kt
@@ -6,39 +6,31 @@ import io.vertx.ext.web.common.template.TemplateEngine
 import io.vertx.kotlin.coroutines.awaitResult
 
 /**
- * Render the template. Template engines that support partials/fragments should extract the template base path from
- * the template filename up to the last file separator.
- *
- * Some engines support localization, for these engines, there is a predefined key "lang" to specify the language to
- * be used in the localization, the format should follow the standard locale formats e.g.: "en-gb", "pt-br", "en".
+ * Suspending version of method [io.vertx.ext.web.common.template.TemplateEngine.render]
  *
  * @param context the routing context
  * @param templateFileName the template file name to use
+ * @return [Buffer]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.web.common.template.TemplateEngine original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.ext.web.common.template.TemplateEngine] using Vert.x codegen.
  */
-suspend fun TemplateEngine.renderAwait(context : JsonObject, templateFileName : String) : Buffer {
-  return awaitResult{
+suspend fun TemplateEngine.renderAwait(context: JsonObject, templateFileName: String): Buffer {
+  return awaitResult {
     this.render(context, templateFileName, it)
   }
 }
 
 /**
- * Render the template. Template engines that support partials/fragments should extract the template base path from
- * the template filename up to the last file separator.
- *
- * Some engines support localization, for these engines, there is a predefined key "lang" to specify the language to
- * be used in the localization, the format should follow the standard locale formats e.g.: "en-gb", "pt-br", "en".
+ * Suspending version of method [io.vertx.ext.web.common.template.TemplateEngine.render]
  *
  * @param context the routing context
  * @param templateFileName the template file name to use
+ * @return [Buffer]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.web.common.template.TemplateEngine original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.ext.web.common.template.TemplateEngine] using Vert.x codegen.
  */
-suspend fun TemplateEngine.renderAwait(context : Map<String,Any>, templateFileName : String) : Buffer {
-  return awaitResult{
+suspend fun TemplateEngine.renderAwait(context: Map<String,Any>, templateFileName: String): Buffer {
+  return awaitResult {
     this.render(context, templateFileName, it)
   }
 }

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/web/handler/AuthHandler.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/web/handler/AuthHandler.kt
@@ -7,31 +7,29 @@ import io.vertx.ext.web.handler.AuthHandler
 import io.vertx.kotlin.coroutines.awaitResult
 
 /**
- * Parses the credentials from the request into a JsonObject. The implementation should
- * be able to extract the required info for the auth provider in the format the provider
- * expects.
+ * Suspending version of method [io.vertx.ext.web.handler.AuthHandler.parseCredentials]
  *
  * @param context the routing context
+ * @return [JsonObject]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.web.handler.AuthHandler original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.ext.web.handler.AuthHandler] using Vert.x codegen.
  */
-suspend fun AuthHandler.parseCredentialsAwait(context : RoutingContext) : JsonObject {
-  return awaitResult{
+suspend fun AuthHandler.parseCredentialsAwait(context: RoutingContext): JsonObject {
+  return awaitResult {
     this.parseCredentials(context, it)
   }
 }
 
 /**
- * Authorizes the given user against all added authorities.
+ * Suspending version of method [io.vertx.ext.web.handler.AuthHandler.authorize]
  *
  * @param user a user.
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.web.handler.AuthHandler original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.ext.web.handler.AuthHandler] using Vert.x codegen.
  */
-suspend fun AuthHandler.authorizeAwait(user : User) : Unit {
-  return awaitResult{
-    this.authorize(user, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun AuthHandler.authorizeAwait(user: User): Unit {
+  return awaitResult {
+    this.authorize(user) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/web/handler/BasicAuthHandler.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/web/handler/BasicAuthHandler.kt
@@ -7,31 +7,29 @@ import io.vertx.ext.web.handler.BasicAuthHandler
 import io.vertx.kotlin.coroutines.awaitResult
 
 /**
- * Parses the credentials from the request into a JsonObject. The implementation should
- * be able to extract the required info for the auth provider in the format the provider
- * expects.
+ * Suspending version of method [io.vertx.ext.web.handler.BasicAuthHandler.parseCredentials]
  *
  * @param context the routing context
+ * @return [JsonObject]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.web.handler.BasicAuthHandler original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.ext.web.handler.BasicAuthHandler] using Vert.x codegen.
  */
-suspend fun BasicAuthHandler.parseCredentialsAwait(context : RoutingContext) : JsonObject {
-  return awaitResult{
+suspend fun BasicAuthHandler.parseCredentialsAwait(context: RoutingContext): JsonObject {
+  return awaitResult {
     this.parseCredentials(context, it)
   }
 }
 
 /**
- * Authorizes the given user against all added authorities.
+ * Suspending version of method [io.vertx.ext.web.handler.BasicAuthHandler.authorize]
  *
  * @param user a user.
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.web.handler.BasicAuthHandler original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.ext.web.handler.BasicAuthHandler] using Vert.x codegen.
  */
-suspend fun BasicAuthHandler.authorizeAwait(user : User) : Unit {
-  return awaitResult{
-    this.authorize(user, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun BasicAuthHandler.authorizeAwait(user: User): Unit {
+  return awaitResult {
+    this.authorize(user) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/web/handler/ChainAuthHandler.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/web/handler/ChainAuthHandler.kt
@@ -7,31 +7,29 @@ import io.vertx.ext.web.handler.ChainAuthHandler
 import io.vertx.kotlin.coroutines.awaitResult
 
 /**
- * Parses the credentials from the request into a JsonObject. The implementation should
- * be able to extract the required info for the auth provider in the format the provider
- * expects.
+ * Suspending version of method [io.vertx.ext.web.handler.ChainAuthHandler.parseCredentials]
  *
  * @param context the routing context
+ * @return [JsonObject]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.web.handler.ChainAuthHandler original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.ext.web.handler.ChainAuthHandler] using Vert.x codegen.
  */
-suspend fun ChainAuthHandler.parseCredentialsAwait(context : RoutingContext) : JsonObject {
-  return awaitResult{
+suspend fun ChainAuthHandler.parseCredentialsAwait(context: RoutingContext): JsonObject {
+  return awaitResult {
     this.parseCredentials(context, it)
   }
 }
 
 /**
- * Authorizes the given user against all added authorities.
+ * Suspending version of method [io.vertx.ext.web.handler.ChainAuthHandler.authorize]
  *
  * @param user a user.
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.web.handler.ChainAuthHandler original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.ext.web.handler.ChainAuthHandler] using Vert.x codegen.
  */
-suspend fun ChainAuthHandler.authorizeAwait(user : User) : Unit {
-  return awaitResult{
-    this.authorize(user, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun ChainAuthHandler.authorizeAwait(user: User): Unit {
+  return awaitResult {
+    this.authorize(user) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/web/handler/DigestAuthHandler.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/web/handler/DigestAuthHandler.kt
@@ -7,31 +7,29 @@ import io.vertx.ext.web.handler.DigestAuthHandler
 import io.vertx.kotlin.coroutines.awaitResult
 
 /**
- * Parses the credentials from the request into a JsonObject. The implementation should
- * be able to extract the required info for the auth provider in the format the provider
- * expects.
+ * Suspending version of method [io.vertx.ext.web.handler.DigestAuthHandler.parseCredentials]
  *
  * @param context the routing context
+ * @return [JsonObject]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.web.handler.DigestAuthHandler original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.ext.web.handler.DigestAuthHandler] using Vert.x codegen.
  */
-suspend fun DigestAuthHandler.parseCredentialsAwait(context : RoutingContext) : JsonObject {
-  return awaitResult{
+suspend fun DigestAuthHandler.parseCredentialsAwait(context: RoutingContext): JsonObject {
+  return awaitResult {
     this.parseCredentials(context, it)
   }
 }
 
 /**
- * Authorizes the given user against all added authorities.
+ * Suspending version of method [io.vertx.ext.web.handler.DigestAuthHandler.authorize]
  *
  * @param user a user.
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.web.handler.DigestAuthHandler original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.ext.web.handler.DigestAuthHandler] using Vert.x codegen.
  */
-suspend fun DigestAuthHandler.authorizeAwait(user : User) : Unit {
-  return awaitResult{
-    this.authorize(user, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun DigestAuthHandler.authorizeAwait(user: User): Unit {
+  return awaitResult {
+    this.authorize(user) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/web/handler/JWTAuthHandler.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/web/handler/JWTAuthHandler.kt
@@ -7,31 +7,29 @@ import io.vertx.ext.web.handler.JWTAuthHandler
 import io.vertx.kotlin.coroutines.awaitResult
 
 /**
- * Parses the credentials from the request into a JsonObject. The implementation should
- * be able to extract the required info for the auth provider in the format the provider
- * expects.
+ * Suspending version of method [io.vertx.ext.web.handler.JWTAuthHandler.parseCredentials]
  *
  * @param context the routing context
+ * @return [JsonObject]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.web.handler.JWTAuthHandler original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.ext.web.handler.JWTAuthHandler] using Vert.x codegen.
  */
-suspend fun JWTAuthHandler.parseCredentialsAwait(context : RoutingContext) : JsonObject {
-  return awaitResult{
+suspend fun JWTAuthHandler.parseCredentialsAwait(context: RoutingContext): JsonObject {
+  return awaitResult {
     this.parseCredentials(context, it)
   }
 }
 
 /**
- * Authorizes the given user against all added authorities.
+ * Suspending version of method [io.vertx.ext.web.handler.JWTAuthHandler.authorize]
  *
  * @param user a user.
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.web.handler.JWTAuthHandler original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.ext.web.handler.JWTAuthHandler] using Vert.x codegen.
  */
-suspend fun JWTAuthHandler.authorizeAwait(user : User) : Unit {
-  return awaitResult{
-    this.authorize(user, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun JWTAuthHandler.authorizeAwait(user: User): Unit {
+  return awaitResult {
+    this.authorize(user) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/web/handler/OAuth2AuthHandler.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/web/handler/OAuth2AuthHandler.kt
@@ -7,31 +7,29 @@ import io.vertx.ext.web.handler.OAuth2AuthHandler
 import io.vertx.kotlin.coroutines.awaitResult
 
 /**
- * Parses the credentials from the request into a JsonObject. The implementation should
- * be able to extract the required info for the auth provider in the format the provider
- * expects.
+ * Suspending version of method [io.vertx.ext.web.handler.OAuth2AuthHandler.parseCredentials]
  *
  * @param context the routing context
+ * @return [JsonObject]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.web.handler.OAuth2AuthHandler original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.ext.web.handler.OAuth2AuthHandler] using Vert.x codegen.
  */
-suspend fun OAuth2AuthHandler.parseCredentialsAwait(context : RoutingContext) : JsonObject {
-  return awaitResult{
+suspend fun OAuth2AuthHandler.parseCredentialsAwait(context: RoutingContext): JsonObject {
+  return awaitResult {
     this.parseCredentials(context, it)
   }
 }
 
 /**
- * Authorizes the given user against all added authorities.
+ * Suspending version of method [io.vertx.ext.web.handler.OAuth2AuthHandler.authorize]
  *
  * @param user a user.
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.web.handler.OAuth2AuthHandler original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.ext.web.handler.OAuth2AuthHandler] using Vert.x codegen.
  */
-suspend fun OAuth2AuthHandler.authorizeAwait(user : User) : Unit {
-  return awaitResult{
-    this.authorize(user, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun OAuth2AuthHandler.authorizeAwait(user: User): Unit {
+  return awaitResult {
+    this.authorize(user) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/web/handler/RedirectAuthHandler.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/web/handler/RedirectAuthHandler.kt
@@ -7,31 +7,29 @@ import io.vertx.ext.web.handler.RedirectAuthHandler
 import io.vertx.kotlin.coroutines.awaitResult
 
 /**
- * Parses the credentials from the request into a JsonObject. The implementation should
- * be able to extract the required info for the auth provider in the format the provider
- * expects.
+ * Suspending version of method [io.vertx.ext.web.handler.RedirectAuthHandler.parseCredentials]
  *
  * @param context the routing context
+ * @return [JsonObject]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.web.handler.RedirectAuthHandler original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.ext.web.handler.RedirectAuthHandler] using Vert.x codegen.
  */
-suspend fun RedirectAuthHandler.parseCredentialsAwait(context : RoutingContext) : JsonObject {
-  return awaitResult{
+suspend fun RedirectAuthHandler.parseCredentialsAwait(context: RoutingContext): JsonObject {
+  return awaitResult {
     this.parseCredentials(context, it)
   }
 }
 
 /**
- * Authorizes the given user against all added authorities.
+ * Suspending version of method [io.vertx.ext.web.handler.RedirectAuthHandler.authorize]
  *
  * @param user a user.
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.web.handler.RedirectAuthHandler original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.ext.web.handler.RedirectAuthHandler] using Vert.x codegen.
  */
-suspend fun RedirectAuthHandler.authorizeAwait(user : User) : Unit {
-  return awaitResult{
-    this.authorize(user, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun RedirectAuthHandler.authorizeAwait(user: User): Unit {
+  return awaitResult {
+    this.authorize(user) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/web/handler/sockjs/BridgeEvent.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/web/handler/sockjs/BridgeEvent.kt
@@ -4,17 +4,14 @@ import io.vertx.ext.web.handler.sockjs.BridgeEvent
 import io.vertx.kotlin.coroutines.awaitResult
 
 /**
- * Set a handler for the result.
- * <p>
- * If the future has already been completed it will be called immediately. Otherwise it will be called when the
- * future is completed.
+ * Suspending version of method [io.vertx.ext.web.handler.sockjs.BridgeEvent.setHandler]
  *
- * @return a reference to this, so it can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.web.handler.sockjs.BridgeEvent original] using Vert.x codegen.
+ * @return [Boolean]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.web.handler.sockjs.BridgeEvent] using Vert.x codegen.
  */
-suspend fun BridgeEvent.setHandlerAwait() : Boolean {
-  return awaitResult{
+suspend fun BridgeEvent.setHandlerAwait(): Boolean {
+  return awaitResult {
     this.setHandler(it)
   }
 }

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/web/sstore/SessionStore.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/web/sstore/SessionStore.kt
@@ -5,68 +5,66 @@ import io.vertx.ext.web.sstore.SessionStore
 import io.vertx.kotlin.coroutines.awaitResult
 
 /**
- * Get the session with the specified ID.
+ * Suspending version of method [io.vertx.ext.web.sstore.SessionStore.get]
  *
  * @param cookieValue the unique ID of the session
+ * @return [Session?]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.web.sstore.SessionStore original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.ext.web.sstore.SessionStore] using Vert.x codegen.
  */
-suspend fun SessionStore.getAwait(cookieValue : String) : Session? {
-  return awaitResult{
+suspend fun SessionStore.getAwait(cookieValue: String): Session? {
+  return awaitResult {
     this.get(cookieValue, it)
   }
 }
 
 /**
- * Delete the session with the specified ID.
+ * Suspending version of method [io.vertx.ext.web.sstore.SessionStore.delete]
  *
  * @param id the session id
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.web.sstore.SessionStore original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.ext.web.sstore.SessionStore] using Vert.x codegen.
  */
-suspend fun SessionStore.deleteAwait(id : String) : Unit {
-  return awaitResult{
-    this.delete(id, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun SessionStore.deleteAwait(id: String): Unit {
+  return awaitResult {
+    this.delete(id) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Add a session with the specified ID.
+ * Suspending version of method [io.vertx.ext.web.sstore.SessionStore.put]
  *
  * @param session the session
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.web.sstore.SessionStore original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.ext.web.sstore.SessionStore] using Vert.x codegen.
  */
-suspend fun SessionStore.putAwait(session : Session) : Unit {
-  return awaitResult{
-    this.put(session, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun SessionStore.putAwait(session: Session): Unit {
+  return awaitResult {
+    this.put(session) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Remove all sessions from the store.
+ * Suspending version of method [io.vertx.ext.web.sstore.SessionStore.clear]
  *
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.web.sstore.SessionStore original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.ext.web.sstore.SessionStore] using Vert.x codegen.
  */
-suspend fun SessionStore.clearAwait() : Unit {
-  return awaitResult{
-    this.clear({ ar -> it.handle(ar.mapEmpty()) })}
+suspend fun SessionStore.clearAwait(): Unit {
+  return awaitResult {
+    this.clear { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Get the number of sessions in the store.
- * <p>
- * Beware of the result which is just an estimate, in particular with distributed session stores.
+ * Suspending version of method [io.vertx.ext.web.sstore.SessionStore.size]
  *
+ * @return [Int]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.ext.web.sstore.SessionStore original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.ext.web.sstore.SessionStore] using Vert.x codegen.
  */
-suspend fun SessionStore.sizeAwait() : Int {
-  return awaitResult{
+suspend fun SessionStore.sizeAwait(): Int {
+  return awaitResult {
     this.size(it)
   }
 }

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/kafka/admin/AdminUtils.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/kafka/admin/AdminUtils.kt
@@ -4,90 +4,86 @@ import io.vertx.kafka.admin.AdminUtils
 import io.vertx.kotlin.coroutines.awaitResult
 
 /**
- * Creates a new Kafka topic on all Brokers managed by the given Zookeeper instance(s)
+ * Suspending version of method [io.vertx.kafka.admin.AdminUtils.createTopic]
  *
  * @param topicName Name of the to-be-created topic
  * @param partitionCount Number of partitions
  * @param replicationFactor Number of replicates. Must be lower or equal to the number of available Brokers
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.kafka.admin.AdminUtils original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.kafka.admin.AdminUtils] using Vert.x codegen.
  */
-suspend fun AdminUtils.createTopicAwait(topicName : String, partitionCount : Int, replicationFactor : Int) : Unit {
-  return awaitResult{
-    this.createTopic(topicName, partitionCount, replicationFactor, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun AdminUtils.createTopicAwait(topicName: String, partitionCount: Int, replicationFactor: Int): Unit {
+  return awaitResult {
+    this.createTopic(topicName, partitionCount, replicationFactor) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Creates a new Kafka topic on all Brokers managed by the given Zookeeper instance(s). In contrast
- * to @see [io.vertx.kafka.admin.AdminUtils], one can pass in additional configuration
- * parameters as a map (String -> String).
+ * Suspending version of method [io.vertx.kafka.admin.AdminUtils.createTopic]
  *
  * @param topicName Name of the to-be-created topic
  * @param partitionCount Number of partitions
  * @param replicationFactor Number of replicates. Must be lower or equal to the number of available Brokers
  * @param topicConfig map with additional topic configuration parameters
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.kafka.admin.AdminUtils original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.kafka.admin.AdminUtils] using Vert.x codegen.
  */
-suspend fun AdminUtils.createTopicAwait(topicName : String, partitionCount : Int, replicationFactor : Int, topicConfig : Map<String,String>) : Unit {
-  return awaitResult{
-    this.createTopic(topicName, partitionCount, replicationFactor, topicConfig, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun AdminUtils.createTopicAwait(topicName: String, partitionCount: Int, replicationFactor: Int, topicConfig: Map<String,String>): Unit {
+  return awaitResult {
+    this.createTopic(topicName, partitionCount, replicationFactor, topicConfig) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Delete the Kafka topic given by the topicName.
+ * Suspending version of method [io.vertx.kafka.admin.AdminUtils.deleteTopic]
  *
  * @param topicName Name of the topic to be deleted
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.kafka.admin.AdminUtils original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.kafka.admin.AdminUtils] using Vert.x codegen.
  */
-suspend fun AdminUtils.deleteTopicAwait(topicName : String) : Unit {
-  return awaitResult{
-    this.deleteTopic(topicName, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun AdminUtils.deleteTopicAwait(topicName: String): Unit {
+  return awaitResult {
+    this.deleteTopic(topicName) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Checks if the Kafka topic given by topicName does exist.
+ * Suspending version of method [io.vertx.kafka.admin.AdminUtils.topicExists]
  *
  * @param topicName Name of the topic
+ * @return [Boolean]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.kafka.admin.AdminUtils original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.kafka.admin.AdminUtils] using Vert.x codegen.
  */
-suspend fun AdminUtils.topicExistsAwait(topicName : String) : Boolean {
-  return awaitResult{
+suspend fun AdminUtils.topicExistsAwait(topicName: String): Boolean {
+  return awaitResult {
     this.topicExists(topicName, it)
   }
 }
 
 /**
- * Updates the configuration of the topic given by topicName. Configuration parameters
- * are passed in as a Map (Key -> Value) of Strings.
+ * Suspending version of method [io.vertx.kafka.admin.AdminUtils.changeTopicConfig]
  *
  * @param topicName topic to be configured
  * @param topicConfig Map with configuration items
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.kafka.admin.AdminUtils original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.kafka.admin.AdminUtils] using Vert.x codegen.
  */
-suspend fun AdminUtils.changeTopicConfigAwait(topicName : String, topicConfig : Map<String,String>) : Unit {
-  return awaitResult{
-    this.changeTopicConfig(topicName, topicConfig, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun AdminUtils.changeTopicConfigAwait(topicName: String, topicConfig: Map<String,String>): Unit {
+  return awaitResult {
+    this.changeTopicConfig(topicName, topicConfig) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Closes the underlying connection to Zookeeper. It is required to call the method for cleanup
- * purposes if AdminUtils was not created with autoClose set to true.
+ * Suspending version of method [io.vertx.kafka.admin.AdminUtils.close]
  *
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.kafka.admin.AdminUtils original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.kafka.admin.AdminUtils] using Vert.x codegen.
  */
-suspend fun AdminUtils.closeAwait() : Unit {
-  return awaitResult{
-    this.close({ ar -> it.handle(ar.mapEmpty()) })}
+suspend fun AdminUtils.closeAwait(): Unit {
+  return awaitResult {
+    this.close { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/kafka/client/consumer/KafkaConsumer.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/kafka/client/consumer/KafkaConsumer.kt
@@ -9,435 +9,345 @@ import io.vertx.kafka.client.consumer.OffsetAndTimestamp
 import io.vertx.kotlin.coroutines.awaitResult
 
 /**
- * Subscribe to the given topic to get dynamically assigned partitions.
- * <p>
- * Due to internal buffering of messages, when changing the subscribed topic
- * the old topic may remain in effect
- * (as observed by the  record handler})
- * until some time <em>after</em> the given <code>completionHandler</code>
- * is called. In contrast, the once the given <code>completionHandler</code>
- * is called the [io.vertx.kafka.client.consumer.KafkaConsumer] will only see messages
- * consistent with the new topic.
+ * Suspending version of method [io.vertx.kafka.client.consumer.KafkaConsumer.subscribe]
  *
  * @param topic topic to subscribe to
- * @return current KafkaConsumer instance *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.kafka.client.consumer.KafkaConsumer original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.kafka.client.consumer.KafkaConsumer] using Vert.x codegen.
  */
-suspend fun <K,V> KafkaConsumer<K,V>.subscribeAwait(topic : String) : Unit {
-  return awaitResult{
-    this.subscribe(topic, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun <K,V> KafkaConsumer<K,V>.subscribeAwait(topic: String): Unit {
+  return awaitResult {
+    this.subscribe(topic) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Subscribe to the given list of topics to get dynamically assigned partitions.
- * <p>
- * Due to internal buffering of messages, when changing the subscribed topics
- * the old set of topics may remain in effect
- * (as observed by the  record handler})
- * until some time <em>after</em> the given <code>completionHandler</code>
- * is called. In contrast, the once the given <code>completionHandler</code>
- * is called the [io.vertx.kafka.client.consumer.KafkaConsumer] will only see messages
- * consistent with the new set of topics.
+ * Suspending version of method [io.vertx.kafka.client.consumer.KafkaConsumer.subscribe]
  *
  * @param topics topics to subscribe to
- * @return current KafkaConsumer instance *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.kafka.client.consumer.KafkaConsumer original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.kafka.client.consumer.KafkaConsumer] using Vert.x codegen.
  */
-suspend fun <K,V> KafkaConsumer<K,V>.subscribeAwait(topics : Set<String>) : Unit {
-  return awaitResult{
-    this.subscribe(topics, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun <K,V> KafkaConsumer<K,V>.subscribeAwait(topics: Set<String>): Unit {
+  return awaitResult {
+    this.subscribe(topics) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Manually assign a partition to this consumer.
- * <p>
- * Due to internal buffering of messages, when reassigning
- * the old partition may remain in effect
- * (as observed by the  record handler)}
- * until some time <em>after</em> the given <code>completionHandler</code>
- * is called. In contrast, the once the given <code>completionHandler</code>
- * is called the [io.vertx.kafka.client.consumer.KafkaConsumer] will only see messages
- * consistent with the new partition.
+ * Suspending version of method [io.vertx.kafka.client.consumer.KafkaConsumer.assign]
  *
  * @param topicPartition partition which want assigned
- * @return current KafkaConsumer instance *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.kafka.client.consumer.KafkaConsumer original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.kafka.client.consumer.KafkaConsumer] using Vert.x codegen.
  */
-suspend fun <K,V> KafkaConsumer<K,V>.assignAwait(topicPartition : TopicPartition) : Unit {
-  return awaitResult{
-    this.assign(topicPartition, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun <K,V> KafkaConsumer<K,V>.assignAwait(topicPartition: TopicPartition): Unit {
+  return awaitResult {
+    this.assign(topicPartition) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Manually assign a list of partition to this consumer.
- * <p>
- * Due to internal buffering of messages, when reassigning
- * the old set of partitions may remain in effect
- * (as observed by the  record handler)}
- * until some time <em>after</em> the given <code>completionHandler</code>
- * is called. In contrast, the once the given <code>completionHandler</code>
- * is called the [io.vertx.kafka.client.consumer.KafkaConsumer] will only see messages
- * consistent with the new set of partitions.
+ * Suspending version of method [io.vertx.kafka.client.consumer.KafkaConsumer.assign]
  *
  * @param topicPartitions partitions which want assigned
- * @return current KafkaConsumer instance *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.kafka.client.consumer.KafkaConsumer original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.kafka.client.consumer.KafkaConsumer] using Vert.x codegen.
  */
-suspend fun <K,V> KafkaConsumer<K,V>.assignAwait(topicPartitions : Set<TopicPartition>) : Unit {
-  return awaitResult{
-    this.assign(topicPartitions, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun <K,V> KafkaConsumer<K,V>.assignAwait(topicPartitions: Set<TopicPartition>): Unit {
+  return awaitResult {
+    this.assign(topicPartitions) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Get the set of partitions currently assigned to this consumer.
+ * Suspending version of method [io.vertx.kafka.client.consumer.KafkaConsumer.assignment]
  *
- * @return current KafkaConsumer instance *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.kafka.client.consumer.KafkaConsumer original] using Vert.x codegen.
+ * @return [Set<TopicPartition>]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.kafka.client.consumer.KafkaConsumer] using Vert.x codegen.
  */
-suspend fun <K,V> KafkaConsumer<K,V>.assignmentAwait() : Set<TopicPartition> {
-  return awaitResult{
+suspend fun <K,V> KafkaConsumer<K,V>.assignmentAwait(): Set<TopicPartition> {
+  return awaitResult {
     this.assignment(it)
   }
 }
 
 /**
- * Unsubscribe from topics currently subscribed with subscribe.
+ * Suspending version of method [io.vertx.kafka.client.consumer.KafkaConsumer.unsubscribe]
  *
- * @return current KafkaConsumer instance *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.kafka.client.consumer.KafkaConsumer original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.kafka.client.consumer.KafkaConsumer] using Vert.x codegen.
  */
-suspend fun <K,V> KafkaConsumer<K,V>.unsubscribeAwait() : Unit {
-  return awaitResult{
-    this.unsubscribe({ ar -> it.handle(ar.mapEmpty()) })}
+suspend fun <K,V> KafkaConsumer<K,V>.unsubscribeAwait(): Unit {
+  return awaitResult {
+    this.unsubscribe { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Get the current subscription.
+ * Suspending version of method [io.vertx.kafka.client.consumer.KafkaConsumer.subscription]
  *
- * @return current KafkaConsumer instance *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.kafka.client.consumer.KafkaConsumer original] using Vert.x codegen.
+ * @return [Set<String>]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.kafka.client.consumer.KafkaConsumer] using Vert.x codegen.
  */
-suspend fun <K,V> KafkaConsumer<K,V>.subscriptionAwait() : Set<String> {
-  return awaitResult{
+suspend fun <K,V> KafkaConsumer<K,V>.subscriptionAwait(): Set<String> {
+  return awaitResult {
     this.subscription(it)
   }
 }
 
 /**
- * Suspend fetching from the requested partition.
- * <p>
- * Due to internal buffering of messages,
- * the  will
- * continue to observe messages from the given <code>topicPartition</code>
- * until some time <em>after</em> the given <code>completionHandler</code>
- * is called. In contrast, the once the given <code>completionHandler</code>
- * is called the [io.vertx.kafka.client.consumer.KafkaConsumer] will not see messages
- * from the given <code>topicPartition</code>.
+ * Suspending version of method [io.vertx.kafka.client.consumer.KafkaConsumer.pause]
  *
  * @param topicPartition topic partition from which suspend fetching
- * @return current KafkaConsumer instance *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.kafka.client.consumer.KafkaConsumer original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.kafka.client.consumer.KafkaConsumer] using Vert.x codegen.
  */
-suspend fun <K,V> KafkaConsumer<K,V>.pauseAwait(topicPartition : TopicPartition) : Unit {
-  return awaitResult{
-    this.pause(topicPartition, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun <K,V> KafkaConsumer<K,V>.pauseAwait(topicPartition: TopicPartition): Unit {
+  return awaitResult {
+    this.pause(topicPartition) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Suspend fetching from the requested partitions.
- * <p>
- * Due to internal buffering of messages,
- * the  will
- * continue to observe messages from the given <code>topicPartitions</code>
- * until some time <em>after</em> the given <code>completionHandler</code>
- * is called. In contrast, the once the given <code>completionHandler</code>
- * is called the [io.vertx.kafka.client.consumer.KafkaConsumer] will not see messages
- * from the given <code>topicPartitions</code>.
+ * Suspending version of method [io.vertx.kafka.client.consumer.KafkaConsumer.pause]
  *
  * @param topicPartitions topic partition from which suspend fetching
- * @return current KafkaConsumer instance *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.kafka.client.consumer.KafkaConsumer original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.kafka.client.consumer.KafkaConsumer] using Vert.x codegen.
  */
-suspend fun <K,V> KafkaConsumer<K,V>.pauseAwait(topicPartitions : Set<TopicPartition>) : Unit {
-  return awaitResult{
-    this.pause(topicPartitions, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun <K,V> KafkaConsumer<K,V>.pauseAwait(topicPartitions: Set<TopicPartition>): Unit {
+  return awaitResult {
+    this.pause(topicPartitions) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Get the set of partitions that were previously paused by a call to pause(Set).
+ * Suspending version of method [io.vertx.kafka.client.consumer.KafkaConsumer.paused]
  *
+ * @return [Set<TopicPartition>]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.kafka.client.consumer.KafkaConsumer original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.kafka.client.consumer.KafkaConsumer] using Vert.x codegen.
  */
-suspend fun <K,V> KafkaConsumer<K,V>.pausedAwait() : Set<TopicPartition> {
-  return awaitResult{
+suspend fun <K,V> KafkaConsumer<K,V>.pausedAwait(): Set<TopicPartition> {
+  return awaitResult {
     this.paused(it)
   }
 }
 
 /**
- * Resume specified partition which have been paused with pause.
+ * Suspending version of method [io.vertx.kafka.client.consumer.KafkaConsumer.resume]
  *
  * @param topicPartition topic partition from which resume fetching
- * @return current KafkaConsumer instance *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.kafka.client.consumer.KafkaConsumer original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.kafka.client.consumer.KafkaConsumer] using Vert.x codegen.
  */
-suspend fun <K,V> KafkaConsumer<K,V>.resumeAwait(topicPartition : TopicPartition) : Unit {
-  return awaitResult{
-    this.resume(topicPartition, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun <K,V> KafkaConsumer<K,V>.resumeAwait(topicPartition: TopicPartition): Unit {
+  return awaitResult {
+    this.resume(topicPartition) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Resume specified partitions which have been paused with pause.
+ * Suspending version of method [io.vertx.kafka.client.consumer.KafkaConsumer.resume]
  *
  * @param topicPartitions topic partition from which resume fetching
- * @return current KafkaConsumer instance *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.kafka.client.consumer.KafkaConsumer original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.kafka.client.consumer.KafkaConsumer] using Vert.x codegen.
  */
-suspend fun <K,V> KafkaConsumer<K,V>.resumeAwait(topicPartitions : Set<TopicPartition>) : Unit {
-  return awaitResult{
-    this.resume(topicPartitions, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun <K,V> KafkaConsumer<K,V>.resumeAwait(topicPartitions: Set<TopicPartition>): Unit {
+  return awaitResult {
+    this.resume(topicPartitions) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Overrides the fetch offsets that the consumer will use on the next poll.
- * <p>
- * Due to internal buffering of messages,
- * the  will
- * continue to observe messages fetched with respect to the old offset
- * until some time <em>after</em> the given <code>completionHandler</code>
- * is called. In contrast, the once the given <code>completionHandler</code>
- * is called the [io.vertx.kafka.client.consumer.KafkaConsumer] will only see messages
- * consistent with the new offset.
+ * Suspending version of method [io.vertx.kafka.client.consumer.KafkaConsumer.seek]
  *
  * @param topicPartition topic partition for which seek
  * @param offset offset to seek inside the topic partition
- * @return current KafkaConsumer instance *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.kafka.client.consumer.KafkaConsumer original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.kafka.client.consumer.KafkaConsumer] using Vert.x codegen.
  */
-suspend fun <K,V> KafkaConsumer<K,V>.seekAwait(topicPartition : TopicPartition, offset : Long) : Unit {
-  return awaitResult{
-    this.seek(topicPartition, offset, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun <K,V> KafkaConsumer<K,V>.seekAwait(topicPartition: TopicPartition, offset: Long): Unit {
+  return awaitResult {
+    this.seek(topicPartition, offset) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Seek to the first offset for each of the given partition.
- * <p>
- * Due to internal buffering of messages,
- * the  will
- * continue to observe messages fetched with respect to the old offset
- * until some time <em>after</em> the given <code>completionHandler</code>
- * is called. In contrast, the once the given <code>completionHandler</code>
- * is called the [io.vertx.kafka.client.consumer.KafkaConsumer] will only see messages
- * consistent with the new offset.
+ * Suspending version of method [io.vertx.kafka.client.consumer.KafkaConsumer.seekToBeginning]
  *
  * @param topicPartition topic partition for which seek
- * @return current KafkaConsumer instance *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.kafka.client.consumer.KafkaConsumer original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.kafka.client.consumer.KafkaConsumer] using Vert.x codegen.
  */
-suspend fun <K,V> KafkaConsumer<K,V>.seekToBeginningAwait(topicPartition : TopicPartition) : Unit {
-  return awaitResult{
-    this.seekToBeginning(topicPartition, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun <K,V> KafkaConsumer<K,V>.seekToBeginningAwait(topicPartition: TopicPartition): Unit {
+  return awaitResult {
+    this.seekToBeginning(topicPartition) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Seek to the first offset for each of the given partitions.
- * <p>
- * Due to internal buffering of messages,
- * the  will
- * continue to observe messages fetched with respect to the old offset
- * until some time <em>after</em> the given <code>completionHandler</code>
- * is called. In contrast, the once the given <code>completionHandler</code>
- * is called the [io.vertx.kafka.client.consumer.KafkaConsumer] will only see messages
- * consistent with the new offset.
+ * Suspending version of method [io.vertx.kafka.client.consumer.KafkaConsumer.seekToBeginning]
  *
  * @param topicPartitions topic partition for which seek
- * @return current KafkaConsumer instance *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.kafka.client.consumer.KafkaConsumer original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.kafka.client.consumer.KafkaConsumer] using Vert.x codegen.
  */
-suspend fun <K,V> KafkaConsumer<K,V>.seekToBeginningAwait(topicPartitions : Set<TopicPartition>) : Unit {
-  return awaitResult{
-    this.seekToBeginning(topicPartitions, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun <K,V> KafkaConsumer<K,V>.seekToBeginningAwait(topicPartitions: Set<TopicPartition>): Unit {
+  return awaitResult {
+    this.seekToBeginning(topicPartitions) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Seek to the last offset for each of the given partition.
- * <p>
- * Due to internal buffering of messages,
- * the  will
- * continue to observe messages fetched with respect to the old offset
- * until some time <em>after</em> the given <code>completionHandler</code>
- * is called. In contrast, the once the given <code>completionHandler</code>
- * is called the [io.vertx.kafka.client.consumer.KafkaConsumer] will only see messages
- * consistent with the new offset.
+ * Suspending version of method [io.vertx.kafka.client.consumer.KafkaConsumer.seekToEnd]
  *
  * @param topicPartition topic partition for which seek
- * @return current KafkaConsumer instance *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.kafka.client.consumer.KafkaConsumer original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.kafka.client.consumer.KafkaConsumer] using Vert.x codegen.
  */
-suspend fun <K,V> KafkaConsumer<K,V>.seekToEndAwait(topicPartition : TopicPartition) : Unit {
-  return awaitResult{
-    this.seekToEnd(topicPartition, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun <K,V> KafkaConsumer<K,V>.seekToEndAwait(topicPartition: TopicPartition): Unit {
+  return awaitResult {
+    this.seekToEnd(topicPartition) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Seek to the last offset for each of the given partitions.
- * <p>
- * Due to internal buffering of messages,
- * the  will
- * continue to observe messages fetched with respect to the old offset
- * until some time <em>after</em> the given <code>completionHandler</code>
- * is called. In contrast, the once the given <code>completionHandler</code>
- * is called the [io.vertx.kafka.client.consumer.KafkaConsumer] will only see messages
- * consistent with the new offset.
+ * Suspending version of method [io.vertx.kafka.client.consumer.KafkaConsumer.seekToEnd]
  *
  * @param topicPartitions topic partition for which seek
- * @return current KafkaConsumer instance *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.kafka.client.consumer.KafkaConsumer original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.kafka.client.consumer.KafkaConsumer] using Vert.x codegen.
  */
-suspend fun <K,V> KafkaConsumer<K,V>.seekToEndAwait(topicPartitions : Set<TopicPartition>) : Unit {
-  return awaitResult{
-    this.seekToEnd(topicPartitions, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun <K,V> KafkaConsumer<K,V>.seekToEndAwait(topicPartitions: Set<TopicPartition>): Unit {
+  return awaitResult {
+    this.seekToEnd(topicPartitions) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Commit current offsets for all the subscribed list of topics and partition.
+ * Suspending version of method [io.vertx.kafka.client.consumer.KafkaConsumer.commit]
  *
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.kafka.client.consumer.KafkaConsumer original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.kafka.client.consumer.KafkaConsumer] using Vert.x codegen.
  */
-suspend fun <K,V> KafkaConsumer<K,V>.commitAwait() : Unit {
-  return awaitResult{
-    this.commit({ ar -> it.handle(ar.mapEmpty()) })}
+suspend fun <K,V> KafkaConsumer<K,V>.commitAwait(): Unit {
+  return awaitResult {
+    this.commit { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Get the last committed offset for the given partition (whether the commit happened by this process or another).
+ * Suspending version of method [io.vertx.kafka.client.consumer.KafkaConsumer.committed]
  *
  * @param topicPartition topic partition for getting last committed offset
+ * @return [OffsetAndMetadata]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.kafka.client.consumer.KafkaConsumer original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.kafka.client.consumer.KafkaConsumer] using Vert.x codegen.
  */
-suspend fun <K,V> KafkaConsumer<K,V>.committedAwait(topicPartition : TopicPartition) : OffsetAndMetadata {
-  return awaitResult{
+suspend fun <K,V> KafkaConsumer<K,V>.committedAwait(topicPartition: TopicPartition): OffsetAndMetadata {
+  return awaitResult {
     this.committed(topicPartition, it)
   }
 }
 
 /**
- * Get metadata about the partitions for a given topic.
+ * Suspending version of method [io.vertx.kafka.client.consumer.KafkaConsumer.partitionsFor]
  *
  * @param topic topic partition for which getting partitions info
- * @return current KafkaConsumer instance *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.kafka.client.consumer.KafkaConsumer original] using Vert.x codegen.
+ * @return [List<PartitionInfo>]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.kafka.client.consumer.KafkaConsumer] using Vert.x codegen.
  */
-suspend fun <K,V> KafkaConsumer<K,V>.partitionsForAwait(topic : String) : List<PartitionInfo> {
-  return awaitResult{
+suspend fun <K,V> KafkaConsumer<K,V>.partitionsForAwait(topic: String): List<PartitionInfo> {
+  return awaitResult {
     this.partitionsFor(topic, it)
   }
 }
 
 /**
- * Close the consumer
+ * Suspending version of method [io.vertx.kafka.client.consumer.KafkaConsumer.close]
  *
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.kafka.client.consumer.KafkaConsumer original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.kafka.client.consumer.KafkaConsumer] using Vert.x codegen.
  */
-suspend fun <K,V> KafkaConsumer<K,V>.closeAwait() : Unit {
-  return awaitResult{
-    this.close({ ar -> it.handle(ar.mapEmpty()) })}
+suspend fun <K,V> KafkaConsumer<K,V>.closeAwait(): Unit {
+  return awaitResult {
+    this.close { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Get the offset of the next record that will be fetched (if a record with that offset exists).
+ * Suspending version of method [io.vertx.kafka.client.consumer.KafkaConsumer.position]
  *
  * @param partition The partition to get the position for
+ * @return [Long]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.kafka.client.consumer.KafkaConsumer original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.kafka.client.consumer.KafkaConsumer] using Vert.x codegen.
  */
-suspend fun <K,V> KafkaConsumer<K,V>.positionAwait(partition : TopicPartition) : Long {
-  return awaitResult{
+suspend fun <K,V> KafkaConsumer<K,V>.positionAwait(partition: TopicPartition): Long {
+  return awaitResult {
     this.position(partition, it)
   }
 }
 
 /**
- * Look up the offset for the given partition by timestamp. Note: the result might be null in case
- * for the given timestamp no offset can be found -- e.g., when the timestamp refers to the future
+ * Suspending version of method [io.vertx.kafka.client.consumer.KafkaConsumer.offsetsForTimes]
  *
  * @param topicPartition TopicPartition to query.
  * @param timestamp Timestamp to be used in the query.
+ * @return [OffsetAndTimestamp]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.kafka.client.consumer.KafkaConsumer original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.kafka.client.consumer.KafkaConsumer] using Vert.x codegen.
  */
-suspend fun <K,V> KafkaConsumer<K,V>.offsetsForTimesAwait(topicPartition : TopicPartition, timestamp : Long) : OffsetAndTimestamp {
-  return awaitResult{
+suspend fun <K,V> KafkaConsumer<K,V>.offsetsForTimesAwait(topicPartition: TopicPartition, timestamp: Long): OffsetAndTimestamp {
+  return awaitResult {
     this.offsetsForTimes(topicPartition, timestamp, it)
   }
 }
 
 /**
- * Get the first offset for the given partitions.
+ * Suspending version of method [io.vertx.kafka.client.consumer.KafkaConsumer.beginningOffsets]
  *
  * @param topicPartition the partition to get the earliest offset.
+ * @return [Long]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.kafka.client.consumer.KafkaConsumer original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.kafka.client.consumer.KafkaConsumer] using Vert.x codegen.
  */
-suspend fun <K,V> KafkaConsumer<K,V>.beginningOffsetsAwait(topicPartition : TopicPartition) : Long {
-  return awaitResult{
+suspend fun <K,V> KafkaConsumer<K,V>.beginningOffsetsAwait(topicPartition: TopicPartition): Long {
+  return awaitResult {
     this.beginningOffsets(topicPartition, it)
   }
 }
 
 /**
- * Get the last offset for the given partition. The last offset of a partition is the offset
- * of the upcoming message, i.e. the offset of the last available message + 1.
+ * Suspending version of method [io.vertx.kafka.client.consumer.KafkaConsumer.endOffsets]
  *
  * @param topicPartition the partition to get the end offset.
+ * @return [Long]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.kafka.client.consumer.KafkaConsumer original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.kafka.client.consumer.KafkaConsumer] using Vert.x codegen.
  */
-suspend fun <K,V> KafkaConsumer<K,V>.endOffsetsAwait(topicPartition : TopicPartition) : Long {
-  return awaitResult{
+suspend fun <K,V> KafkaConsumer<K,V>.endOffsetsAwait(topicPartition: TopicPartition): Long {
+  return awaitResult {
     this.endOffsets(topicPartition, it)
   }
 }
 
 /**
- * Executes a poll for getting messages from Kafka
+ * Suspending version of method [io.vertx.kafka.client.consumer.KafkaConsumer.poll]
  *
  * @param timeout The time, in milliseconds, spent waiting in poll if data is not available in the buffer. If 0, returns immediately with any records that are available currently in the native Kafka consumer's buffer, else returns empty. Must not be negative.
+ * @return [KafkaConsumerRecords<K,V>]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.kafka.client.consumer.KafkaConsumer original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.kafka.client.consumer.KafkaConsumer] using Vert.x codegen.
  */
-suspend fun <K,V> KafkaConsumer<K,V>.pollAwait(timeout : Long) : KafkaConsumerRecords<K,V> {
-  return awaitResult{
+suspend fun <K,V> KafkaConsumer<K,V>.pollAwait(timeout: Long): KafkaConsumerRecords<K,V> {
+  return awaitResult {
     this.poll(timeout, it)
   }
 }

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/kafka/client/producer/KafkaProducer.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/kafka/client/producer/KafkaProducer.kt
@@ -7,55 +7,55 @@ import io.vertx.kafka.client.producer.RecordMetadata
 import io.vertx.kotlin.coroutines.awaitResult
 
 /**
- * Asynchronously write a record to a topic
+ * Suspending version of method [io.vertx.kafka.client.producer.KafkaProducer.write]
  *
  * @param record record to write
- * @return current KafkaWriteStream instance *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.kafka.client.producer.KafkaProducer original] using Vert.x codegen.
+ * @return [RecordMetadata]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.kafka.client.producer.KafkaProducer] using Vert.x codegen.
  */
-suspend fun <K,V> KafkaProducer<K,V>.writeAwait(record : KafkaProducerRecord<K,V>) : RecordMetadata {
-  return awaitResult{
+suspend fun <K,V> KafkaProducer<K,V>.writeAwait(record: KafkaProducerRecord<K,V>): RecordMetadata {
+  return awaitResult {
     this.write(record, it)
   }
 }
 
 /**
- * Get the partition metadata for the give topic.
+ * Suspending version of method [io.vertx.kafka.client.producer.KafkaProducer.partitionsFor]
  *
  * @param topic topic partition for which getting partitions info
- * @return current KafkaProducer instance *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.kafka.client.producer.KafkaProducer original] using Vert.x codegen.
+ * @return [List<PartitionInfo>]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.kafka.client.producer.KafkaProducer] using Vert.x codegen.
  */
-suspend fun <K,V> KafkaProducer<K,V>.partitionsForAwait(topic : String) : List<PartitionInfo> {
-  return awaitResult{
+suspend fun <K,V> KafkaProducer<K,V>.partitionsForAwait(topic: String): List<PartitionInfo> {
+  return awaitResult {
     this.partitionsFor(topic, it)
   }
 }
 
 /**
- * Close the producer
+ * Suspending version of method [io.vertx.kafka.client.producer.KafkaProducer.close]
  *
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.kafka.client.producer.KafkaProducer original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.kafka.client.producer.KafkaProducer] using Vert.x codegen.
  */
-suspend fun <K,V> KafkaProducer<K,V>.closeAwait() : Unit {
-  return awaitResult{
-    this.close({ ar -> it.handle(ar.mapEmpty()) })}
+suspend fun <K,V> KafkaProducer<K,V>.closeAwait(): Unit {
+  return awaitResult {
+    this.close { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Close the producer
+ * Suspending version of method [io.vertx.kafka.client.producer.KafkaProducer.close]
  *
  * @param timeout timeout to wait for closing
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.kafka.client.producer.KafkaProducer original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.kafka.client.producer.KafkaProducer] using Vert.x codegen.
  */
-suspend fun <K,V> KafkaProducer<K,V>.closeAwait(timeout : Long) : Unit {
-  return awaitResult{
-    this.close(timeout, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun <K,V> KafkaProducer<K,V>.closeAwait(timeout: Long): Unit {
+  return awaitResult {
+    this.close(timeout) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/mqtt/MqttClient.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/mqtt/MqttClient.kt
@@ -7,105 +7,105 @@ import io.vertx.mqtt.MqttClient
 import io.vertx.mqtt.messages.MqttConnAckMessage
 
 /**
- * Connects to an MQTT server calling connectHandler after connection
+ * Suspending version of method [io.vertx.mqtt.MqttClient.connect]
  *
  * @param port port of the MQTT server
  * @param host hostname/ip address of the MQTT server
- * @return current MQTT client instance *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.mqtt.MqttClient original] using Vert.x codegen.
+ * @return [MqttConnAckMessage]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.mqtt.MqttClient] using Vert.x codegen.
  */
-suspend fun MqttClient.connectAwait(port : Int, host : String) : MqttConnAckMessage {
-  return awaitResult{
+suspend fun MqttClient.connectAwait(port: Int, host: String): MqttConnAckMessage {
+  return awaitResult {
     this.connect(port, host, it)
   }
 }
 
 /**
- * Connects to an MQTT server calling connectHandler after connection
+ * Suspending version of method [io.vertx.mqtt.MqttClient.connect]
  *
  * @param port port of the MQTT server
  * @param host hostname/ip address of the MQTT server
  * @param serverName the SNI server name
- * @return current MQTT client instance *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.mqtt.MqttClient original] using Vert.x codegen.
+ * @return [MqttConnAckMessage]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.mqtt.MqttClient] using Vert.x codegen.
  */
-suspend fun MqttClient.connectAwait(port : Int, host : String, serverName : String) : MqttConnAckMessage {
-  return awaitResult{
+suspend fun MqttClient.connectAwait(port: Int, host: String, serverName: String): MqttConnAckMessage {
+  return awaitResult {
     this.connect(port, host, serverName, it)
   }
 }
 
 /**
- * Disconnects from the MQTT server calling disconnectHandler after disconnection
+ * Suspending version of method [io.vertx.mqtt.MqttClient.disconnect]
  *
- * @return current MQTT client instance *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.mqtt.MqttClient original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.mqtt.MqttClient] using Vert.x codegen.
  */
-suspend fun MqttClient.disconnectAwait() : Unit {
-  return awaitResult{
-    this.disconnect({ ar -> it.handle(ar.mapEmpty()) })}
+suspend fun MqttClient.disconnectAwait(): Unit {
+  return awaitResult {
+    this.disconnect { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Sends the PUBLISH message to the remote MQTT server
+ * Suspending version of method [io.vertx.mqtt.MqttClient.publish]
  *
  * @param topic topic on which the message is published
  * @param payload message payload
  * @param qosLevel QoS level
  * @param isDup if the message is a duplicate
  * @param isRetain if the message needs to be retained
- * @return current MQTT client instance *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.mqtt.MqttClient original] using Vert.x codegen.
+ * @return [Int]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.mqtt.MqttClient] using Vert.x codegen.
  */
-suspend fun MqttClient.publishAwait(topic : String, payload : Buffer, qosLevel : MqttQoS, isDup : Boolean, isRetain : Boolean) : Int {
-  return awaitResult{
+suspend fun MqttClient.publishAwait(topic: String, payload: Buffer, qosLevel: MqttQoS, isDup: Boolean, isRetain: Boolean): Int {
+  return awaitResult {
     this.publish(topic, payload, qosLevel, isDup, isRetain, it)
   }
 }
 
 /**
- * Subscribes to the topic with a specified QoS level
+ * Suspending version of method [io.vertx.mqtt.MqttClient.subscribe]
  *
  * @param topic topic you subscribe on
  * @param qos QoS level
- * @return current MQTT client instance *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.mqtt.MqttClient original] using Vert.x codegen.
+ * @return [Int]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.mqtt.MqttClient] using Vert.x codegen.
  */
-suspend fun MqttClient.subscribeAwait(topic : String, qos : Int) : Int {
-  return awaitResult{
+suspend fun MqttClient.subscribeAwait(topic: String, qos: Int): Int {
+  return awaitResult {
     this.subscribe(topic, qos, it)
   }
 }
 
 /**
- * Subscribes to the topic and adds a handler which will be called after the request is sent
+ * Suspending version of method [io.vertx.mqtt.MqttClient.subscribe]
  *
  * @param topics topics you subscribe on
- * @return current MQTT client instance *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.mqtt.MqttClient original] using Vert.x codegen.
+ * @return [Int]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.mqtt.MqttClient] using Vert.x codegen.
  */
-suspend fun MqttClient.subscribeAwait(topics : Map<String,Int>) : Int {
-  return awaitResult{
+suspend fun MqttClient.subscribeAwait(topics: Map<String,Int>): Int {
+  return awaitResult {
     this.subscribe(topics, it)
   }
 }
 
 /**
- * Unsubscribe from receiving messages on given topic
+ * Suspending version of method [io.vertx.mqtt.MqttClient.unsubscribe]
  *
  * @param topic Topic you want to unsubscribe from
- * @return current MQTT client instance *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.mqtt.MqttClient original] using Vert.x codegen.
+ * @return [Int]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.mqtt.MqttClient] using Vert.x codegen.
  */
-suspend fun MqttClient.unsubscribeAwait(topic : String) : Int {
-  return awaitResult{
+suspend fun MqttClient.unsubscribeAwait(topic: String): Int {
+  return awaitResult {
     this.unsubscribe(topic, it)
   }
 }

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/mqtt/MqttEndpoint.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/mqtt/MqttEndpoint.kt
@@ -6,19 +6,19 @@ import io.vertx.kotlin.coroutines.awaitResult
 import io.vertx.mqtt.MqttEndpoint
 
 /**
- * Sends the PUBLISH message to the remote MQTT server
+ * Suspending version of method [io.vertx.mqtt.MqttEndpoint.publish]
  *
  * @param topic topic on which the message is published
  * @param payload message payload
  * @param qosLevel QoS level
  * @param isDup if the message is a duplicate
  * @param isRetain if the message needs to be retained
- * @return current MQTT client instance *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.mqtt.MqttEndpoint original] using Vert.x codegen.
+ * @return [Int]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.mqtt.MqttEndpoint] using Vert.x codegen.
  */
-suspend fun MqttEndpoint.publishAwait(topic : String, payload : Buffer, qosLevel : MqttQoS, isDup : Boolean, isRetain : Boolean) : Int {
-  return awaitResult{
+suspend fun MqttEndpoint.publishAwait(topic: String, payload: Buffer, qosLevel: MqttQoS, isDup: Boolean, isRetain: Boolean): Int {
+  return awaitResult {
     this.publish(topic, payload, qosLevel, isDup, isRetain, it)
   }
 }

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/mqtt/MqttServer.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/mqtt/MqttServer.kt
@@ -4,59 +4,56 @@ import io.vertx.kotlin.coroutines.awaitResult
 import io.vertx.mqtt.MqttServer
 
 /**
- * Start the server listening for incoming connections on the port and host specified
- * It ignores any options specified through the constructor
+ * Suspending version of method [io.vertx.mqtt.MqttServer.listen]
  *
  * @param port the port to listen on
  * @param host the host to listen on
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.mqtt.MqttServer original] using Vert.x codegen.
+ * @return [MqttServer]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.mqtt.MqttServer] using Vert.x codegen.
  */
-suspend fun MqttServer.listenAwait(port : Int, host : String) : MqttServer {
-  return awaitResult{
+suspend fun MqttServer.listenAwait(port: Int, host: String): MqttServer {
+  return awaitResult {
     this.listen(port, host, it)
   }
 }
 
 /**
- * Start the server listening for incoming connections on the port specified but on
- * "0.0.0.0" as host. It ignores any options specified through the constructor
+ * Suspending version of method [io.vertx.mqtt.MqttServer.listen]
  *
  * @param port the port to listen on
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.mqtt.MqttServer original] using Vert.x codegen.
+ * @return [MqttServer]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.mqtt.MqttServer] using Vert.x codegen.
  */
-suspend fun MqttServer.listenAwait(port : Int) : MqttServer {
-  return awaitResult{
+suspend fun MqttServer.listenAwait(port: Int): MqttServer {
+  return awaitResult {
     this.listen(port, it)
   }
 }
 
 /**
- * Start the server listening for incoming connections using the specified options
- * through the constructor
+ * Suspending version of method [io.vertx.mqtt.MqttServer.listen]
  *
- * @return a reference to this, so the API can be used fluently *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.mqtt.MqttServer original] using Vert.x codegen.
+ * @return [MqttServer]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.mqtt.MqttServer] using Vert.x codegen.
  */
-suspend fun MqttServer.listenAwait() : MqttServer {
-  return awaitResult{
+suspend fun MqttServer.listenAwait(): MqttServer {
+  return awaitResult {
     this.listen(it)
   }
 }
 
 /**
- * Close the server supplying an handler that will be called when the server is actually closed (or has failed).
+ * Suspending version of method [io.vertx.mqtt.MqttServer.close]
  *
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.mqtt.MqttServer original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.mqtt.MqttServer] using Vert.x codegen.
  */
-suspend fun MqttServer.closeAwait() : Unit {
-  return awaitResult{
-    this.close({ ar -> it.handle(ar.mapEmpty()) })}
+suspend fun MqttServer.closeAwait(): Unit {
+  return awaitResult {
+    this.close { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/rabbitmq/RabbitMQClient.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/rabbitmq/RabbitMQClient.kt
@@ -7,202 +7,192 @@ import io.vertx.rabbitmq.RabbitMQClient
 import io.vertx.rabbitmq.RabbitMQConsumer
 
 /**
- * Acknowledge one or several received messages. Supply the deliveryTag from the AMQP.Basic.GetOk or AMQP.Basic.Deliver
- * method containing the received message being acknowledged.
+ * Suspending version of method [io.vertx.rabbitmq.RabbitMQClient.basicAck]
  *
  * @param deliveryTag 
  * @param multiple 
+ * @return [JsonObject]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.rabbitmq.RabbitMQClient original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.rabbitmq.RabbitMQClient] using Vert.x codegen.
  */
-suspend fun RabbitMQClient.basicAckAwait(deliveryTag : Long, multiple : Boolean) : JsonObject {
-  return awaitResult{
+suspend fun RabbitMQClient.basicAckAwait(deliveryTag: Long, multiple: Boolean): JsonObject {
+  return awaitResult {
     this.basicAck(deliveryTag, multiple, it)
   }
 }
 
 /**
- * Reject one or several received messages.
+ * Suspending version of method [io.vertx.rabbitmq.RabbitMQClient.basicNack]
  *
  * @param deliveryTag 
  * @param multiple 
  * @param requeue 
+ * @return [JsonObject]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.rabbitmq.RabbitMQClient original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.rabbitmq.RabbitMQClient] using Vert.x codegen.
  */
-suspend fun RabbitMQClient.basicNackAwait(deliveryTag : Long, multiple : Boolean, requeue : Boolean) : JsonObject {
-  return awaitResult{
+suspend fun RabbitMQClient.basicNackAwait(deliveryTag: Long, multiple: Boolean, requeue: Boolean): JsonObject {
+  return awaitResult {
     this.basicNack(deliveryTag, multiple, requeue, it)
   }
 }
 
 /**
- * Retrieve a message from a queue using AMQP.Basic.Get
+ * Suspending version of method [io.vertx.rabbitmq.RabbitMQClient.basicGet]
  *
  * @param queue 
  * @param autoAck 
+ * @return [JsonObject]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.rabbitmq.RabbitMQClient original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.rabbitmq.RabbitMQClient] using Vert.x codegen.
  */
-suspend fun RabbitMQClient.basicGetAwait(queue : String, autoAck : Boolean) : JsonObject {
-  return awaitResult{
+suspend fun RabbitMQClient.basicGetAwait(queue: String, autoAck: Boolean): JsonObject {
+  return awaitResult {
     this.basicGet(queue, autoAck, it)
   }
 }
 
 /**
+ * Suspending version of method [io.vertx.rabbitmq.RabbitMQClient.basicConsumer]
  *
  * @param queue 
+ * @return [RabbitMQConsumer]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.rabbitmq.RabbitMQClient original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.rabbitmq.RabbitMQClient] using Vert.x codegen.
  */
-suspend fun RabbitMQClient.basicConsumerAwait(queue : String) : RabbitMQConsumer {
-  return awaitResult{
+suspend fun RabbitMQClient.basicConsumerAwait(queue: String): RabbitMQConsumer {
+  return awaitResult {
     this.basicConsumer(queue, it)
   }
 }
 
 /**
- * Create a consumer with the given <code>options</code>.
+ * Suspending version of method [io.vertx.rabbitmq.RabbitMQClient.basicConsumer]
  *
  * @param queue the name of a queue
  * @param options options for queue
+ * @return [RabbitMQConsumer]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.rabbitmq.RabbitMQClient original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.rabbitmq.RabbitMQClient] using Vert.x codegen.
  */
-suspend fun RabbitMQClient.basicConsumerAwait(queue : String, options : QueueOptions) : RabbitMQConsumer {
-  return awaitResult{
+suspend fun RabbitMQClient.basicConsumerAwait(queue: String, options: QueueOptions): RabbitMQConsumer {
+  return awaitResult {
     this.basicConsumer(queue, options, it)
   }
 }
 
 /**
- * Publish a message. Publishing to a non-existent exchange will result in a channel-level protocol exception,
- * which closes the channel. Invocations of Channel#basicPublish will eventually block if a resource-driven alarm is in effect.
+ * Suspending version of method [io.vertx.rabbitmq.RabbitMQClient.basicPublish]
  *
  * @param exchange 
  * @param routingKey 
  * @param message 
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.rabbitmq.RabbitMQClient original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.rabbitmq.RabbitMQClient] using Vert.x codegen.
  */
-suspend fun RabbitMQClient.basicPublishAwait(exchange : String, routingKey : String, message : JsonObject) : Unit {
-  return awaitResult{
-    this.basicPublish(exchange, routingKey, message, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun RabbitMQClient.basicPublishAwait(exchange: String, routingKey: String, message: JsonObject): Unit {
+  return awaitResult {
+    this.basicPublish(exchange, routingKey, message) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Enables publisher acknowledgements on this channel. Can be called once during client initialisation. Calls to basicPublish()
- * will have to be confirmed.
+ * Suspending version of method [io.vertx.rabbitmq.RabbitMQClient.confirmSelect]
  *
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.rabbitmq.RabbitMQClient original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.rabbitmq.RabbitMQClient] using Vert.x codegen.
  */
-suspend fun RabbitMQClient.confirmSelectAwait() : Unit {
-  return awaitResult{
-    this.confirmSelect({ ar -> it.handle(ar.mapEmpty()) })}
+suspend fun RabbitMQClient.confirmSelectAwait(): Unit {
+  return awaitResult {
+    this.confirmSelect { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Wait until all messages published since the last call have been either ack'd or nack'd by the broker.
- * This will incur slight performance loss at the expense of higher write consistency.
- * If desired, multiple calls to basicPublish() can be batched before confirming.
+ * Suspending version of method [io.vertx.rabbitmq.RabbitMQClient.waitForConfirms]
  *
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.rabbitmq.RabbitMQClient original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.rabbitmq.RabbitMQClient] using Vert.x codegen.
  */
-suspend fun RabbitMQClient.waitForConfirmsAwait() : Unit {
-  return awaitResult{
-    this.waitForConfirms({ ar -> it.handle(ar.mapEmpty()) })}
+suspend fun RabbitMQClient.waitForConfirmsAwait(): Unit {
+  return awaitResult {
+    this.waitForConfirms { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Wait until all messages published since the last call have been either ack'd or nack'd by the broker; or until timeout elapses. If the timeout expires a TimeoutException is thrown.
+ * Suspending version of method [io.vertx.rabbitmq.RabbitMQClient.waitForConfirms]
  *
  * @param timeout 
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.rabbitmq.RabbitMQClient original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.rabbitmq.RabbitMQClient] using Vert.x codegen.
  */
-suspend fun RabbitMQClient.waitForConfirmsAwait(timeout : Long) : Unit {
-  return awaitResult{
-    this.waitForConfirms(timeout, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun RabbitMQClient.waitForConfirmsAwait(timeout: Long): Unit {
+  return awaitResult {
+    this.waitForConfirms(timeout) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Request a specific prefetchCount "quality of service" settings
- * for this channel.
+ * Suspending version of method [io.vertx.rabbitmq.RabbitMQClient.basicQos]
  *
  * @param prefetchCount maximum number of messages that the server will deliver, 0 if unlimited
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.rabbitmq.RabbitMQClient original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.rabbitmq.RabbitMQClient] using Vert.x codegen.
  */
-suspend fun RabbitMQClient.basicQosAwait(prefetchCount : Int) : Unit {
-  return awaitResult{
-    this.basicQos(prefetchCount, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun RabbitMQClient.basicQosAwait(prefetchCount: Int): Unit {
+  return awaitResult {
+    this.basicQos(prefetchCount) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Request a specific prefetchCount "quality of service" settings
- * for this channel.
+ * Suspending version of method [io.vertx.rabbitmq.RabbitMQClient.basicQos]
  *
  * @param prefetchCount maximum number of messages that the server will deliver, 0 if unlimited
  * @param global true if the settings should be applied to the entire channel rather than each consumer
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.rabbitmq.RabbitMQClient original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.rabbitmq.RabbitMQClient] using Vert.x codegen.
  */
-suspend fun RabbitMQClient.basicQosAwait(prefetchCount : Int, global : Boolean) : Unit {
-  return awaitResult{
-    this.basicQos(prefetchCount, global, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun RabbitMQClient.basicQosAwait(prefetchCount: Int, global: Boolean): Unit {
+  return awaitResult {
+    this.basicQos(prefetchCount, global) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Request specific "quality of service" settings.
- *
- * These settings impose limits on the amount of data the server
- * will deliver to consumers before requiring acknowledgements.
- * Thus they provide a means of consumer-initiated flow control.
+ * Suspending version of method [io.vertx.rabbitmq.RabbitMQClient.basicQos]
  *
  * @param prefetchSize maximum amount of content (measured in octets) that the server will deliver, 0 if unlimited
  * @param prefetchCount maximum number of messages that the server will deliver, 0 if unlimited
  * @param global true if the settings should be applied to the entire channel rather than each consumer
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.rabbitmq.RabbitMQClient original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.rabbitmq.RabbitMQClient] using Vert.x codegen.
  */
-suspend fun RabbitMQClient.basicQosAwait(prefetchSize : Int, prefetchCount : Int, global : Boolean) : Unit {
-  return awaitResult{
-    this.basicQos(prefetchSize, prefetchCount, global, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun RabbitMQClient.basicQosAwait(prefetchSize: Int, prefetchCount: Int, global: Boolean): Unit {
+  return awaitResult {
+    this.basicQos(prefetchSize, prefetchCount, global) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Declare an exchange.
+ * Suspending version of method [io.vertx.rabbitmq.RabbitMQClient.exchangeDeclare]
  *
  * @param exchange 
  * @param type 
  * @param durable 
  * @param autoDelete 
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.rabbitmq.RabbitMQClient original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.rabbitmq.RabbitMQClient] using Vert.x codegen.
  */
-suspend fun RabbitMQClient.exchangeDeclareAwait(exchange : String, type : String, durable : Boolean, autoDelete : Boolean) : Unit {
-  return awaitResult{
-    this.exchangeDeclare(exchange, type, durable, autoDelete, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun RabbitMQClient.exchangeDeclareAwait(exchange: String, type: String, durable: Boolean, autoDelete: Boolean): Unit {
+  return awaitResult {
+    this.exchangeDeclare(exchange, type, durable, autoDelete) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Declare an exchange with additional parameters such as dead lettering, an alternate exchange or TTL.
+ * Suspending version of method [io.vertx.rabbitmq.RabbitMQClient.exchangeDeclare]
  *
  * @param exchange 
  * @param type 
@@ -210,185 +200,185 @@ suspend fun RabbitMQClient.exchangeDeclareAwait(exchange : String, type : String
  * @param autoDelete 
  * @param config 
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.rabbitmq.RabbitMQClient original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.rabbitmq.RabbitMQClient] using Vert.x codegen.
  */
-suspend fun RabbitMQClient.exchangeDeclareAwait(exchange : String, type : String, durable : Boolean, autoDelete : Boolean, config : JsonObject) : Unit {
-  return awaitResult{
-    this.exchangeDeclare(exchange, type, durable, autoDelete, config, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun RabbitMQClient.exchangeDeclareAwait(exchange: String, type: String, durable: Boolean, autoDelete: Boolean, config: JsonObject): Unit {
+  return awaitResult {
+    this.exchangeDeclare(exchange, type, durable, autoDelete, config) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Delete an exchange, without regard for whether it is in use or not.
+ * Suspending version of method [io.vertx.rabbitmq.RabbitMQClient.exchangeDelete]
  *
  * @param exchange 
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.rabbitmq.RabbitMQClient original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.rabbitmq.RabbitMQClient] using Vert.x codegen.
  */
-suspend fun RabbitMQClient.exchangeDeleteAwait(exchange : String) : Unit {
-  return awaitResult{
-    this.exchangeDelete(exchange, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun RabbitMQClient.exchangeDeleteAwait(exchange: String): Unit {
+  return awaitResult {
+    this.exchangeDelete(exchange) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Bind an exchange to an exchange.
+ * Suspending version of method [io.vertx.rabbitmq.RabbitMQClient.exchangeBind]
  *
  * @param destination 
  * @param source 
  * @param routingKey 
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.rabbitmq.RabbitMQClient original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.rabbitmq.RabbitMQClient] using Vert.x codegen.
  */
-suspend fun RabbitMQClient.exchangeBindAwait(destination : String, source : String, routingKey : String) : Unit {
-  return awaitResult{
-    this.exchangeBind(destination, source, routingKey, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun RabbitMQClient.exchangeBindAwait(destination: String, source: String, routingKey: String): Unit {
+  return awaitResult {
+    this.exchangeBind(destination, source, routingKey) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Unbind an exchange from an exchange.
+ * Suspending version of method [io.vertx.rabbitmq.RabbitMQClient.exchangeUnbind]
  *
  * @param destination 
  * @param source 
  * @param routingKey 
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.rabbitmq.RabbitMQClient original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.rabbitmq.RabbitMQClient] using Vert.x codegen.
  */
-suspend fun RabbitMQClient.exchangeUnbindAwait(destination : String, source : String, routingKey : String) : Unit {
-  return awaitResult{
-    this.exchangeUnbind(destination, source, routingKey, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun RabbitMQClient.exchangeUnbindAwait(destination: String, source: String, routingKey: String): Unit {
+  return awaitResult {
+    this.exchangeUnbind(destination, source, routingKey) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Actively declare a server-named exclusive, autodelete, non-durable queue.
+ * Suspending version of method [io.vertx.rabbitmq.RabbitMQClient.queueDeclareAuto]
  *
+ * @return [JsonObject]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.rabbitmq.RabbitMQClient original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.rabbitmq.RabbitMQClient] using Vert.x codegen.
  */
-suspend fun RabbitMQClient.queueDeclareAutoAwait() : JsonObject {
-  return awaitResult{
+suspend fun RabbitMQClient.queueDeclareAutoAwait(): JsonObject {
+  return awaitResult {
     this.queueDeclareAuto(it)
   }
 }
 
 /**
- * Declare a queue
+ * Suspending version of method [io.vertx.rabbitmq.RabbitMQClient.queueDeclare]
  *
  * @param queue 
  * @param durable 
  * @param exclusive 
  * @param autoDelete 
+ * @return [JsonObject]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.rabbitmq.RabbitMQClient original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.rabbitmq.RabbitMQClient] using Vert.x codegen.
  */
-suspend fun RabbitMQClient.queueDeclareAwait(queue : String, durable : Boolean, exclusive : Boolean, autoDelete : Boolean) : JsonObject {
-  return awaitResult{
+suspend fun RabbitMQClient.queueDeclareAwait(queue: String, durable: Boolean, exclusive: Boolean, autoDelete: Boolean): JsonObject {
+  return awaitResult {
     this.queueDeclare(queue, durable, exclusive, autoDelete, it)
   }
 }
 
 /**
- * Declare a queue with config options
+ * Suspending version of method [io.vertx.rabbitmq.RabbitMQClient.queueDeclare]
  *
  * @param queue 
  * @param durable 
  * @param exclusive 
  * @param autoDelete 
  * @param config 
+ * @return [JsonObject]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.rabbitmq.RabbitMQClient original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.rabbitmq.RabbitMQClient] using Vert.x codegen.
  */
-suspend fun RabbitMQClient.queueDeclareAwait(queue : String, durable : Boolean, exclusive : Boolean, autoDelete : Boolean, config : JsonObject) : JsonObject {
-  return awaitResult{
+suspend fun RabbitMQClient.queueDeclareAwait(queue: String, durable: Boolean, exclusive: Boolean, autoDelete: Boolean, config: JsonObject): JsonObject {
+  return awaitResult {
     this.queueDeclare(queue, durable, exclusive, autoDelete, config, it)
   }
 }
 
 /**
- * Delete a queue, without regard for whether it is in use or has messages on it
+ * Suspending version of method [io.vertx.rabbitmq.RabbitMQClient.queueDelete]
  *
  * @param queue 
+ * @return [JsonObject]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.rabbitmq.RabbitMQClient original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.rabbitmq.RabbitMQClient] using Vert.x codegen.
  */
-suspend fun RabbitMQClient.queueDeleteAwait(queue : String) : JsonObject {
-  return awaitResult{
+suspend fun RabbitMQClient.queueDeleteAwait(queue: String): JsonObject {
+  return awaitResult {
     this.queueDelete(queue, it)
   }
 }
 
 /**
- * Delete a queue
+ * Suspending version of method [io.vertx.rabbitmq.RabbitMQClient.queueDeleteIf]
  *
  * @param queue 
  * @param ifUnused 
  * @param ifEmpty 
+ * @return [JsonObject]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.rabbitmq.RabbitMQClient original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.rabbitmq.RabbitMQClient] using Vert.x codegen.
  */
-suspend fun RabbitMQClient.queueDeleteIfAwait(queue : String, ifUnused : Boolean, ifEmpty : Boolean) : JsonObject {
-  return awaitResult{
+suspend fun RabbitMQClient.queueDeleteIfAwait(queue: String, ifUnused: Boolean, ifEmpty: Boolean): JsonObject {
+  return awaitResult {
     this.queueDeleteIf(queue, ifUnused, ifEmpty, it)
   }
 }
 
 /**
- * Bind a queue to an exchange
+ * Suspending version of method [io.vertx.rabbitmq.RabbitMQClient.queueBind]
  *
  * @param queue 
  * @param exchange 
  * @param routingKey 
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.rabbitmq.RabbitMQClient original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.rabbitmq.RabbitMQClient] using Vert.x codegen.
  */
-suspend fun RabbitMQClient.queueBindAwait(queue : String, exchange : String, routingKey : String) : Unit {
-  return awaitResult{
-    this.queueBind(queue, exchange, routingKey, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun RabbitMQClient.queueBindAwait(queue: String, exchange: String, routingKey: String): Unit {
+  return awaitResult {
+    this.queueBind(queue, exchange, routingKey) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Returns the number of messages in a queue ready to be delivered.
+ * Suspending version of method [io.vertx.rabbitmq.RabbitMQClient.messageCount]
  *
  * @param queue 
+ * @return [Long]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.rabbitmq.RabbitMQClient original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.rabbitmq.RabbitMQClient] using Vert.x codegen.
  */
-suspend fun RabbitMQClient.messageCountAwait(queue : String) : Long {
-  return awaitResult{
+suspend fun RabbitMQClient.messageCountAwait(queue: String): Long {
+  return awaitResult {
     this.messageCount(queue, it)
   }
 }
 
 /**
- * Start the rabbitMQ client. Create the connection and the chanel.
+ * Suspending version of method [io.vertx.rabbitmq.RabbitMQClient.start]
  *
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.rabbitmq.RabbitMQClient original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.rabbitmq.RabbitMQClient] using Vert.x codegen.
  */
-suspend fun RabbitMQClient.startAwait() : Unit {
-  return awaitResult{
-    this.start({ ar -> it.handle(ar.mapEmpty()) })}
+suspend fun RabbitMQClient.startAwait(): Unit {
+  return awaitResult {
+    this.start { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Stop the rabbitMQ client. Close the connection and its chanel.
+ * Suspending version of method [io.vertx.rabbitmq.RabbitMQClient.stop]
  *
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.rabbitmq.RabbitMQClient original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.rabbitmq.RabbitMQClient] using Vert.x codegen.
  */
-suspend fun RabbitMQClient.stopAwait() : Unit {
-  return awaitResult{
-    this.stop({ ar -> it.handle(ar.mapEmpty()) })}
+suspend fun RabbitMQClient.stopAwait(): Unit {
+  return awaitResult {
+    this.stop { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/rabbitmq/RabbitMQConsumer.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/rabbitmq/RabbitMQConsumer.kt
@@ -4,16 +4,14 @@ import io.vertx.kotlin.coroutines.awaitResult
 import io.vertx.rabbitmq.RabbitMQConsumer
 
 /**
- * Stop message consumption from a queue.
- * <p>
- * The operation is asynchronous. When consumption will be stopped, you can by notified via [io.vertx.rabbitmq.RabbitMQConsumer]
+ * Suspending version of method [io.vertx.rabbitmq.RabbitMQConsumer.cancel]
  *
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.rabbitmq.RabbitMQConsumer original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.rabbitmq.RabbitMQConsumer] using Vert.x codegen.
  */
-suspend fun RabbitMQConsumer.cancelAwait() : Unit {
-  return awaitResult{
-    this.cancel({ ar -> it.handle(ar.mapEmpty()) })}
+suspend fun RabbitMQConsumer.cancelAwait(): Unit {
+  return awaitResult {
+    this.cancel { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/redis/RedisClient.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/redis/RedisClient.kt
@@ -30,1567 +30,1549 @@ import io.vertx.redis.op.SlotCmd
 import io.vertx.redis.op.SortOptions
 
 /**
- * Close the client - when it is fully closed the handler will be called.
+ * Suspending version of method [io.vertx.redis.RedisClient.close]
  *
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.closeAwait() : Unit {
-  return awaitResult{
-    this.close({ ar -> it.handle(ar.mapEmpty()) })}
+suspend fun RedisClient.closeAwait(): Unit {
+  return awaitResult {
+    this.close { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Append a value to a key
+ * Suspending version of method [io.vertx.redis.RedisClient.append]
  *
  * @param key Key string
  * @param value Value to append
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.appendAwait(key : String, value : String) : Long {
-  return awaitResult{
+suspend fun RedisClient.appendAwait(key: String, value: String): Long {
+  return awaitResult {
     this.append(key, value, it)
   }
 }
 
 /**
- * Authenticate to the server
+ * Suspending version of method [io.vertx.redis.RedisClient.auth]
  *
  * @param password Password for authentication
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.authAwait(password : String) : String {
-  return awaitResult{
+suspend fun RedisClient.authAwait(password: String): String {
+  return awaitResult {
     this.auth(password, it)
   }
 }
 
 /**
- * Asynchronously rewrite the append-only file
+ * Suspending version of method [io.vertx.redis.RedisClient.bgrewriteaof]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.bgrewriteaofAwait() : String {
-  return awaitResult{
+suspend fun RedisClient.bgrewriteaofAwait(): String {
+  return awaitResult {
     this.bgrewriteaof(it)
   }
 }
 
 /**
- * Asynchronously save the dataset to disk
+ * Suspending version of method [io.vertx.redis.RedisClient.bgsave]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.bgsaveAwait() : String {
-  return awaitResult{
+suspend fun RedisClient.bgsaveAwait(): String {
+  return awaitResult {
     this.bgsave(it)
   }
 }
 
 /**
- * Count set bits in a string
+ * Suspending version of method [io.vertx.redis.RedisClient.bitcount]
  *
  * @param key Key string
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.bitcountAwait(key : String) : Long {
-  return awaitResult{
+suspend fun RedisClient.bitcountAwait(key: String): Long {
+  return awaitResult {
     this.bitcount(key, it)
   }
 }
 
 /**
- * Count set bits in a string
+ * Suspending version of method [io.vertx.redis.RedisClient.bitcountRange]
  *
  * @param key Key string
  * @param start Start index
  * @param end End index
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.bitcountRangeAwait(key : String, start : Long, end : Long) : Long {
-  return awaitResult{
+suspend fun RedisClient.bitcountRangeAwait(key: String, start: Long, end: Long): Long {
+  return awaitResult {
     this.bitcountRange(key, start, end, it)
   }
 }
 
 /**
- * Perform bitwise operations between strings
+ * Suspending version of method [io.vertx.redis.RedisClient.bitop]
  *
  * @param operation Bitwise operation to perform
  * @param destkey Destination key where result is stored
  * @param keys List of keys on which to perform the operation
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.bitopAwait(operation : BitOperation, destkey : String, keys : List<String>) : Long {
-  return awaitResult{
+suspend fun RedisClient.bitopAwait(operation: BitOperation, destkey: String, keys: List<String>): Long {
+  return awaitResult {
     this.bitop(operation, destkey, keys, it)
   }
 }
 
 /**
- * Find first bit set or clear in a string
+ * Suspending version of method [io.vertx.redis.RedisClient.bitpos]
  *
  * @param key Key string
  * @param bit What bit value to look for - must be 1, or 0
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.bitposAwait(key : String, bit : Int) : Long {
-  return awaitResult{
+suspend fun RedisClient.bitposAwait(key: String, bit: Int): Long {
+  return awaitResult {
     this.bitpos(key, bit, it)
   }
 }
 
 /**
- * Find first bit set or clear in a string
- *
- * See also bitposRange() method, which takes start, and stop offset.
+ * Suspending version of method [io.vertx.redis.RedisClient.bitposFrom]
  *
  * @param key Key string
  * @param bit What bit value to look for - must be 1, or 0
  * @param start Start offset
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.bitposFromAwait(key : String, bit : Int, start : Int) : Long {
-  return awaitResult{
+suspend fun RedisClient.bitposFromAwait(key: String, bit: Int, start: Int): Long {
+  return awaitResult {
     this.bitposFrom(key, bit, start, it)
   }
 }
 
 /**
- * Find first bit set or clear in a string
- *
- * Note: when both start, and stop offsets are specified,
- * behaviour is slightly different than if only start is specified
+ * Suspending version of method [io.vertx.redis.RedisClient.bitposRange]
  *
  * @param key Key string
  * @param bit What bit value to look for - must be 1, or 0
  * @param start Start offset
  * @param stop End offset - inclusive
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.bitposRangeAwait(key : String, bit : Int, start : Int, stop : Int) : Long {
-  return awaitResult{
+suspend fun RedisClient.bitposRangeAwait(key: String, bit: Int, start: Int, stop: Int): Long {
+  return awaitResult {
     this.bitposRange(key, bit, start, stop, it)
   }
 }
 
 /**
- * Remove and get the first element in a list, or block until one is available
+ * Suspending version of method [io.vertx.redis.RedisClient.blpop]
  *
  * @param key Key string identifying a list to watch
  * @param seconds Timeout in seconds
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.blpopAwait(key : String, seconds : Int) : JsonArray {
-  return awaitResult{
+suspend fun RedisClient.blpopAwait(key: String, seconds: Int): JsonArray {
+  return awaitResult {
     this.blpop(key, seconds, it)
   }
 }
 
 /**
- * Remove and get the first element in any of the lists, or block until one is available
+ * Suspending version of method [io.vertx.redis.RedisClient.blpopMany]
  *
  * @param keys List of key strings identifying lists to watch
  * @param seconds Timeout in seconds
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.blpopManyAwait(keys : List<String>, seconds : Int) : JsonArray {
-  return awaitResult{
+suspend fun RedisClient.blpopManyAwait(keys: List<String>, seconds: Int): JsonArray {
+  return awaitResult {
     this.blpopMany(keys, seconds, it)
   }
 }
 
 /**
- * Remove and get the last element in a list, or block until one is available
+ * Suspending version of method [io.vertx.redis.RedisClient.brpop]
  *
  * @param key Key string identifying a list to watch
  * @param seconds Timeout in seconds
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.brpopAwait(key : String, seconds : Int) : JsonArray {
-  return awaitResult{
+suspend fun RedisClient.brpopAwait(key: String, seconds: Int): JsonArray {
+  return awaitResult {
     this.brpop(key, seconds, it)
   }
 }
 
 /**
- * Remove and get the last element in any of the lists, or block until one is available
+ * Suspending version of method [io.vertx.redis.RedisClient.brpopMany]
  *
  * @param keys List of key strings identifying lists to watch
  * @param seconds Timeout in seconds
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.brpopManyAwait(keys : List<String>, seconds : Int) : JsonArray {
-  return awaitResult{
+suspend fun RedisClient.brpopManyAwait(keys: List<String>, seconds: Int): JsonArray {
+  return awaitResult {
     this.brpopMany(keys, seconds, it)
   }
 }
 
 /**
- * Pop a value from a list, push it to another list and return it; or block until one is available
+ * Suspending version of method [io.vertx.redis.RedisClient.brpoplpush]
  *
  * @param key Key string identifying the source list
  * @param destkey Key string identifying the destination list
  * @param seconds Timeout in seconds
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.brpoplpushAwait(key : String, destkey : String, seconds : Int) : String {
-  return awaitResult{
+suspend fun RedisClient.brpoplpushAwait(key: String, destkey: String, seconds: Int): String {
+  return awaitResult {
     this.brpoplpush(key, destkey, seconds, it)
   }
 }
 
 /**
- * Kill the connection of a client
+ * Suspending version of method [io.vertx.redis.RedisClient.clientKill]
  *
  * @param filter Filter options
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.clientKillAwait(filter : KillFilter) : Long {
-  return awaitResult{
+suspend fun RedisClient.clientKillAwait(filter: KillFilter): Long {
+  return awaitResult {
     this.clientKill(filter, it)
   }
 }
 
 /**
- * Get the list of client connections
+ * Suspending version of method [io.vertx.redis.RedisClient.clientList]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.clientListAwait() : String {
-  return awaitResult{
+suspend fun RedisClient.clientListAwait(): String {
+  return awaitResult {
     this.clientList(it)
   }
 }
 
 /**
- * Get the current connection name
+ * Suspending version of method [io.vertx.redis.RedisClient.clientGetname]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.clientGetnameAwait() : String {
-  return awaitResult{
+suspend fun RedisClient.clientGetnameAwait(): String {
+  return awaitResult {
     this.clientGetname(it)
   }
 }
 
 /**
- * Stop processing commands from clients for some time
+ * Suspending version of method [io.vertx.redis.RedisClient.clientPause]
  *
  * @param millis Pause time in milliseconds
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.clientPauseAwait(millis : Long) : String {
-  return awaitResult{
+suspend fun RedisClient.clientPauseAwait(millis: Long): String {
+  return awaitResult {
     this.clientPause(millis, it)
   }
 }
 
 /**
- * Set the current connection name
+ * Suspending version of method [io.vertx.redis.RedisClient.clientSetname]
  *
  * @param name New name for current connection
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.clientSetnameAwait(name : String) : String {
-  return awaitResult{
+suspend fun RedisClient.clientSetnameAwait(name: String): String {
+  return awaitResult {
     this.clientSetname(name, it)
   }
 }
 
 /**
- * Assign new hash slots to receiving node.
+ * Suspending version of method [io.vertx.redis.RedisClient.clusterAddslots]
  *
  * @param slots 
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.clusterAddslotsAwait(slots : List<Long>) : Unit {
-  return awaitResult{
-    this.clusterAddslots(slots, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun RedisClient.clusterAddslotsAwait(slots: List<Long>): Unit {
+  return awaitResult {
+    this.clusterAddslots(slots) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Return the number of failure reports active for a given node.
+ * Suspending version of method [io.vertx.redis.RedisClient.clusterCountFailureReports]
  *
  * @param nodeId 
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.clusterCountFailureReportsAwait(nodeId : String) : Long {
-  return awaitResult{
+suspend fun RedisClient.clusterCountFailureReportsAwait(nodeId: String): Long {
+  return awaitResult {
     this.clusterCountFailureReports(nodeId, it)
   }
 }
 
 /**
- * Return the number of local keys in the specified hash slot.
+ * Suspending version of method [io.vertx.redis.RedisClient.clusterCountkeysinslot]
  *
  * @param slot 
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.clusterCountkeysinslotAwait(slot : Long) : Long {
-  return awaitResult{
+suspend fun RedisClient.clusterCountkeysinslotAwait(slot: Long): Long {
+  return awaitResult {
     this.clusterCountkeysinslot(slot, it)
   }
 }
 
 /**
- * Set hash slots as unbound in receiving node.
+ * Suspending version of method [io.vertx.redis.RedisClient.clusterDelslots]
  *
  * @param slot 
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.clusterDelslotsAwait(slot : Long) : Unit {
-  return awaitResult{
-    this.clusterDelslots(slot, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun RedisClient.clusterDelslotsAwait(slot: Long): Unit {
+  return awaitResult {
+    this.clusterDelslots(slot) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Set hash slots as unbound in receiving node.
+ * Suspending version of method [io.vertx.redis.RedisClient.clusterDelslotsMany]
  *
  * @param slots 
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
- */
-suspend fun RedisClient.clusterDelslotsManyAwait(slots : List<Long>) : Unit {
-  return awaitResult{
-    this.clusterDelslotsMany(slots, { ar -> it.handle(ar.mapEmpty()) })}
-}
-
-/**
- * Forces a slave to perform a manual failover of its master.
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.clusterFailoverAwait() : Unit {
-  return awaitResult{
-    this.clusterFailover({ ar -> it.handle(ar.mapEmpty()) })}
+suspend fun RedisClient.clusterDelslotsManyAwait(slots: List<Long>): Unit {
+  return awaitResult {
+    this.clusterDelslotsMany(slots) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Forces a slave to perform a manual failover of its master.
+ * Suspending version of method [io.vertx.redis.RedisClient.clusterFailover]
+ *
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
+ */
+suspend fun RedisClient.clusterFailoverAwait(): Unit {
+  return awaitResult {
+    this.clusterFailover { ar -> it.handle(ar.mapEmpty()) }
+  }
+}
+
+/**
+ * Suspending version of method [io.vertx.redis.RedisClient.clusterFailOverWithOptions]
  *
  * @param options 
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.clusterFailOverWithOptionsAwait(options : FailoverOptions) : Unit {
-  return awaitResult{
-    this.clusterFailOverWithOptions(options, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun RedisClient.clusterFailOverWithOptionsAwait(options: FailoverOptions): Unit {
+  return awaitResult {
+    this.clusterFailOverWithOptions(options) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Remove a node from the nodes table.
+ * Suspending version of method [io.vertx.redis.RedisClient.clusterForget]
  *
  * @param nodeId 
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.clusterForgetAwait(nodeId : String) : Unit {
-  return awaitResult{
-    this.clusterForget(nodeId, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun RedisClient.clusterForgetAwait(nodeId: String): Unit {
+  return awaitResult {
+    this.clusterForget(nodeId) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Return local key names in the specified hash slot.
+ * Suspending version of method [io.vertx.redis.RedisClient.clusterGetkeysinslot]
  *
  * @param slot 
  * @param count 
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.clusterGetkeysinslotAwait(slot : Long, count : Long) : JsonArray {
-  return awaitResult{
+suspend fun RedisClient.clusterGetkeysinslotAwait(slot: Long, count: Long): JsonArray {
+  return awaitResult {
     this.clusterGetkeysinslot(slot, count, it)
   }
 }
 
 /**
- * Provides info about Redis Cluster node state.
+ * Suspending version of method [io.vertx.redis.RedisClient.clusterInfo]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.clusterInfoAwait() : JsonArray {
-  return awaitResult{
+suspend fun RedisClient.clusterInfoAwait(): JsonArray {
+  return awaitResult {
     this.clusterInfo(it)
   }
 }
 
 /**
- * Returns the hash slot of the specified key.
+ * Suspending version of method [io.vertx.redis.RedisClient.clusterKeyslot]
  *
  * @param key 
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.clusterKeyslotAwait(key : String) : Long {
-  return awaitResult{
+suspend fun RedisClient.clusterKeyslotAwait(key: String): Long {
+  return awaitResult {
     this.clusterKeyslot(key, it)
   }
 }
 
 /**
- * Force a node cluster to handshake with another node.
+ * Suspending version of method [io.vertx.redis.RedisClient.clusterMeet]
  *
  * @param ip 
  * @param port 
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.clusterMeetAwait(ip : String, port : Long) : Unit {
-  return awaitResult{
-    this.clusterMeet(ip, port, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun RedisClient.clusterMeetAwait(ip: String, port: Long): Unit {
+  return awaitResult {
+    this.clusterMeet(ip, port) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Get Cluster config for the node.
+ * Suspending version of method [io.vertx.redis.RedisClient.clusterNodes]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.clusterNodesAwait() : JsonArray {
-  return awaitResult{
+suspend fun RedisClient.clusterNodesAwait(): JsonArray {
+  return awaitResult {
     this.clusterNodes(it)
   }
 }
 
 /**
- * Reconfigure a node as a slave of the specified master node.
+ * Suspending version of method [io.vertx.redis.RedisClient.clusterReplicate]
  *
  * @param nodeId 
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
- */
-suspend fun RedisClient.clusterReplicateAwait(nodeId : String) : Unit {
-  return awaitResult{
-    this.clusterReplicate(nodeId, { ar -> it.handle(ar.mapEmpty()) })}
-}
-
-/**
- * Reset a Redis Cluster node.
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.clusterResetAwait() : Unit {
-  return awaitResult{
-    this.clusterReset({ ar -> it.handle(ar.mapEmpty()) })}
+suspend fun RedisClient.clusterReplicateAwait(nodeId: String): Unit {
+  return awaitResult {
+    this.clusterReplicate(nodeId) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Reset a Redis Cluster node.
+ * Suspending version of method [io.vertx.redis.RedisClient.clusterReset]
+ *
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
+ */
+suspend fun RedisClient.clusterResetAwait(): Unit {
+  return awaitResult {
+    this.clusterReset { ar -> it.handle(ar.mapEmpty()) }
+  }
+}
+
+/**
+ * Suspending version of method [io.vertx.redis.RedisClient.clusterResetWithOptions]
  *
  * @param options 
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
- */
-suspend fun RedisClient.clusterResetWithOptionsAwait(options : ResetOptions) : Unit {
-  return awaitResult{
-    this.clusterResetWithOptions(options, { ar -> it.handle(ar.mapEmpty()) })}
-}
-
-/**
- * Forces the node to save cluster state on disk.
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.clusterSaveconfigAwait() : Unit {
-  return awaitResult{
-    this.clusterSaveconfig({ ar -> it.handle(ar.mapEmpty()) })}
+suspend fun RedisClient.clusterResetWithOptionsAwait(options: ResetOptions): Unit {
+  return awaitResult {
+    this.clusterResetWithOptions(options) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Set the configuration epoch in a new node.
+ * Suspending version of method [io.vertx.redis.RedisClient.clusterSaveconfig]
+ *
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
+ */
+suspend fun RedisClient.clusterSaveconfigAwait(): Unit {
+  return awaitResult {
+    this.clusterSaveconfig { ar -> it.handle(ar.mapEmpty()) }
+  }
+}
+
+/**
+ * Suspending version of method [io.vertx.redis.RedisClient.clusterSetConfigEpoch]
  *
  * @param epoch 
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.clusterSetConfigEpochAwait(epoch : Long) : Unit {
-  return awaitResult{
-    this.clusterSetConfigEpoch(epoch, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun RedisClient.clusterSetConfigEpochAwait(epoch: Long): Unit {
+  return awaitResult {
+    this.clusterSetConfigEpoch(epoch) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Bind an hash slot to a specific node.
+ * Suspending version of method [io.vertx.redis.RedisClient.clusterSetslot]
  *
  * @param slot 
  * @param subcommand 
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.clusterSetslotAwait(slot : Long, subcommand : SlotCmd) : Unit {
-  return awaitResult{
-    this.clusterSetslot(slot, subcommand, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun RedisClient.clusterSetslotAwait(slot: Long, subcommand: SlotCmd): Unit {
+  return awaitResult {
+    this.clusterSetslot(slot, subcommand) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Bind an hash slot to a specific node.
+ * Suspending version of method [io.vertx.redis.RedisClient.clusterSetslotWithNode]
  *
  * @param slot 
  * @param subcommand 
  * @param nodeId 
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.clusterSetslotWithNodeAwait(slot : Long, subcommand : SlotCmd, nodeId : String) : Unit {
-  return awaitResult{
-    this.clusterSetslotWithNode(slot, subcommand, nodeId, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun RedisClient.clusterSetslotWithNodeAwait(slot: Long, subcommand: SlotCmd, nodeId: String): Unit {
+  return awaitResult {
+    this.clusterSetslotWithNode(slot, subcommand, nodeId) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * List slave nodes of the specified master node.
+ * Suspending version of method [io.vertx.redis.RedisClient.clusterSlaves]
  *
  * @param nodeId 
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.clusterSlavesAwait(nodeId : String) : JsonArray {
-  return awaitResult{
+suspend fun RedisClient.clusterSlavesAwait(nodeId: String): JsonArray {
+  return awaitResult {
     this.clusterSlaves(nodeId, it)
   }
 }
 
 /**
- * Get array of Cluster slot to node mappings
+ * Suspending version of method [io.vertx.redis.RedisClient.clusterSlots]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.clusterSlotsAwait() : JsonArray {
-  return awaitResult{
+suspend fun RedisClient.clusterSlotsAwait(): JsonArray {
+  return awaitResult {
     this.clusterSlots(it)
   }
 }
 
 /**
- * Get array of Redis command details
+ * Suspending version of method [io.vertx.redis.RedisClient.command]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.commandAwait() : JsonArray {
-  return awaitResult{
+suspend fun RedisClient.commandAwait(): JsonArray {
+  return awaitResult {
     this.command(it)
   }
 }
 
 /**
- * Get total number of Redis commands
+ * Suspending version of method [io.vertx.redis.RedisClient.commandCount]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.commandCountAwait() : Long {
-  return awaitResult{
+suspend fun RedisClient.commandCountAwait(): Long {
+  return awaitResult {
     this.commandCount(it)
   }
 }
 
 /**
- * Extract keys given a full Redis command
+ * Suspending version of method [io.vertx.redis.RedisClient.commandGetkeys]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.commandGetkeysAwait() : JsonArray {
-  return awaitResult{
+suspend fun RedisClient.commandGetkeysAwait(): JsonArray {
+  return awaitResult {
     this.commandGetkeys(it)
   }
 }
 
 /**
- * Get array of specific Redis command details
+ * Suspending version of method [io.vertx.redis.RedisClient.commandInfo]
  *
  * @param commands List of commands to get info for
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.commandInfoAwait(commands : List<String>) : JsonArray {
-  return awaitResult{
+suspend fun RedisClient.commandInfoAwait(commands: List<String>): JsonArray {
+  return awaitResult {
     this.commandInfo(commands, it)
   }
 }
 
 /**
- * Get the value of a configuration parameter
+ * Suspending version of method [io.vertx.redis.RedisClient.configGet]
  *
  * @param parameter Configuration parameter
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.configGetAwait(parameter : String) : JsonArray {
-  return awaitResult{
+suspend fun RedisClient.configGetAwait(parameter: String): JsonArray {
+  return awaitResult {
     this.configGet(parameter, it)
   }
 }
 
 /**
- * Rewrite the configuration file with the in memory configuration
+ * Suspending version of method [io.vertx.redis.RedisClient.configRewrite]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.configRewriteAwait() : String {
-  return awaitResult{
+suspend fun RedisClient.configRewriteAwait(): String {
+  return awaitResult {
     this.configRewrite(it)
   }
 }
 
 /**
- * Set a configuration parameter to the given value
+ * Suspending version of method [io.vertx.redis.RedisClient.configSet]
  *
  * @param parameter Configuration parameter
  * @param value New value
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.configSetAwait(parameter : String, value : String) : String {
-  return awaitResult{
+suspend fun RedisClient.configSetAwait(parameter: String, value: String): String {
+  return awaitResult {
     this.configSet(parameter, value, it)
   }
 }
 
 /**
- * Reset the stats returned by INFO
+ * Suspending version of method [io.vertx.redis.RedisClient.configResetstat]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.configResetstatAwait() : String {
-  return awaitResult{
+suspend fun RedisClient.configResetstatAwait(): String {
+  return awaitResult {
     this.configResetstat(it)
   }
 }
 
 /**
- * Return the number of keys in the selected database
+ * Suspending version of method [io.vertx.redis.RedisClient.dbsize]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.dbsizeAwait() : Long {
-  return awaitResult{
+suspend fun RedisClient.dbsizeAwait(): Long {
+  return awaitResult {
     this.dbsize(it)
   }
 }
 
 /**
- * Get debugging information about a key
+ * Suspending version of method [io.vertx.redis.RedisClient.debugObject]
  *
  * @param key Key string
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.debugObjectAwait(key : String) : String {
-  return awaitResult{
+suspend fun RedisClient.debugObjectAwait(key: String): String {
+  return awaitResult {
     this.debugObject(key, it)
   }
 }
 
 /**
- * Make the server crash
+ * Suspending version of method [io.vertx.redis.RedisClient.debugSegfault]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.debugSegfaultAwait() : String {
-  return awaitResult{
+suspend fun RedisClient.debugSegfaultAwait(): String {
+  return awaitResult {
     this.debugSegfault(it)
   }
 }
 
 /**
- * Decrement the integer value of a key by one
+ * Suspending version of method [io.vertx.redis.RedisClient.decr]
  *
  * @param key Key string
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.decrAwait(key : String) : Long {
-  return awaitResult{
+suspend fun RedisClient.decrAwait(key: String): Long {
+  return awaitResult {
     this.decr(key, it)
   }
 }
 
 /**
- * Decrement the integer value of a key by the given number
+ * Suspending version of method [io.vertx.redis.RedisClient.decrby]
  *
  * @param key Key string
  * @param decrement Value by which to decrement
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.decrbyAwait(key : String, decrement : Long) : Long {
-  return awaitResult{
+suspend fun RedisClient.decrbyAwait(key: String, decrement: Long): Long {
+  return awaitResult {
     this.decrby(key, decrement, it)
   }
 }
 
 /**
- * Delete a key
+ * Suspending version of method [io.vertx.redis.RedisClient.del]
  *
  * @param key Keys to delete
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.delAwait(key : String) : Long {
-  return awaitResult{
+suspend fun RedisClient.delAwait(key: String): Long {
+  return awaitResult {
     this.del(key, it)
   }
 }
 
 /**
- * Delete many keys
+ * Suspending version of method [io.vertx.redis.RedisClient.delMany]
  *
  * @param keys List of keys to delete
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.delManyAwait(keys : List<String>) : Long {
-  return awaitResult{
+suspend fun RedisClient.delManyAwait(keys: List<String>): Long {
+  return awaitResult {
     this.delMany(keys, it)
   }
 }
 
 /**
- * Return a serialized version of the value stored at the specified key.
+ * Suspending version of method [io.vertx.redis.RedisClient.dump]
  *
  * @param key Key string
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.dumpAwait(key : String) : String {
-  return awaitResult{
+suspend fun RedisClient.dumpAwait(key: String): String {
+  return awaitResult {
     this.dump(key, it)
   }
 }
 
 /**
- * Echo the given string
+ * Suspending version of method [io.vertx.redis.RedisClient.echo]
  *
  * @param message String to echo
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.echoAwait(message : String) : String {
-  return awaitResult{
+suspend fun RedisClient.echoAwait(message: String): String {
+  return awaitResult {
     this.echo(message, it)
   }
 }
 
 /**
- * Execute a Lua script server side. Due to the dynamic nature of this command any response type could be returned
- * for This reason and to ensure type safety the reply is always guaranteed to be a JsonArray.
- *
- * When a reply if for example a String the handler will be called with a JsonArray with a single element containing
- * the String.
+ * Suspending version of method [io.vertx.redis.RedisClient.eval]
  *
  * @param script Lua script to evaluate
  * @param keys List of keys
  * @param args List of argument values
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.evalAwait(script : String, keys : List<String>, args : List<String>) : JsonArray {
-  return awaitResult{
+suspend fun RedisClient.evalAwait(script: String, keys: List<String>, args: List<String>): JsonArray {
+  return awaitResult {
     this.eval(script, keys, args, it)
   }
 }
 
 /**
- * Execute a Lua script server side. Due to the dynamic nature of this command any response type could be returned
- * for This reason and to ensure type safety the reply is always guaranteed to be a JsonArray.
- *
- * When a reply if for example a String the handler will be called with a JsonArray with a single element containing
- * the String.
+ * Suspending version of method [io.vertx.redis.RedisClient.evalsha]
  *
  * @param sha1 SHA1 digest of the script cached on the server
  * @param keys List of keys
  * @param values List of values
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.evalshaAwait(sha1 : String, keys : List<String>, values : List<String>) : JsonArray {
-  return awaitResult{
+suspend fun RedisClient.evalshaAwait(sha1: String, keys: List<String>, values: List<String>): JsonArray {
+  return awaitResult {
     this.evalsha(sha1, keys, values, it)
   }
 }
 
 /**
- * Execute a Lua script server side. This method is a high level wrapper around EVAL and EVALSHA
- * using the latter if possible, falling back to EVAL if the script is not cached by the server yet.
- * According to Redis documentation, executed scripts are guaranteed to be in the script cache of a
- * given execution of a Redis instance forever, which means typically the overhead incurred by
- * optimistically sending EVALSHA is minimal, while improving performance and saving bandwidth
- * compared to using EVAL every time.
+ * Suspending version of method [io.vertx.redis.RedisClient.evalScript]
  *
  * @param script Lua script and its SHA1 digest
  * @param keys List of keys
  * @param args List of argument values
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.evalScriptAwait(script : Script, keys : List<String>, args : List<String>) : JsonArray {
-  return awaitResult{
+suspend fun RedisClient.evalScriptAwait(script: Script, keys: List<String>, args: List<String>): JsonArray {
+  return awaitResult {
     this.evalScript(script, keys, args, it)
   }
 }
 
 /**
- * Determine if a key exists
+ * Suspending version of method [io.vertx.redis.RedisClient.exists]
  *
  * @param key Key string
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.existsAwait(key : String) : Long {
-  return awaitResult{
+suspend fun RedisClient.existsAwait(key: String): Long {
+  return awaitResult {
     this.exists(key, it)
   }
 }
 
 /**
- * Determine if one or many keys exist
+ * Suspending version of method [io.vertx.redis.RedisClient.existsMany]
  *
  * @param keys List of key strings
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.existsManyAwait(keys : List<String>) : Long {
-  return awaitResult{
+suspend fun RedisClient.existsManyAwait(keys: List<String>): Long {
+  return awaitResult {
     this.existsMany(keys, it)
   }
 }
 
 /**
- * Set a key's time to live in seconds
+ * Suspending version of method [io.vertx.redis.RedisClient.expire]
  *
  * @param key Key string
  * @param seconds Time to live in seconds
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.expireAwait(key : String, seconds : Long) : Long {
-  return awaitResult{
+suspend fun RedisClient.expireAwait(key: String, seconds: Long): Long {
+  return awaitResult {
     this.expire(key, seconds, it)
   }
 }
 
 /**
- * Set the expiration for a key as a UNIX timestamp
+ * Suspending version of method [io.vertx.redis.RedisClient.expireat]
  *
  * @param key Key string
  * @param seconds Expiry time as Unix timestamp in seconds
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.expireatAwait(key : String, seconds : Long) : Long {
-  return awaitResult{
+suspend fun RedisClient.expireatAwait(key: String, seconds: Long): Long {
+  return awaitResult {
     this.expireat(key, seconds, it)
   }
 }
 
 /**
- * Remove all keys from all databases
+ * Suspending version of method [io.vertx.redis.RedisClient.flushall]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.flushallAwait() : String {
-  return awaitResult{
+suspend fun RedisClient.flushallAwait(): String {
+  return awaitResult {
     this.flushall(it)
   }
 }
 
 /**
- * Remove all keys from the current database
+ * Suspending version of method [io.vertx.redis.RedisClient.flushdb]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.flushdbAwait() : String {
-  return awaitResult{
+suspend fun RedisClient.flushdbAwait(): String {
+  return awaitResult {
     this.flushdb(it)
   }
 }
 
 /**
- * Get the value of a key
+ * Suspending version of method [io.vertx.redis.RedisClient.get]
  *
  * @param key Key string
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [String?]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.getAwait(key : String) : String? {
-  return awaitResult{
+suspend fun RedisClient.getAwait(key: String): String? {
+  return awaitResult {
     this.get(key, it)
   }
 }
 
 /**
- * Get the value of a key - without decoding as utf-8
+ * Suspending version of method [io.vertx.redis.RedisClient.getBinary]
  *
  * @param key Key string
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Buffer?]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.getBinaryAwait(key : String) : Buffer? {
-  return awaitResult{
+suspend fun RedisClient.getBinaryAwait(key: String): Buffer? {
+  return awaitResult {
     this.getBinary(key, it)
   }
 }
 
 /**
- * Returns the bit value at offset in the string value stored at key
+ * Suspending version of method [io.vertx.redis.RedisClient.getbit]
  *
  * @param key Key string
  * @param offset Offset in bits
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.getbitAwait(key : String, offset : Long) : Long {
-  return awaitResult{
+suspend fun RedisClient.getbitAwait(key: String, offset: Long): Long {
+  return awaitResult {
     this.getbit(key, offset, it)
   }
 }
 
 /**
- * Get a substring of the string stored at a key
+ * Suspending version of method [io.vertx.redis.RedisClient.getrange]
  *
  * @param key Key string
  * @param start Start offset
  * @param end End offset - inclusive
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.getrangeAwait(key : String, start : Long, end : Long) : String {
-  return awaitResult{
+suspend fun RedisClient.getrangeAwait(key: String, start: Long, end: Long): String {
+  return awaitResult {
     this.getrange(key, start, end, it)
   }
 }
 
 /**
- * Set the string value of a key and return its old value
+ * Suspending version of method [io.vertx.redis.RedisClient.getset]
  *
  * @param key Key of which value to set
  * @param value New value for the key
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [String?]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.getsetAwait(key : String, value : String) : String? {
-  return awaitResult{
+suspend fun RedisClient.getsetAwait(key: String, value: String): String? {
+  return awaitResult {
     this.getset(key, value, it)
   }
 }
 
 /**
- * Delete one or more hash fields
+ * Suspending version of method [io.vertx.redis.RedisClient.hdel]
  *
  * @param key Key string
  * @param field Field name
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.hdelAwait(key : String, field : String) : Long {
-  return awaitResult{
+suspend fun RedisClient.hdelAwait(key: String, field: String): Long {
+  return awaitResult {
     this.hdel(key, field, it)
   }
 }
 
 /**
- * Delete one or more hash fields
+ * Suspending version of method [io.vertx.redis.RedisClient.hdelMany]
  *
  * @param key Key string
  * @param fields Field names
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.hdelManyAwait(key : String, fields : List<String>) : Long {
-  return awaitResult{
+suspend fun RedisClient.hdelManyAwait(key: String, fields: List<String>): Long {
+  return awaitResult {
     this.hdelMany(key, fields, it)
   }
 }
 
 /**
- * Determine if a hash field exists
+ * Suspending version of method [io.vertx.redis.RedisClient.hexists]
  *
  * @param key Key string
  * @param field Field name
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.hexistsAwait(key : String, field : String) : Long {
-  return awaitResult{
+suspend fun RedisClient.hexistsAwait(key: String, field: String): Long {
+  return awaitResult {
     this.hexists(key, field, it)
   }
 }
 
 /**
- * Get the value of a hash field
+ * Suspending version of method [io.vertx.redis.RedisClient.hget]
  *
  * @param key Key string
  * @param field Field name
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [String?]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.hgetAwait(key : String, field : String) : String? {
-  return awaitResult{
+suspend fun RedisClient.hgetAwait(key: String, field: String): String? {
+  return awaitResult {
     this.hget(key, field, it)
   }
 }
 
 /**
- * Get all the fields and values in a hash
+ * Suspending version of method [io.vertx.redis.RedisClient.hgetall]
  *
  * @param key Key string
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [JsonObject]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.hgetallAwait(key : String) : JsonObject {
-  return awaitResult{
+suspend fun RedisClient.hgetallAwait(key: String): JsonObject {
+  return awaitResult {
     this.hgetall(key, it)
   }
 }
 
 /**
- * Increment the integer value of a hash field by the given number
+ * Suspending version of method [io.vertx.redis.RedisClient.hincrby]
  *
  * @param key Key string
  * @param field Field name
  * @param increment Value by which to increment
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.hincrbyAwait(key : String, field : String, increment : Long) : Long {
-  return awaitResult{
+suspend fun RedisClient.hincrbyAwait(key: String, field: String, increment: Long): Long {
+  return awaitResult {
     this.hincrby(key, field, increment, it)
   }
 }
 
 /**
- * Increment the float value of a hash field by the given amount
+ * Suspending version of method [io.vertx.redis.RedisClient.hincrbyfloat]
  *
  * @param key Key string
  * @param field Field name
  * @param increment Value by which to increment
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.hincrbyfloatAwait(key : String, field : String, increment : Double) : String {
-  return awaitResult{
+suspend fun RedisClient.hincrbyfloatAwait(key: String, field: String, increment: Double): String {
+  return awaitResult {
     this.hincrbyfloat(key, field, increment, it)
   }
 }
 
 /**
- * Get all the fields in a hash
+ * Suspending version of method [io.vertx.redis.RedisClient.hkeys]
  *
  * @param key Key string
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.hkeysAwait(key : String) : JsonArray {
-  return awaitResult{
+suspend fun RedisClient.hkeysAwait(key: String): JsonArray {
+  return awaitResult {
     this.hkeys(key, it)
   }
 }
 
 /**
- * Get the number of fields in a hash
+ * Suspending version of method [io.vertx.redis.RedisClient.hlen]
  *
  * @param key Key string
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.hlenAwait(key : String) : Long {
-  return awaitResult{
+suspend fun RedisClient.hlenAwait(key: String): Long {
+  return awaitResult {
     this.hlen(key, it)
   }
 }
 
 /**
- * Get the values of all the given hash fields
+ * Suspending version of method [io.vertx.redis.RedisClient.hmget]
  *
  * @param key Key string
  * @param fields Field names
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.hmgetAwait(key : String, fields : List<String>) : JsonArray {
-  return awaitResult{
+suspend fun RedisClient.hmgetAwait(key: String, fields: List<String>): JsonArray {
+  return awaitResult {
     this.hmget(key, fields, it)
   }
 }
 
 /**
- * Set multiple hash fields to multiple values
+ * Suspending version of method [io.vertx.redis.RedisClient.hmset]
  *
  * @param key Key string
  * @param values Map of field:value pairs
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.hmsetAwait(key : String, values : JsonObject) : String {
-  return awaitResult{
+suspend fun RedisClient.hmsetAwait(key: String, values: JsonObject): String {
+  return awaitResult {
     this.hmset(key, values, it)
   }
 }
 
 /**
- * Set the string value of a hash field
+ * Suspending version of method [io.vertx.redis.RedisClient.hset]
  *
  * @param key Key string
  * @param field Field name
  * @param value New value
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.hsetAwait(key : String, field : String, value : String) : Long {
-  return awaitResult{
+suspend fun RedisClient.hsetAwait(key: String, field: String, value: String): Long {
+  return awaitResult {
     this.hset(key, field, value, it)
   }
 }
 
 /**
- * Set the value of a hash field, only if the field does not exist
+ * Suspending version of method [io.vertx.redis.RedisClient.hsetnx]
  *
  * @param key Key string
  * @param field Field name
  * @param value New value
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.hsetnxAwait(key : String, field : String, value : String) : Long {
-  return awaitResult{
+suspend fun RedisClient.hsetnxAwait(key: String, field: String, value: String): Long {
+  return awaitResult {
     this.hsetnx(key, field, value, it)
   }
 }
 
 /**
- * Get all the values in a hash
+ * Suspending version of method [io.vertx.redis.RedisClient.hvals]
  *
  * @param key Key string
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.hvalsAwait(key : String) : JsonArray {
-  return awaitResult{
+suspend fun RedisClient.hvalsAwait(key: String): JsonArray {
+  return awaitResult {
     this.hvals(key, it)
   }
 }
 
 /**
- * Increment the integer value of a key by one
+ * Suspending version of method [io.vertx.redis.RedisClient.incr]
  *
  * @param key Key string
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.incrAwait(key : String) : Long {
-  return awaitResult{
+suspend fun RedisClient.incrAwait(key: String): Long {
+  return awaitResult {
     this.incr(key, it)
   }
 }
 
 /**
- * Increment the integer value of a key by the given amount
+ * Suspending version of method [io.vertx.redis.RedisClient.incrby]
  *
  * @param key Key string
  * @param increment Value by which to increment
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.incrbyAwait(key : String, increment : Long) : Long {
-  return awaitResult{
+suspend fun RedisClient.incrbyAwait(key: String, increment: Long): Long {
+  return awaitResult {
     this.incrby(key, increment, it)
   }
 }
 
 /**
- * Increment the float value of a key by the given amount
+ * Suspending version of method [io.vertx.redis.RedisClient.incrbyfloat]
  *
  * @param key Key string
  * @param increment Value by which to increment
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.incrbyfloatAwait(key : String, increment : Double) : String {
-  return awaitResult{
+suspend fun RedisClient.incrbyfloatAwait(key: String, increment: Double): String {
+  return awaitResult {
     this.incrbyfloat(key, increment, it)
   }
 }
 
 /**
- * Get information and statistics about the server
+ * Suspending version of method [io.vertx.redis.RedisClient.info]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [JsonObject]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.infoAwait() : JsonObject {
-  return awaitResult{
+suspend fun RedisClient.infoAwait(): JsonObject {
+  return awaitResult {
     this.info(it)
   }
 }
 
 /**
- * Get information and statistics about the server
+ * Suspending version of method [io.vertx.redis.RedisClient.infoSection]
  *
  * @param section Specific section of information to return
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [JsonObject]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.infoSectionAwait(section : String) : JsonObject {
-  return awaitResult{
+suspend fun RedisClient.infoSectionAwait(section: String): JsonObject {
+  return awaitResult {
     this.infoSection(section, it)
   }
 }
 
 /**
- * Find all keys matching the given pattern
+ * Suspending version of method [io.vertx.redis.RedisClient.keys]
  *
  * @param pattern Pattern to limit the keys returned
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.keysAwait(pattern : String) : JsonArray {
-  return awaitResult{
+suspend fun RedisClient.keysAwait(pattern: String): JsonArray {
+  return awaitResult {
     this.keys(pattern, it)
   }
 }
 
 /**
- * Get the UNIX time stamp of the last successful save to disk
+ * Suspending version of method [io.vertx.redis.RedisClient.lastsave]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.lastsaveAwait() : Long {
-  return awaitResult{
+suspend fun RedisClient.lastsaveAwait(): Long {
+  return awaitResult {
     this.lastsave(it)
   }
 }
 
 /**
- * Get an element from a list by its index
+ * Suspending version of method [io.vertx.redis.RedisClient.lindex]
  *
  * @param key Key string
  * @param index Index of list element to get
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.lindexAwait(key : String, index : Int) : String {
-  return awaitResult{
+suspend fun RedisClient.lindexAwait(key: String, index: Int): String {
+  return awaitResult {
     this.lindex(key, index, it)
   }
 }
 
 /**
- * Insert an element before or after another element in a list
+ * Suspending version of method [io.vertx.redis.RedisClient.linsert]
  *
  * @param key Key string
  * @param option BEFORE or AFTER
  * @param pivot Key to use as a pivot
  * @param value Value to be inserted before or after the pivot
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.linsertAwait(key : String, option : InsertOptions, pivot : String, value : String) : Long {
-  return awaitResult{
+suspend fun RedisClient.linsertAwait(key: String, option: InsertOptions, pivot: String, value: String): Long {
+  return awaitResult {
     this.linsert(key, option, pivot, value, it)
   }
 }
 
 /**
- * Get the length of a list
+ * Suspending version of method [io.vertx.redis.RedisClient.llen]
  *
  * @param key String key
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.llenAwait(key : String) : Long {
-  return awaitResult{
+suspend fun RedisClient.llenAwait(key: String): Long {
+  return awaitResult {
     this.llen(key, it)
   }
 }
 
 /**
- * Remove and get the first element in a list
+ * Suspending version of method [io.vertx.redis.RedisClient.lpop]
  *
  * @param key String key
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [String?]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.lpopAwait(key : String) : String? {
-  return awaitResult{
+suspend fun RedisClient.lpopAwait(key: String): String? {
+  return awaitResult {
     this.lpop(key, it)
   }
 }
 
 /**
- * Prepend one or multiple values to a list
+ * Suspending version of method [io.vertx.redis.RedisClient.lpushMany]
  *
  * @param key Key string
  * @param values Values to be added at the beginning of the list, one by one
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.lpushManyAwait(key : String, values : List<String>) : Long {
-  return awaitResult{
+suspend fun RedisClient.lpushManyAwait(key: String, values: List<String>): Long {
+  return awaitResult {
     this.lpushMany(key, values, it)
   }
 }
 
 /**
- * Prepend one value to a list
+ * Suspending version of method [io.vertx.redis.RedisClient.lpush]
  *
  * @param key Key string
  * @param value Value to be added at the beginning of the list
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.lpushAwait(key : String, value : String) : Long {
-  return awaitResult{
+suspend fun RedisClient.lpushAwait(key: String, value: String): Long {
+  return awaitResult {
     this.lpush(key, value, it)
   }
 }
 
 /**
- * Prepend a value to a list, only if the list exists
+ * Suspending version of method [io.vertx.redis.RedisClient.lpushx]
  *
  * @param key Key string
  * @param value Value to add at the beginning of the list
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.lpushxAwait(key : String, value : String) : Long {
-  return awaitResult{
+suspend fun RedisClient.lpushxAwait(key: String, value: String): Long {
+  return awaitResult {
     this.lpushx(key, value, it)
   }
 }
 
 /**
- * Get a range of elements from a list
+ * Suspending version of method [io.vertx.redis.RedisClient.lrange]
  *
  * @param key Key string
  * @param from Start index
  * @param to Stop index
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.lrangeAwait(key : String, from : Long, to : Long) : JsonArray {
-  return awaitResult{
+suspend fun RedisClient.lrangeAwait(key: String, from: Long, to: Long): JsonArray {
+  return awaitResult {
     this.lrange(key, from, to, it)
   }
 }
 
 /**
- * Remove elements from a list
+ * Suspending version of method [io.vertx.redis.RedisClient.lrem]
  *
  * @param key Key string
  * @param count Number of first found occurrences equal to $value to remove from the list
  * @param value Value to be removed
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.lremAwait(key : String, count : Long, value : String) : Long {
-  return awaitResult{
+suspend fun RedisClient.lremAwait(key: String, count: Long, value: String): Long {
+  return awaitResult {
     this.lrem(key, count, value, it)
   }
 }
 
 /**
- * Set the value of an element in a list by its index
+ * Suspending version of method [io.vertx.redis.RedisClient.lset]
  *
  * @param key Key string
  * @param index Position within list
  * @param value New value
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.lsetAwait(key : String, index : Long, value : String) : String {
-  return awaitResult{
+suspend fun RedisClient.lsetAwait(key: String, index: Long, value: String): String {
+  return awaitResult {
     this.lset(key, index, value, it)
   }
 }
 
 /**
- * Trim a list to the specified range
+ * Suspending version of method [io.vertx.redis.RedisClient.ltrim]
  *
  * @param key Key string
  * @param from Start index
  * @param to Stop index
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.ltrimAwait(key : String, from : Long, to : Long) : String {
-  return awaitResult{
+suspend fun RedisClient.ltrimAwait(key: String, from: Long, to: Long): String {
+  return awaitResult {
     this.ltrim(key, from, to, it)
   }
 }
 
 /**
- * Get the value of the given key
+ * Suspending version of method [io.vertx.redis.RedisClient.mget]
  *
  * @param key Key string
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.mgetAwait(key : String) : JsonArray {
-  return awaitResult{
+suspend fun RedisClient.mgetAwait(key: String): JsonArray {
+  return awaitResult {
     this.mget(key, it)
   }
 }
 
 /**
- * Get the values of all the given keys
+ * Suspending version of method [io.vertx.redis.RedisClient.mgetMany]
  *
  * @param keys List of keys to get
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.mgetManyAwait(keys : List<String>) : JsonArray {
-  return awaitResult{
+suspend fun RedisClient.mgetManyAwait(keys: List<String>): JsonArray {
+  return awaitResult {
     this.mgetMany(keys, it)
   }
 }
 
 /**
- * Atomically transfer a key from a Redis instance to another one.
+ * Suspending version of method [io.vertx.redis.RedisClient.migrate]
  *
  * @param host Destination host
  * @param port Destination port
@@ -1598,1787 +1580,1781 @@ suspend fun RedisClient.mgetManyAwait(keys : List<String>) : JsonArray {
  * @param destdb Destination database index
  * @param timeout 
  * @param options Migrate options
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.migrateAwait(host : String, port : Int, key : String, destdb : Int, timeout : Long, options : MigrateOptions) : String {
-  return awaitResult{
+suspend fun RedisClient.migrateAwait(host: String, port: Int, key: String, destdb: Int, timeout: Long, options: MigrateOptions): String {
+  return awaitResult {
     this.migrate(host, port, key, destdb, timeout, options, it)
   }
 }
 
 /**
- * Listen for all requests received by the server in real time
+ * Suspending version of method [io.vertx.redis.RedisClient.monitor]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.monitorAwait() : Unit {
-  return awaitResult{
-    this.monitor({ ar -> it.handle(ar.mapEmpty()) })}
+suspend fun RedisClient.monitorAwait(): Unit {
+  return awaitResult {
+    this.monitor { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Move a key to another database
+ * Suspending version of method [io.vertx.redis.RedisClient.move]
  *
  * @param key Key to migrate
  * @param destdb Destination database index
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.moveAwait(key : String, destdb : Int) : Long {
-  return awaitResult{
+suspend fun RedisClient.moveAwait(key: String, destdb: Int): Long {
+  return awaitResult {
     this.move(key, destdb, it)
   }
 }
 
 /**
- * Set multiple keys to multiple values
+ * Suspending version of method [io.vertx.redis.RedisClient.mset]
  *
  * @param keyvals Key value pairs to set
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.msetAwait(keyvals : JsonObject) : String {
-  return awaitResult{
+suspend fun RedisClient.msetAwait(keyvals: JsonObject): String {
+  return awaitResult {
     this.mset(keyvals, it)
   }
 }
 
 /**
- * Set multiple keys to multiple values, only if none of the keys exist
+ * Suspending version of method [io.vertx.redis.RedisClient.msetnx]
  *
  * @param keyvals Key value pairs to set
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.msetnxAwait(keyvals : JsonObject) : Long {
-  return awaitResult{
+suspend fun RedisClient.msetnxAwait(keyvals: JsonObject): Long {
+  return awaitResult {
     this.msetnx(keyvals, it)
   }
 }
 
 /**
- * Inspect the internals of Redis objects
+ * Suspending version of method [io.vertx.redis.RedisClient.object]
  *
  * @param key Key string
  * @param cmd Object sub command
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.objectAwait(key : String, cmd : ObjectCmd) : Unit {
-  return awaitResult{
-    this.`object`(key, cmd, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun RedisClient.objectAwait(key: String, cmd: ObjectCmd): Unit {
+  return awaitResult {
+    this.`object`(key, cmd) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Remove the expiration from a key
+ * Suspending version of method [io.vertx.redis.RedisClient.persist]
  *
  * @param key Key string
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.persistAwait(key : String) : Long {
-  return awaitResult{
+suspend fun RedisClient.persistAwait(key: String): Long {
+  return awaitResult {
     this.persist(key, it)
   }
 }
 
 /**
- * Set a key's time to live in milliseconds
+ * Suspending version of method [io.vertx.redis.RedisClient.pexpire]
  *
  * @param key String key
  * @param millis Time to live in milliseconds
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.pexpireAwait(key : String, millis : Long) : Long {
-  return awaitResult{
+suspend fun RedisClient.pexpireAwait(key: String, millis: Long): Long {
+  return awaitResult {
     this.pexpire(key, millis, it)
   }
 }
 
 /**
- * Set the expiration for a key as a UNIX timestamp specified in milliseconds
+ * Suspending version of method [io.vertx.redis.RedisClient.pexpireat]
  *
  * @param key Key string
  * @param millis Expiry time as Unix timestamp in milliseconds
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.pexpireatAwait(key : String, millis : Long) : Long {
-  return awaitResult{
+suspend fun RedisClient.pexpireatAwait(key: String, millis: Long): Long {
+  return awaitResult {
     this.pexpireat(key, millis, it)
   }
 }
 
 /**
- * Adds the specified element to the specified HyperLogLog.
+ * Suspending version of method [io.vertx.redis.RedisClient.pfadd]
  *
  * @param key Key string
  * @param element Element to add
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.pfaddAwait(key : String, element : String) : Long {
-  return awaitResult{
+suspend fun RedisClient.pfaddAwait(key: String, element: String): Long {
+  return awaitResult {
     this.pfadd(key, element, it)
   }
 }
 
 /**
- * Adds the specified elements to the specified HyperLogLog.
+ * Suspending version of method [io.vertx.redis.RedisClient.pfaddMany]
  *
  * @param key Key string
  * @param elements Elementa to add
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.pfaddManyAwait(key : String, elements : List<String>) : Long {
-  return awaitResult{
+suspend fun RedisClient.pfaddManyAwait(key: String, elements: List<String>): Long {
+  return awaitResult {
     this.pfaddMany(key, elements, it)
   }
 }
 
 /**
- * Return the approximated cardinality of the set observed by the HyperLogLog at key.
+ * Suspending version of method [io.vertx.redis.RedisClient.pfcount]
  *
  * @param key Key string
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.pfcountAwait(key : String) : Long {
-  return awaitResult{
+suspend fun RedisClient.pfcountAwait(key: String): Long {
+  return awaitResult {
     this.pfcount(key, it)
   }
 }
 
 /**
- * Return the approximated cardinality of the set(s) observed by the HyperLogLog at key(s).
+ * Suspending version of method [io.vertx.redis.RedisClient.pfcountMany]
  *
  * @param keys List of keys
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.pfcountManyAwait(keys : List<String>) : Long {
-  return awaitResult{
+suspend fun RedisClient.pfcountManyAwait(keys: List<String>): Long {
+  return awaitResult {
     this.pfcountMany(keys, it)
   }
 }
 
 /**
- * Merge N different HyperLogLogs into a single one.
+ * Suspending version of method [io.vertx.redis.RedisClient.pfmerge]
  *
  * @param destkey Destination key
  * @param keys List of source keys
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.pfmergeAwait(destkey : String, keys : List<String>) : String {
-  return awaitResult{
+suspend fun RedisClient.pfmergeAwait(destkey: String, keys: List<String>): String {
+  return awaitResult {
     this.pfmerge(destkey, keys, it)
   }
 }
 
 /**
- * Ping the server
+ * Suspending version of method [io.vertx.redis.RedisClient.ping]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.pingAwait() : String {
-  return awaitResult{
+suspend fun RedisClient.pingAwait(): String {
+  return awaitResult {
     this.ping(it)
   }
 }
 
 /**
- * Set the value and expiration in milliseconds of a key
+ * Suspending version of method [io.vertx.redis.RedisClient.psetex]
  *
  * @param key Key string
  * @param millis Number of milliseconds until the key expires
  * @param value New value for key
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.psetexAwait(key : String, millis : Long, value : String) : Unit {
-  return awaitResult{
-    this.psetex(key, millis, value, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun RedisClient.psetexAwait(key: String, millis: Long, value: String): Unit {
+  return awaitResult {
+    this.psetex(key, millis, value) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Listen for messages published to channels matching the given pattern
+ * Suspending version of method [io.vertx.redis.RedisClient.psubscribe]
  *
  * @param pattern Pattern string
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.psubscribeAwait(pattern : String) : JsonArray {
-  return awaitResult{
+suspend fun RedisClient.psubscribeAwait(pattern: String): JsonArray {
+  return awaitResult {
     this.psubscribe(pattern, it)
   }
 }
 
 /**
- * Listen for messages published to channels matching the given patterns
+ * Suspending version of method [io.vertx.redis.RedisClient.psubscribeMany]
  *
  * @param patterns List of patterns
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.psubscribeManyAwait(patterns : List<String>) : JsonArray {
-  return awaitResult{
+suspend fun RedisClient.psubscribeManyAwait(patterns: List<String>): JsonArray {
+  return awaitResult {
     this.psubscribeMany(patterns, it)
   }
 }
 
 /**
- * Lists the currently active channels - only those matching the pattern
+ * Suspending version of method [io.vertx.redis.RedisClient.pubsubChannels]
  *
  * @param pattern A glob-style pattern - an empty string means no pattern
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.pubsubChannelsAwait(pattern : String) : JsonArray {
-  return awaitResult{
+suspend fun RedisClient.pubsubChannelsAwait(pattern: String): JsonArray {
+  return awaitResult {
     this.pubsubChannels(pattern, it)
   }
 }
 
 /**
- * Returns the number of subscribers (not counting clients subscribed to patterns) for the specified channels
+ * Suspending version of method [io.vertx.redis.RedisClient.pubsubNumsub]
  *
  * @param channels List of channels
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.pubsubNumsubAwait(channels : List<String>) : JsonArray {
-  return awaitResult{
+suspend fun RedisClient.pubsubNumsubAwait(channels: List<String>): JsonArray {
+  return awaitResult {
     this.pubsubNumsub(channels, it)
   }
 }
 
 /**
- * Returns the number of subscriptions to patterns (that are performed using the PSUBSCRIBE command)
+ * Suspending version of method [io.vertx.redis.RedisClient.pubsubNumpat]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.pubsubNumpatAwait() : Long {
-  return awaitResult{
+suspend fun RedisClient.pubsubNumpatAwait(): Long {
+  return awaitResult {
     this.pubsubNumpat(it)
   }
 }
 
 /**
- * Get the time to live for a key in milliseconds
+ * Suspending version of method [io.vertx.redis.RedisClient.pttl]
  *
  * @param key Key string
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.pttlAwait(key : String) : Long {
-  return awaitResult{
+suspend fun RedisClient.pttlAwait(key: String): Long {
+  return awaitResult {
     this.pttl(key, it)
   }
 }
 
 /**
- * Post a message to a channel
+ * Suspending version of method [io.vertx.redis.RedisClient.publish]
  *
  * @param channel Channel key
  * @param message Message to send to channel
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.publishAwait(channel : String, message : String) : Long {
-  return awaitResult{
+suspend fun RedisClient.publishAwait(channel: String, message: String): Long {
+  return awaitResult {
     this.publish(channel, message, it)
   }
 }
 
 /**
- * Stop listening for messages posted to channels matching the given patterns
+ * Suspending version of method [io.vertx.redis.RedisClient.punsubscribe]
  *
  * @param patterns List of patterns to match against
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.punsubscribeAwait(patterns : List<String>) : Unit {
-  return awaitResult{
-    this.punsubscribe(patterns, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun RedisClient.punsubscribeAwait(patterns: List<String>): Unit {
+  return awaitResult {
+    this.punsubscribe(patterns) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Return a random key from the keyspace
+ * Suspending version of method [io.vertx.redis.RedisClient.randomkey]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.randomkeyAwait() : String {
-  return awaitResult{
+suspend fun RedisClient.randomkeyAwait(): String {
+  return awaitResult {
     this.randomkey(it)
   }
 }
 
 /**
- * Rename a key
+ * Suspending version of method [io.vertx.redis.RedisClient.rename]
  *
  * @param key Key string to be renamed
  * @param newkey New key string
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.renameAwait(key : String, newkey : String) : String {
-  return awaitResult{
+suspend fun RedisClient.renameAwait(key: String, newkey: String): String {
+  return awaitResult {
     this.rename(key, newkey, it)
   }
 }
 
 /**
- * Rename a key, only if the new key does not exist
+ * Suspending version of method [io.vertx.redis.RedisClient.renamenx]
  *
  * @param key Key string to be renamed
  * @param newkey New key string
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.renamenxAwait(key : String, newkey : String) : Long {
-  return awaitResult{
+suspend fun RedisClient.renamenxAwait(key: String, newkey: String): Long {
+  return awaitResult {
     this.renamenx(key, newkey, it)
   }
 }
 
 /**
- * Create a key using the provided serialized value, previously obtained using DUMP.
+ * Suspending version of method [io.vertx.redis.RedisClient.restore]
  *
  * @param key Key string
  * @param millis Expiry time in milliseconds to set on the key
  * @param serialized Serialized form of the key value as obtained using DUMP
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.restoreAwait(key : String, millis : Long, serialized : String) : String {
-  return awaitResult{
+suspend fun RedisClient.restoreAwait(key: String, millis: Long, serialized: String): String {
+  return awaitResult {
     this.restore(key, millis, serialized, it)
   }
 }
 
 /**
- * Return the role of the instance in the context of replication
+ * Suspending version of method [io.vertx.redis.RedisClient.role]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.roleAwait() : JsonArray {
-  return awaitResult{
+suspend fun RedisClient.roleAwait(): JsonArray {
+  return awaitResult {
     this.role(it)
   }
 }
 
 /**
- * Remove and get the last element in a list
+ * Suspending version of method [io.vertx.redis.RedisClient.rpop]
  *
  * @param key Key string
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.rpopAwait(key : String) : String {
-  return awaitResult{
+suspend fun RedisClient.rpopAwait(key: String): String {
+  return awaitResult {
     this.rpop(key, it)
   }
 }
 
 /**
- * Remove the last element in a list, append it to another list and return it
+ * Suspending version of method [io.vertx.redis.RedisClient.rpoplpush]
  *
  * @param key Key string identifying source list
  * @param destkey Key string identifying destination list
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.rpoplpushAwait(key : String, destkey : String) : String {
-  return awaitResult{
+suspend fun RedisClient.rpoplpushAwait(key: String, destkey: String): String {
+  return awaitResult {
     this.rpoplpush(key, destkey, it)
   }
 }
 
 /**
- * Append one or multiple values to a list
+ * Suspending version of method [io.vertx.redis.RedisClient.rpushMany]
  *
  * @param key Key string
  * @param values List of values to add to the end of the list
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.rpushManyAwait(key : String, values : List<String>) : Long {
-  return awaitResult{
+suspend fun RedisClient.rpushManyAwait(key: String, values: List<String>): Long {
+  return awaitResult {
     this.rpushMany(key, values, it)
   }
 }
 
 /**
- * Append one or multiple values to a list
+ * Suspending version of method [io.vertx.redis.RedisClient.rpush]
  *
  * @param key Key string
  * @param value Value to be added to the end of the list
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.rpushAwait(key : String, value : String) : Long {
-  return awaitResult{
+suspend fun RedisClient.rpushAwait(key: String, value: String): Long {
+  return awaitResult {
     this.rpush(key, value, it)
   }
 }
 
 /**
- * Append a value to a list, only if the list exists
+ * Suspending version of method [io.vertx.redis.RedisClient.rpushx]
  *
  * @param key Key string
  * @param value Value to be added to the end of the list
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.rpushxAwait(key : String, value : String) : Long {
-  return awaitResult{
+suspend fun RedisClient.rpushxAwait(key: String, value: String): Long {
+  return awaitResult {
     this.rpushx(key, value, it)
   }
 }
 
 /**
- * Add a member to a set
+ * Suspending version of method [io.vertx.redis.RedisClient.sadd]
  *
  * @param key Key string
  * @param member Value to be added to the set
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.saddAwait(key : String, member : String) : Long {
-  return awaitResult{
+suspend fun RedisClient.saddAwait(key: String, member: String): Long {
+  return awaitResult {
     this.sadd(key, member, it)
   }
 }
 
 /**
- * Add one or more members to a set
+ * Suspending version of method [io.vertx.redis.RedisClient.saddMany]
  *
  * @param key Key string
  * @param members Values to be added to the set
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.saddManyAwait(key : String, members : List<String>) : Long {
-  return awaitResult{
+suspend fun RedisClient.saddManyAwait(key: String, members: List<String>): Long {
+  return awaitResult {
     this.saddMany(key, members, it)
   }
 }
 
 /**
- * Synchronously save the dataset to disk
+ * Suspending version of method [io.vertx.redis.RedisClient.save]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.saveAwait() : String {
-  return awaitResult{
+suspend fun RedisClient.saveAwait(): String {
+  return awaitResult {
     this.save(it)
   }
 }
 
 /**
- * Get the number of members in a set
+ * Suspending version of method [io.vertx.redis.RedisClient.scard]
  *
  * @param key Key string
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.scardAwait(key : String) : Long {
-  return awaitResult{
+suspend fun RedisClient.scardAwait(key: String): Long {
+  return awaitResult {
     this.scard(key, it)
   }
 }
 
 /**
- * Check existence of script in the script cache.
+ * Suspending version of method [io.vertx.redis.RedisClient.scriptExists]
  *
  * @param script SHA1 digest identifying a script in the script cache
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.scriptExistsAwait(script : String) : JsonArray {
-  return awaitResult{
+suspend fun RedisClient.scriptExistsAwait(script: String): JsonArray {
+  return awaitResult {
     this.scriptExists(script, it)
   }
 }
 
 /**
- * Check existence of scripts in the script cache.
+ * Suspending version of method [io.vertx.redis.RedisClient.scriptExistsMany]
  *
  * @param scripts List of SHA1 digests identifying scripts in the script cache
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.scriptExistsManyAwait(scripts : List<String>) : JsonArray {
-  return awaitResult{
+suspend fun RedisClient.scriptExistsManyAwait(scripts: List<String>): JsonArray {
+  return awaitResult {
     this.scriptExistsMany(scripts, it)
   }
 }
 
 /**
- * Remove all the scripts from the script cache.
+ * Suspending version of method [io.vertx.redis.RedisClient.scriptFlush]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.scriptFlushAwait() : String {
-  return awaitResult{
+suspend fun RedisClient.scriptFlushAwait(): String {
+  return awaitResult {
     this.scriptFlush(it)
   }
 }
 
 /**
- * Kill the script currently in execution.
+ * Suspending version of method [io.vertx.redis.RedisClient.scriptKill]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.scriptKillAwait() : String {
-  return awaitResult{
+suspend fun RedisClient.scriptKillAwait(): String {
+  return awaitResult {
     this.scriptKill(it)
   }
 }
 
 /**
- * Load the specified Lua script into the script cache.
+ * Suspending version of method [io.vertx.redis.RedisClient.scriptLoad]
  *
  * @param script Lua script
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.scriptLoadAwait(script : String) : String {
-  return awaitResult{
+suspend fun RedisClient.scriptLoadAwait(script: String): String {
+  return awaitResult {
     this.scriptLoad(script, it)
   }
 }
 
 /**
- * Subtract multiple sets
+ * Suspending version of method [io.vertx.redis.RedisClient.sdiff]
  *
  * @param key Key identifying the set to compare with all other sets combined
  * @param cmpkeys List of keys identifying sets to subtract from the key set
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.sdiffAwait(key : String, cmpkeys : List<String>) : JsonArray {
-  return awaitResult{
+suspend fun RedisClient.sdiffAwait(key: String, cmpkeys: List<String>): JsonArray {
+  return awaitResult {
     this.sdiff(key, cmpkeys, it)
   }
 }
 
 /**
- * Subtract multiple sets and store the resulting set in a key
+ * Suspending version of method [io.vertx.redis.RedisClient.sdiffstore]
  *
  * @param destkey Destination key where the result should be stored
  * @param key Key identifying the set to compare with all other sets combined
  * @param cmpkeys List of keys identifying sets to subtract from the key set
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.sdiffstoreAwait(destkey : String, key : String, cmpkeys : List<String>) : Long {
-  return awaitResult{
+suspend fun RedisClient.sdiffstoreAwait(destkey: String, key: String, cmpkeys: List<String>): Long {
+  return awaitResult {
     this.sdiffstore(destkey, key, cmpkeys, it)
   }
 }
 
 /**
- * Change the selected database for the current connection
+ * Suspending version of method [io.vertx.redis.RedisClient.select]
  *
  * @param dbindex Index identifying the new active database
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.selectAwait(dbindex : Int) : String {
-  return awaitResult{
+suspend fun RedisClient.selectAwait(dbindex: Int): String {
+  return awaitResult {
     this.select(dbindex, it)
   }
 }
 
 /**
- * Set the string value of a key
+ * Suspending version of method [io.vertx.redis.RedisClient.set]
  *
  * @param key Key of which value to set
  * @param value New value for the key
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.setAwait(key : String, value : String) : Unit {
-  return awaitResult{
-    this.set(key, value, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun RedisClient.setAwait(key: String, value: String): Unit {
+  return awaitResult {
+    this.set(key, value) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Set the string value of a key
+ * Suspending version of method [io.vertx.redis.RedisClient.setWithOptions]
  *
  * @param key Key of which value to set
  * @param value New value for the key
  * @param options Set options
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.setWithOptionsAwait(key : String, value : String, options : SetOptions) : String {
-  return awaitResult{
+suspend fun RedisClient.setWithOptionsAwait(key: String, value: String, options: SetOptions): String {
+  return awaitResult {
     this.setWithOptions(key, value, options, it)
   }
 }
 
 /**
- * Set the binary string value of a key - without encoding as utf-8
+ * Suspending version of method [io.vertx.redis.RedisClient.setBinary]
  *
  * @param key Key of which value to set
  * @param value New value for the key
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.setBinaryAwait(key : String, value : Buffer) : Unit {
-  return awaitResult{
-    this.setBinary(key, value, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun RedisClient.setBinaryAwait(key: String, value: Buffer): Unit {
+  return awaitResult {
+    this.setBinary(key, value) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Set the string value of a key
+ * Suspending version of method [io.vertx.redis.RedisClient.setBinaryWithOptions]
  *
  * @param key Key of which value to set
  * @param value New value for the key
  * @param options Set options
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.setBinaryWithOptionsAwait(key : String, value : Buffer, options : SetOptions) : Unit {
-  return awaitResult{
-    this.setBinaryWithOptions(key, value, options, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun RedisClient.setBinaryWithOptionsAwait(key: String, value: Buffer, options: SetOptions): Unit {
+  return awaitResult {
+    this.setBinaryWithOptions(key, value, options) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Sets or clears the bit at offset in the string value stored at key
+ * Suspending version of method [io.vertx.redis.RedisClient.setbit]
  *
  * @param key Key string
  * @param offset Bit offset
  * @param bit New value - must be 1 or 0
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.setbitAwait(key : String, offset : Long, bit : Int) : Long {
-  return awaitResult{
+suspend fun RedisClient.setbitAwait(key: String, offset: Long, bit: Int): Long {
+  return awaitResult {
     this.setbit(key, offset, bit, it)
   }
 }
 
 /**
- * Set the value and expiration of a key
+ * Suspending version of method [io.vertx.redis.RedisClient.setex]
  *
  * @param key Key string
  * @param seconds Number of seconds until the key expires
  * @param value New value for key
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.setexAwait(key : String, seconds : Long, value : String) : String {
-  return awaitResult{
+suspend fun RedisClient.setexAwait(key: String, seconds: Long, value: String): String {
+  return awaitResult {
     this.setex(key, seconds, value, it)
   }
 }
 
 /**
- * Set the value of a key, only if the key does not exist
+ * Suspending version of method [io.vertx.redis.RedisClient.setnx]
  *
  * @param key Key of which value to set
  * @param value New value for the key
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.setnxAwait(key : String, value : String) : Long {
-  return awaitResult{
+suspend fun RedisClient.setnxAwait(key: String, value: String): Long {
+  return awaitResult {
     this.setnx(key, value, it)
   }
 }
 
 /**
- * Overwrite part of a string at key starting at the specified offset
+ * Suspending version of method [io.vertx.redis.RedisClient.setrange]
  *
  * @param key Key string
  * @param offset Offset - the maximum offset that you can set is 2^29 -1 (536870911), as Redis Strings are limited to 512 megabytes
  * @param value Value to overwrite with
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.setrangeAwait(key : String, offset : Int, value : String) : Long {
-  return awaitResult{
+suspend fun RedisClient.setrangeAwait(key: String, offset: Int, value: String): Long {
+  return awaitResult {
     this.setrange(key, offset, value, it)
   }
 }
 
 /**
- * Intersect multiple sets
+ * Suspending version of method [io.vertx.redis.RedisClient.sinter]
  *
  * @param keys List of keys to perform intersection on
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.sinterAwait(keys : List<String>) : JsonArray {
-  return awaitResult{
+suspend fun RedisClient.sinterAwait(keys: List<String>): JsonArray {
+  return awaitResult {
     this.sinter(keys, it)
   }
 }
 
 /**
- * Intersect multiple sets and store the resulting set in a key
+ * Suspending version of method [io.vertx.redis.RedisClient.sinterstore]
  *
  * @param destkey Key where to store the results
  * @param keys List of keys to perform intersection on
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.sinterstoreAwait(destkey : String, keys : List<String>) : Long {
-  return awaitResult{
+suspend fun RedisClient.sinterstoreAwait(destkey: String, keys: List<String>): Long {
+  return awaitResult {
     this.sinterstore(destkey, keys, it)
   }
 }
 
 /**
- * Determine if a given value is a member of a set
+ * Suspending version of method [io.vertx.redis.RedisClient.sismember]
  *
  * @param key Key string
  * @param member Member to look for
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.sismemberAwait(key : String, member : String) : Long {
-  return awaitResult{
+suspend fun RedisClient.sismemberAwait(key: String, member: String): Long {
+  return awaitResult {
     this.sismember(key, member, it)
   }
 }
 
 /**
- * Make the server a slave of another instance
+ * Suspending version of method [io.vertx.redis.RedisClient.slaveof]
  *
  * @param host Host to become this server's master
  * @param port Port of our new master
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.slaveofAwait(host : String, port : Int) : String {
-  return awaitResult{
+suspend fun RedisClient.slaveofAwait(host: String, port: Int): String {
+  return awaitResult {
     this.slaveof(host, port, it)
   }
 }
 
 /**
- * Make this server a master
+ * Suspending version of method [io.vertx.redis.RedisClient.slaveofNoone]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.slaveofNooneAwait() : String {
-  return awaitResult{
+suspend fun RedisClient.slaveofNooneAwait(): String {
+  return awaitResult {
     this.slaveofNoone(it)
   }
 }
 
 /**
- * Read the Redis slow queries log
+ * Suspending version of method [io.vertx.redis.RedisClient.slowlogGet]
  *
  * @param limit Number of log entries to return. If value is less than zero all entries are returned
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.slowlogGetAwait(limit : Int) : JsonArray {
-  return awaitResult{
+suspend fun RedisClient.slowlogGetAwait(limit: Int): JsonArray {
+  return awaitResult {
     this.slowlogGet(limit, it)
   }
 }
 
 /**
- * Get the length of the Redis slow queries log
+ * Suspending version of method [io.vertx.redis.RedisClient.slowlogLen]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.slowlogLenAwait() : Long {
-  return awaitResult{
+suspend fun RedisClient.slowlogLenAwait(): Long {
+  return awaitResult {
     this.slowlogLen(it)
   }
 }
 
 /**
- * Reset the Redis slow queries log
+ * Suspending version of method [io.vertx.redis.RedisClient.slowlogReset]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.slowlogResetAwait() : Unit {
-  return awaitResult{
-    this.slowlogReset({ ar -> it.handle(ar.mapEmpty()) })}
+suspend fun RedisClient.slowlogResetAwait(): Unit {
+  return awaitResult {
+    this.slowlogReset { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Get all the members in a set
+ * Suspending version of method [io.vertx.redis.RedisClient.smembers]
  *
  * @param key Key string
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.smembersAwait(key : String) : JsonArray {
-  return awaitResult{
+suspend fun RedisClient.smembersAwait(key: String): JsonArray {
+  return awaitResult {
     this.smembers(key, it)
   }
 }
 
 /**
- * Move a member from one set to another
+ * Suspending version of method [io.vertx.redis.RedisClient.smove]
  *
  * @param key Key of source set currently containing the member
  * @param destkey Key identifying the destination set
  * @param member Member to move
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.smoveAwait(key : String, destkey : String, member : String) : Long {
-  return awaitResult{
+suspend fun RedisClient.smoveAwait(key: String, destkey: String, member: String): Long {
+  return awaitResult {
     this.smove(key, destkey, member, it)
   }
 }
 
 /**
- * Sort the elements in a list, set or sorted set
+ * Suspending version of method [io.vertx.redis.RedisClient.sort]
  *
  * @param key Key string
  * @param options Sort options
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.sortAwait(key : String, options : SortOptions) : JsonArray {
-  return awaitResult{
+suspend fun RedisClient.sortAwait(key: String, options: SortOptions): JsonArray {
+  return awaitResult {
     this.sort(key, options, it)
   }
 }
 
 /**
- * Remove and return a random member from a set
+ * Suspending version of method [io.vertx.redis.RedisClient.spop]
  *
  * @param key Key string
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [String?]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.spopAwait(key : String) : String? {
-  return awaitResult{
+suspend fun RedisClient.spopAwait(key: String): String? {
+  return awaitResult {
     this.spop(key, it)
   }
 }
 
 /**
- * Remove and return random members from a set
+ * Suspending version of method [io.vertx.redis.RedisClient.spopMany]
  *
  * @param key Key string
  * @param count Number of members to remove
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.spopManyAwait(key : String, count : Int) : JsonArray {
-  return awaitResult{
+suspend fun RedisClient.spopManyAwait(key: String, count: Int): JsonArray {
+  return awaitResult {
     this.spopMany(key, count, it)
   }
 }
 
 /**
- * Get one or multiple random members from a set
+ * Suspending version of method [io.vertx.redis.RedisClient.srandmember]
  *
  * @param key Key string
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.srandmemberAwait(key : String) : String {
-  return awaitResult{
+suspend fun RedisClient.srandmemberAwait(key: String): String {
+  return awaitResult {
     this.srandmember(key, it)
   }
 }
 
 /**
- * Get one or multiple random members from a set
+ * Suspending version of method [io.vertx.redis.RedisClient.srandmemberCount]
  *
  * @param key Key string
  * @param count Number of members to get
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.srandmemberCountAwait(key : String, count : Int) : JsonArray {
-  return awaitResult{
+suspend fun RedisClient.srandmemberCountAwait(key: String, count: Int): JsonArray {
+  return awaitResult {
     this.srandmemberCount(key, count, it)
   }
 }
 
 /**
- * Remove one member from a set
+ * Suspending version of method [io.vertx.redis.RedisClient.srem]
  *
  * @param key Key string
  * @param member Member to remove
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.sremAwait(key : String, member : String) : Long {
-  return awaitResult{
+suspend fun RedisClient.sremAwait(key: String, member: String): Long {
+  return awaitResult {
     this.srem(key, member, it)
   }
 }
 
 /**
- * Remove one or more members from a set
+ * Suspending version of method [io.vertx.redis.RedisClient.sremMany]
  *
  * @param key Key string
  * @param members Members to remove
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.sremManyAwait(key : String, members : List<String>) : Long {
-  return awaitResult{
+suspend fun RedisClient.sremManyAwait(key: String, members: List<String>): Long {
+  return awaitResult {
     this.sremMany(key, members, it)
   }
 }
 
 /**
- * Get the length of the value stored in a key
+ * Suspending version of method [io.vertx.redis.RedisClient.strlen]
  *
  * @param key Key string
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.strlenAwait(key : String) : Long {
-  return awaitResult{
+suspend fun RedisClient.strlenAwait(key: String): Long {
+  return awaitResult {
     this.strlen(key, it)
   }
 }
 
 /**
- * Listen for messages published to the given channels
+ * Suspending version of method [io.vertx.redis.RedisClient.subscribe]
  *
  * @param channel Channel to subscribe to
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.subscribeAwait(channel : String) : JsonArray {
-  return awaitResult{
+suspend fun RedisClient.subscribeAwait(channel: String): JsonArray {
+  return awaitResult {
     this.subscribe(channel, it)
   }
 }
 
 /**
- * Listen for messages published to the given channels
+ * Suspending version of method [io.vertx.redis.RedisClient.subscribeMany]
  *
  * @param channels List of channels to subscribe to
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.subscribeManyAwait(channels : List<String>) : JsonArray {
-  return awaitResult{
+suspend fun RedisClient.subscribeManyAwait(channels: List<String>): JsonArray {
+  return awaitResult {
     this.subscribeMany(channels, it)
   }
 }
 
 /**
- * Add multiple sets
+ * Suspending version of method [io.vertx.redis.RedisClient.sunion]
  *
  * @param keys List of keys identifying sets to add up
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.sunionAwait(keys : List<String>) : JsonArray {
-  return awaitResult{
+suspend fun RedisClient.sunionAwait(keys: List<String>): JsonArray {
+  return awaitResult {
     this.sunion(keys, it)
   }
 }
 
 /**
- * Add multiple sets and store the resulting set in a key
+ * Suspending version of method [io.vertx.redis.RedisClient.sunionstore]
  *
  * @param destkey Destination key
  * @param keys List of keys identifying sets to add up
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.sunionstoreAwait(destkey : String, keys : List<String>) : Long {
-  return awaitResult{
+suspend fun RedisClient.sunionstoreAwait(destkey: String, keys: List<String>): Long {
+  return awaitResult {
     this.sunionstore(destkey, keys, it)
   }
 }
 
 /**
- * Internal command used for replication
+ * Suspending version of method [io.vertx.redis.RedisClient.sync]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.syncAwait() : Unit {
-  return awaitResult{
-    this.sync({ ar -> it.handle(ar.mapEmpty()) })}
+suspend fun RedisClient.syncAwait(): Unit {
+  return awaitResult {
+    this.sync { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Return the current server time
+ * Suspending version of method [io.vertx.redis.RedisClient.time]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.timeAwait() : JsonArray {
-  return awaitResult{
+suspend fun RedisClient.timeAwait(): JsonArray {
+  return awaitResult {
     this.time(it)
   }
 }
 
 /**
- * Get the time to live for a key
+ * Suspending version of method [io.vertx.redis.RedisClient.ttl]
  *
  * @param key Key string
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.ttlAwait(key : String) : Long {
-  return awaitResult{
+suspend fun RedisClient.ttlAwait(key: String): Long {
+  return awaitResult {
     this.ttl(key, it)
   }
 }
 
 /**
- * Determine the type stored at key
+ * Suspending version of method [io.vertx.redis.RedisClient.type]
  *
  * @param key Key string
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.typeAwait(key : String) : String {
-  return awaitResult{
+suspend fun RedisClient.typeAwait(key: String): String {
+  return awaitResult {
     this.type(key, it)
   }
 }
 
 /**
- * Stop listening for messages posted to the given channels
+ * Suspending version of method [io.vertx.redis.RedisClient.unsubscribe]
  *
  * @param channels List of channels to subscribe to
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.unsubscribeAwait(channels : List<String>) : Unit {
-  return awaitResult{
-    this.unsubscribe(channels, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun RedisClient.unsubscribeAwait(channels: List<String>): Unit {
+  return awaitResult {
+    this.unsubscribe(channels) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Wait for the synchronous replication of all the write commands sent in the context of the current connection.
+ * Suspending version of method [io.vertx.redis.RedisClient.wait]
  *
  * @param numSlaves 
  * @param timeout 
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.waitAwait(numSlaves : Long, timeout : Long) : String {
-  return awaitResult{
+suspend fun RedisClient.waitAwait(numSlaves: Long, timeout: Long): String {
+  return awaitResult {
     this.wait(numSlaves, timeout, it)
   }
 }
 
 /**
- * Add one or more members to a sorted set, or update its score if it already exists
+ * Suspending version of method [io.vertx.redis.RedisClient.zadd]
  *
  * @param key Key string
  * @param score Score used for sorting
  * @param member New member key
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.zaddAwait(key : String, score : Double, member : String) : Long {
-  return awaitResult{
+suspend fun RedisClient.zaddAwait(key: String, score: Double, member: String): Long {
+  return awaitResult {
     this.zadd(key, score, member, it)
   }
 }
 
 /**
- * Add one or more members to a sorted set, or update its score if it already exists
+ * Suspending version of method [io.vertx.redis.RedisClient.zaddMany]
  *
  * @param key Key string
  * @param members New member keys and their scores
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.zaddManyAwait(key : String, members : Map<String,Double>) : Long {
-  return awaitResult{
+suspend fun RedisClient.zaddManyAwait(key: String, members: Map<String,Double>): Long {
+  return awaitResult {
     this.zaddMany(key, members, it)
   }
 }
 
 /**
- * Get the number of members in a sorted set
+ * Suspending version of method [io.vertx.redis.RedisClient.zcard]
  *
  * @param key Key string
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.zcardAwait(key : String) : Long {
-  return awaitResult{
+suspend fun RedisClient.zcardAwait(key: String): Long {
+  return awaitResult {
     this.zcard(key, it)
   }
 }
 
 /**
- * Count the members in a sorted set with scores within the given values
+ * Suspending version of method [io.vertx.redis.RedisClient.zcount]
  *
  * @param key Key string
  * @param min Minimum score
  * @param max Maximum score
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.zcountAwait(key : String, min : Double, max : Double) : Long {
-  return awaitResult{
+suspend fun RedisClient.zcountAwait(key: String, min: Double, max: Double): Long {
+  return awaitResult {
     this.zcount(key, min, max, it)
   }
 }
 
 /**
- * Increment the score of a member in a sorted set
+ * Suspending version of method [io.vertx.redis.RedisClient.zincrby]
  *
  * @param key Key string
  * @param increment Increment amount
  * @param member Member key
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.zincrbyAwait(key : String, increment : Double, member : String) : String {
-  return awaitResult{
+suspend fun RedisClient.zincrbyAwait(key: String, increment: Double, member: String): String {
+  return awaitResult {
     this.zincrby(key, increment, member, it)
   }
 }
 
 /**
- * Intersect multiple sorted sets and store the resulting sorted set in a new key
+ * Suspending version of method [io.vertx.redis.RedisClient.zinterstore]
  *
  * @param destkey Destination key
  * @param sets List of keys identifying sorted sets to intersect
  * @param options Aggregation options
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.zinterstoreAwait(destkey : String, sets : List<String>, options : AggregateOptions) : Long {
-  return awaitResult{
+suspend fun RedisClient.zinterstoreAwait(destkey: String, sets: List<String>, options: AggregateOptions): Long {
+  return awaitResult {
     this.zinterstore(destkey, sets, options, it)
   }
 }
 
 /**
- * Intersect multiple sorted sets and store the resulting sorted set in a new key using weights for scoring
+ * Suspending version of method [io.vertx.redis.RedisClient.zinterstoreWeighed]
  *
  * @param destkey Destination key
  * @param sets List of keys identifying sorted sets to intersect
  * @param options Aggregation options
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.zinterstoreWeighedAwait(destkey : String, sets : Map<String,Double>, options : AggregateOptions) : Long {
-  return awaitResult{
+suspend fun RedisClient.zinterstoreWeighedAwait(destkey: String, sets: Map<String,Double>, options: AggregateOptions): Long {
+  return awaitResult {
     this.zinterstoreWeighed(destkey, sets, options, it)
   }
 }
 
 /**
- * Count the number of members in a sorted set between a given lexicographical range
+ * Suspending version of method [io.vertx.redis.RedisClient.zlexcount]
  *
  * @param key Key string
  * @param min Pattern to compare against for minimum value
  * @param max Pattern to compare against for maximum value
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.zlexcountAwait(key : String, min : String, max : String) : Long {
-  return awaitResult{
+suspend fun RedisClient.zlexcountAwait(key: String, min: String, max: String): Long {
+  return awaitResult {
     this.zlexcount(key, min, max, it)
   }
 }
 
 /**
- * Return a range of members in a sorted set, by index
+ * Suspending version of method [io.vertx.redis.RedisClient.zrange]
  *
  * @param key Key string
  * @param start Start index for the range
  * @param stop Stop index for the range - inclusive
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.zrangeAwait(key : String, start : Long, stop : Long) : JsonArray {
-  return awaitResult{
+suspend fun RedisClient.zrangeAwait(key: String, start: Long, stop: Long): JsonArray {
+  return awaitResult {
     this.zrange(key, start, stop, it)
   }
 }
 
 /**
- * Return a range of members in a sorted set, by index
+ * Suspending version of method [io.vertx.redis.RedisClient.zrangeWithOptions]
  *
  * @param key Key string
  * @param start Start index for the range
  * @param stop Stop index for the range - inclusive
  * @param options Range options
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.zrangeWithOptionsAwait(key : String, start : Long, stop : Long, options : RangeOptions) : JsonArray {
-  return awaitResult{
+suspend fun RedisClient.zrangeWithOptionsAwait(key: String, start: Long, stop: Long, options: RangeOptions): JsonArray {
+  return awaitResult {
     this.zrangeWithOptions(key, start, stop, options, it)
   }
 }
 
 /**
- * Return a range of members in a sorted set, by lexicographical range
+ * Suspending version of method [io.vertx.redis.RedisClient.zrangebylex]
  *
  * @param key Key string
  * @param min Pattern representing a minimum allowed value
  * @param max Pattern representing a maximum allowed value
  * @param options Limit options where limit can be specified
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.zrangebylexAwait(key : String, min : String, max : String, options : LimitOptions) : JsonArray {
-  return awaitResult{
+suspend fun RedisClient.zrangebylexAwait(key: String, min: String, max: String, options: LimitOptions): JsonArray {
+  return awaitResult {
     this.zrangebylex(key, min, max, options, it)
   }
 }
 
 /**
- * Return a range of members in a sorted set, by score
+ * Suspending version of method [io.vertx.redis.RedisClient.zrangebyscore]
  *
  * @param key Key string
  * @param min Pattern defining a minimum value
  * @param max Pattern defining a maximum value
  * @param options Range and limit options
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.zrangebyscoreAwait(key : String, min : String, max : String, options : RangeLimitOptions) : JsonArray {
-  return awaitResult{
+suspend fun RedisClient.zrangebyscoreAwait(key: String, min: String, max: String, options: RangeLimitOptions): JsonArray {
+  return awaitResult {
     this.zrangebyscore(key, min, max, options, it)
   }
 }
 
 /**
- * Determine the index of a member in a sorted set
+ * Suspending version of method [io.vertx.redis.RedisClient.zrank]
  *
  * @param key Key string
  * @param member Member in the sorted set identified by key
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.zrankAwait(key : String, member : String) : Long {
-  return awaitResult{
+suspend fun RedisClient.zrankAwait(key: String, member: String): Long {
+  return awaitResult {
     this.zrank(key, member, it)
   }
 }
 
 /**
- * Remove one member from a sorted set
+ * Suspending version of method [io.vertx.redis.RedisClient.zrem]
  *
  * @param key Key string
  * @param member Member in the sorted set identified by key
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.zremAwait(key : String, member : String) : Long {
-  return awaitResult{
+suspend fun RedisClient.zremAwait(key: String, member: String): Long {
+  return awaitResult {
     this.zrem(key, member, it)
   }
 }
 
 /**
- * Remove one or more members from a sorted set
+ * Suspending version of method [io.vertx.redis.RedisClient.zremMany]
  *
  * @param key Key string
  * @param members Members in the sorted set identified by key
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.zremManyAwait(key : String, members : List<String>) : Long {
-  return awaitResult{
+suspend fun RedisClient.zremManyAwait(key: String, members: List<String>): Long {
+  return awaitResult {
     this.zremMany(key, members, it)
   }
 }
 
 /**
- * Remove all members in a sorted set between the given lexicographical range
+ * Suspending version of method [io.vertx.redis.RedisClient.zremrangebylex]
  *
  * @param key Key string
  * @param min Pattern defining a minimum value
  * @param max Pattern defining a maximum value
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.zremrangebylexAwait(key : String, min : String, max : String) : Long {
-  return awaitResult{
+suspend fun RedisClient.zremrangebylexAwait(key: String, min: String, max: String): Long {
+  return awaitResult {
     this.zremrangebylex(key, min, max, it)
   }
 }
 
 /**
- * Remove all members in a sorted set within the given indexes
+ * Suspending version of method [io.vertx.redis.RedisClient.zremrangebyrank]
  *
  * @param key Key string
  * @param start Start index
  * @param stop Stop index
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.zremrangebyrankAwait(key : String, start : Long, stop : Long) : Long {
-  return awaitResult{
+suspend fun RedisClient.zremrangebyrankAwait(key: String, start: Long, stop: Long): Long {
+  return awaitResult {
     this.zremrangebyrank(key, start, stop, it)
   }
 }
 
 /**
- * Remove all members in a sorted set within the given scores
+ * Suspending version of method [io.vertx.redis.RedisClient.zremrangebyscore]
  *
  * @param key Key string
  * @param min Pattern defining a minimum value
  * @param max Pattern defining a maximum value
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.zremrangebyscoreAwait(key : String, min : String, max : String) : Long {
-  return awaitResult{
+suspend fun RedisClient.zremrangebyscoreAwait(key: String, min: String, max: String): Long {
+  return awaitResult {
     this.zremrangebyscore(key, min, max, it)
   }
 }
 
 /**
- * Return a range of members in a sorted set, by index, with scores ordered from high to low
+ * Suspending version of method [io.vertx.redis.RedisClient.zrevrange]
  *
  * @param key Key string
  * @param start Start index for the range
  * @param stop Stop index for the range - inclusive
  * @param options Range options
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.zrevrangeAwait(key : String, start : Long, stop : Long, options : RangeOptions) : JsonArray {
-  return awaitResult{
+suspend fun RedisClient.zrevrangeAwait(key: String, start: Long, stop: Long, options: RangeOptions): JsonArray {
+  return awaitResult {
     this.zrevrange(key, start, stop, options, it)
   }
 }
 
 /**
- * Return a range of members in a sorted set, by score, between the given lexicographical range with scores ordered from high to low
+ * Suspending version of method [io.vertx.redis.RedisClient.zrevrangebylex]
  *
  * @param key Key string
  * @param max Pattern defining a maximum value
  * @param min Pattern defining a minimum value
  * @param options Limit options
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.zrevrangebylexAwait(key : String, max : String, min : String, options : LimitOptions) : JsonArray {
-  return awaitResult{
+suspend fun RedisClient.zrevrangebylexAwait(key: String, max: String, min: String, options: LimitOptions): JsonArray {
+  return awaitResult {
     this.zrevrangebylex(key, max, min, options, it)
   }
 }
 
 /**
- * Return a range of members in a sorted set, by score, with scores ordered from high to low
+ * Suspending version of method [io.vertx.redis.RedisClient.zrevrangebyscore]
  *
  * @param key Key string
  * @param max Pattern defining a maximum value
  * @param min Pattern defining a minimum value
  * @param options Range and limit options
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.zrevrangebyscoreAwait(key : String, max : String, min : String, options : RangeLimitOptions) : JsonArray {
-  return awaitResult{
+suspend fun RedisClient.zrevrangebyscoreAwait(key: String, max: String, min: String, options: RangeLimitOptions): JsonArray {
+  return awaitResult {
     this.zrevrangebyscore(key, max, min, options, it)
   }
 }
 
 /**
- * Determine the index of a member in a sorted set, with scores ordered from high to low
+ * Suspending version of method [io.vertx.redis.RedisClient.zrevrank]
  *
  * @param key Key string
  * @param member Member in the sorted set identified by key
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.zrevrankAwait(key : String, member : String) : Long {
-  return awaitResult{
+suspend fun RedisClient.zrevrankAwait(key: String, member: String): Long {
+  return awaitResult {
     this.zrevrank(key, member, it)
   }
 }
 
 /**
- * Get the score associated with the given member in a sorted set
+ * Suspending version of method [io.vertx.redis.RedisClient.zscore]
  *
  * @param key Key string
  * @param member Member in the sorted set identified by key
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.zscoreAwait(key : String, member : String) : String {
-  return awaitResult{
+suspend fun RedisClient.zscoreAwait(key: String, member: String): String {
+  return awaitResult {
     this.zscore(key, member, it)
   }
 }
 
 /**
- * Add multiple sorted sets and store the resulting sorted set in a new key
+ * Suspending version of method [io.vertx.redis.RedisClient.zunionstore]
  *
  * @param destkey Destination key
  * @param sets List of keys identifying sorted sets
  * @param options Aggregation options
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.zunionstoreAwait(destkey : String, sets : List<String>, options : AggregateOptions) : Long {
-  return awaitResult{
+suspend fun RedisClient.zunionstoreAwait(destkey: String, sets: List<String>, options: AggregateOptions): Long {
+  return awaitResult {
     this.zunionstore(destkey, sets, options, it)
   }
 }
 
 /**
- * Add multiple sorted sets using weights, and store the resulting sorted set in a new key
+ * Suspending version of method [io.vertx.redis.RedisClient.zunionstoreWeighed]
  *
  * @param key Destination key
  * @param sets Map containing set-key:weight pairs
  * @param options Aggregation options
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.zunionstoreWeighedAwait(key : String, sets : Map<String,Double>, options : AggregateOptions) : Long {
-  return awaitResult{
+suspend fun RedisClient.zunionstoreWeighedAwait(key: String, sets: Map<String,Double>, options: AggregateOptions): Long {
+  return awaitResult {
     this.zunionstoreWeighed(key, sets, options, it)
   }
 }
 
 /**
- * Incrementally iterate the keys space
+ * Suspending version of method [io.vertx.redis.RedisClient.scan]
  *
  * @param cursor Cursor id
  * @param options Scan options
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.scanAwait(cursor : String, options : ScanOptions) : JsonArray {
-  return awaitResult{
+suspend fun RedisClient.scanAwait(cursor: String, options: ScanOptions): JsonArray {
+  return awaitResult {
     this.scan(cursor, options, it)
   }
 }
 
 /**
- * Incrementally iterate Set elements
+ * Suspending version of method [io.vertx.redis.RedisClient.sscan]
  *
  * @param key Key string
  * @param cursor Cursor id
  * @param options Scan options
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.sscanAwait(key : String, cursor : String, options : ScanOptions) : JsonArray {
-  return awaitResult{
+suspend fun RedisClient.sscanAwait(key: String, cursor: String, options: ScanOptions): JsonArray {
+  return awaitResult {
     this.sscan(key, cursor, options, it)
   }
 }
 
 /**
- * Incrementally iterate hash fields and associated values
+ * Suspending version of method [io.vertx.redis.RedisClient.hscan]
  *
  * @param key Key string
  * @param cursor Cursor id
  * @param options Scan options
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.hscanAwait(key : String, cursor : String, options : ScanOptions) : JsonArray {
-  return awaitResult{
+suspend fun RedisClient.hscanAwait(key: String, cursor: String, options: ScanOptions): JsonArray {
+  return awaitResult {
     this.hscan(key, cursor, options, it)
   }
 }
 
 /**
- * Incrementally iterate sorted sets elements and associated scores
+ * Suspending version of method [io.vertx.redis.RedisClient.zscan]
  *
  * @param key Key string
  * @param cursor Cursor id
  * @param options Scan options
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.zscanAwait(key : String, cursor : String, options : ScanOptions) : JsonArray {
-  return awaitResult{
+suspend fun RedisClient.zscanAwait(key: String, cursor: String, options: ScanOptions): JsonArray {
+  return awaitResult {
     this.zscan(key, cursor, options, it)
   }
 }
 
 /**
- * Add one or more geospatial items in the geospatial index represented using a sorted set.
+ * Suspending version of method [io.vertx.redis.RedisClient.geoadd]
  *
  * @param key Key string
  * @param longitude longitude
  * @param latitude latitude
  * @param member member
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.geoaddAwait(key : String, longitude : Double, latitude : Double, member : String) : Long {
-  return awaitResult{
+suspend fun RedisClient.geoaddAwait(key: String, longitude: Double, latitude: Double, member: String): Long {
+  return awaitResult {
     this.geoadd(key, longitude, latitude, member, it)
   }
 }
 
 /**
- * Add one or more geospatial items in the geospatial index represented using a sorted set.
+ * Suspending version of method [io.vertx.redis.RedisClient.geoaddMany]
  *
  * @param key Key string
  * @param members list of &lt;lon, lat, member&gt;
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.geoaddManyAwait(key : String, members : List<GeoMember>) : Long {
-  return awaitResult{
+suspend fun RedisClient.geoaddManyAwait(key: String, members: List<GeoMember>): Long {
+  return awaitResult {
     this.geoaddMany(key, members, it)
   }
 }
 
 /**
- * Return valid Geohash strings representing the position of one or more elements in a sorted set value representing
- * a geospatial index (where elements were added using GEOADD).
+ * Suspending version of method [io.vertx.redis.RedisClient.geohash]
  *
  * @param key Key string
  * @param member member
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.geohashAwait(key : String, member : String) : JsonArray {
-  return awaitResult{
+suspend fun RedisClient.geohashAwait(key: String, member: String): JsonArray {
+  return awaitResult {
     this.geohash(key, member, it)
   }
 }
 
 /**
- * Return valid Geohash strings representing the position of one or more elements in a sorted set value representing
- * a geospatial index (where elements were added using GEOADD).
+ * Suspending version of method [io.vertx.redis.RedisClient.geohashMany]
  *
  * @param key Key string
  * @param members list of members
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.geohashManyAwait(key : String, members : List<String>) : JsonArray {
-  return awaitResult{
+suspend fun RedisClient.geohashManyAwait(key: String, members: List<String>): JsonArray {
+  return awaitResult {
     this.geohashMany(key, members, it)
   }
 }
 
 /**
- * Return the positions (longitude,latitude) of all the specified members of the geospatial index represented by the
- * sorted set at key.
+ * Suspending version of method [io.vertx.redis.RedisClient.geopos]
  *
  * @param key Key string
  * @param member member
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.geoposAwait(key : String, member : String) : JsonArray {
-  return awaitResult{
+suspend fun RedisClient.geoposAwait(key: String, member: String): JsonArray {
+  return awaitResult {
     this.geopos(key, member, it)
   }
 }
 
 /**
- * Return the positions (longitude,latitude) of all the specified members of the geospatial index represented by the
- * sorted set at key.
+ * Suspending version of method [io.vertx.redis.RedisClient.geoposMany]
  *
  * @param key Key string
  * @param members list of members
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.geoposManyAwait(key : String, members : List<String>) : JsonArray {
-  return awaitResult{
+suspend fun RedisClient.geoposManyAwait(key: String, members: List<String>): JsonArray {
+  return awaitResult {
     this.geoposMany(key, members, it)
   }
 }
 
 /**
- * Return the distance between two members in the geospatial index represented by the sorted set.
+ * Suspending version of method [io.vertx.redis.RedisClient.geodist]
  *
  * @param key Key string
  * @param member1 member 1
  * @param member2 member 2
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.geodistAwait(key : String, member1 : String, member2 : String) : String {
-  return awaitResult{
+suspend fun RedisClient.geodistAwait(key: String, member1: String, member2: String): String {
+  return awaitResult {
     this.geodist(key, member1, member2, it)
   }
 }
 
 /**
- * Return the distance between two members in the geospatial index represented by the sorted set.
+ * Suspending version of method [io.vertx.redis.RedisClient.geodistWithUnit]
  *
  * @param key Key string
  * @param member1 member 1
  * @param member2 member 2
  * @param unit geo unit
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.geodistWithUnitAwait(key : String, member1 : String, member2 : String, unit : GeoUnit) : String {
-  return awaitResult{
+suspend fun RedisClient.geodistWithUnitAwait(key: String, member1: String, member2: String, unit: GeoUnit): String {
+  return awaitResult {
     this.geodistWithUnit(key, member1, member2, unit, it)
   }
 }
 
 /**
- * Return the members of a sorted set populated with geospatial information using GEOADD, which are within the borders
- * of the area specified with the center location and the maximum distance from the center (the radius).
+ * Suspending version of method [io.vertx.redis.RedisClient.georadius]
  *
  * @param key Key string
  * @param longitude longitude
  * @param latitude latitude
  * @param radius radius
  * @param unit geo unit
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.georadiusAwait(key : String, longitude : Double, latitude : Double, radius : Double, unit : GeoUnit) : JsonArray {
-  return awaitResult{
+suspend fun RedisClient.georadiusAwait(key: String, longitude: Double, latitude: Double, radius: Double, unit: GeoUnit): JsonArray {
+  return awaitResult {
     this.georadius(key, longitude, latitude, radius, unit, it)
   }
 }
 
 /**
- * Return the members of a sorted set populated with geospatial information using GEOADD, which are within the borders
- * of the area specified with the center location and the maximum distance from the center (the radius).
+ * Suspending version of method [io.vertx.redis.RedisClient.georadiusWithOptions]
  *
  * @param key Key string
  * @param longitude longitude
@@ -3386,196 +3362,192 @@ suspend fun RedisClient.georadiusAwait(key : String, longitude : Double, latitud
  * @param radius radius
  * @param unit geo unit
  * @param options geo radius options
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.georadiusWithOptionsAwait(key : String, longitude : Double, latitude : Double, radius : Double, unit : GeoUnit, options : GeoRadiusOptions) : JsonArray {
-  return awaitResult{
+suspend fun RedisClient.georadiusWithOptionsAwait(key: String, longitude: Double, latitude: Double, radius: Double, unit: GeoUnit, options: GeoRadiusOptions): JsonArray {
+  return awaitResult {
     this.georadiusWithOptions(key, longitude, latitude, radius, unit, options, it)
   }
 }
 
 /**
- * This command is exactly like GEORADIUS with the sole difference that instead of taking, as the center of the area
- * to query, a longitude and latitude value, it takes the name of a member already existing inside the geospatial
- * index represented by the sorted set.
+ * Suspending version of method [io.vertx.redis.RedisClient.georadiusbymember]
  *
  * @param key Key string
  * @param member member
  * @param radius radius
  * @param unit geo unit
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.georadiusbymemberAwait(key : String, member : String, radius : Double, unit : GeoUnit) : JsonArray {
-  return awaitResult{
+suspend fun RedisClient.georadiusbymemberAwait(key: String, member: String, radius: Double, unit: GeoUnit): JsonArray {
+  return awaitResult {
     this.georadiusbymember(key, member, radius, unit, it)
   }
 }
 
 /**
- * This command is exactly like GEORADIUS with the sole difference that instead of taking, as the center of the area
- * to query, a longitude and latitude value, it takes the name of a member already existing inside the geospatial
- * index represented by the sorted set.
+ * Suspending version of method [io.vertx.redis.RedisClient.georadiusbymemberWithOptions]
  *
  * @param key Key string
  * @param member member
  * @param radius radius
  * @param unit geo unit
  * @param options geo radius options
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.georadiusbymemberWithOptionsAwait(key : String, member : String, radius : Double, unit : GeoUnit, options : GeoRadiusOptions) : JsonArray {
-  return awaitResult{
+suspend fun RedisClient.georadiusbymemberWithOptionsAwait(key: String, member: String, radius: Double, unit: GeoUnit, options: GeoRadiusOptions): JsonArray {
+  return awaitResult {
     this.georadiusbymemberWithOptions(key, member, radius, unit, options, it)
   }
 }
 
 /**
- * Instruct the server whether to reply to commands.
+ * Suspending version of method [io.vertx.redis.RedisClient.clientReply]
  *
  * @param options 
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.clientReplyAwait(options : ClientReplyOptions) : String {
-  return awaitResult{
+suspend fun RedisClient.clientReplyAwait(options: ClientReplyOptions): String {
+  return awaitResult {
     this.clientReply(options, it)
   }
 }
 
 /**
- * Get the length of the value of a hash field.
+ * Suspending version of method [io.vertx.redis.RedisClient.hstrlen]
  *
  * @param key Key String
  * @param field field
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.hstrlenAwait(key : String, field : String) : Long {
-  return awaitResult{
+suspend fun RedisClient.hstrlenAwait(key: String, field: String): Long {
+  return awaitResult {
     this.hstrlen(key, field, it)
   }
 }
 
 /**
- * Alters the last access time of a key(s). Returns the number of existing keys specified.
+ * Suspending version of method [io.vertx.redis.RedisClient.touch]
  *
  * @param key Key String
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.touchAwait(key : String) : Long {
-  return awaitResult{
+suspend fun RedisClient.touchAwait(key: String): Long {
+  return awaitResult {
     this.touch(key, it)
   }
 }
 
 /**
- * Alters the last access time of a key(s). Returns the number of existing keys specified.
+ * Suspending version of method [io.vertx.redis.RedisClient.touchMany]
  *
  * @param keys list of keys
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.touchManyAwait(keys : List<String>) : Long {
-  return awaitResult{
+suspend fun RedisClient.touchManyAwait(keys: List<String>): Long {
+  return awaitResult {
     this.touchMany(keys, it)
   }
 }
 
 /**
- * Set the debug mode for executed scripts.
+ * Suspending version of method [io.vertx.redis.RedisClient.scriptDebug]
  *
  * @param scriptDebugOptions the option
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.scriptDebugAwait(scriptDebugOptions : ScriptDebugOptions) : String {
-  return awaitResult{
+suspend fun RedisClient.scriptDebugAwait(scriptDebugOptions: ScriptDebugOptions): String {
+  return awaitResult {
     this.scriptDebug(scriptDebugOptions, it)
   }
 }
 
 /**
- * Perform arbitrary bitfield integer operations on strings.
+ * Suspending version of method [io.vertx.redis.RedisClient.bitfield]
  *
  * @param key Key string
  * @param bitFieldOptions 
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.bitfieldAwait(key : String, bitFieldOptions : BitFieldOptions) : JsonArray {
-  return awaitResult{
+suspend fun RedisClient.bitfieldAwait(key: String, bitFieldOptions: BitFieldOptions): JsonArray {
+  return awaitResult {
     this.bitfield(key, bitFieldOptions, it)
   }
 }
 
 /**
- * Perform arbitrary bitfield integer operations on strings.
+ * Suspending version of method [io.vertx.redis.RedisClient.bitfieldWithOverflow]
  *
  * @param key Key string
  * @param commands 
  * @param overflow 
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.bitfieldWithOverflowAwait(key : String, commands : BitFieldOptions, overflow : BitFieldOverflowOptions) : JsonArray {
-  return awaitResult{
+suspend fun RedisClient.bitfieldWithOverflowAwait(key: String, commands: BitFieldOptions, overflow: BitFieldOverflowOptions): JsonArray {
+  return awaitResult {
     this.bitfieldWithOverflow(key, commands, overflow, it)
   }
 }
 
 /**
- * Delete a key asynchronously in another thread. Otherwise it is just as DEL, but non blocking.
+ * Suspending version of method [io.vertx.redis.RedisClient.unlink]
  *
  * @param key Key to delete
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.unlinkAwait(key : String) : Long {
-  return awaitResult{
+suspend fun RedisClient.unlinkAwait(key: String): Long {
+  return awaitResult {
     this.unlink(key, it)
   }
 }
 
 /**
- * Delete multiple keys asynchronously in another thread. Otherwise it is just as DEL, but non blocking.
+ * Suspending version of method [io.vertx.redis.RedisClient.unlinkMany]
  *
  * @param keys List of keys to delete
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [Long]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.unlinkManyAwait(keys : List<String>) : Long {
-  return awaitResult{
+suspend fun RedisClient.unlinkManyAwait(keys: List<String>): Long {
+  return awaitResult {
     this.unlinkMany(keys, it)
   }
 }
 
 /**
- * Swaps two Redis databases
+ * Suspending version of method [io.vertx.redis.RedisClient.swapdb]
  *
  * @param index1 index of first database to swap
  * @param index2 index of second database to swap
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisClient original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisClient] using Vert.x codegen.
  */
-suspend fun RedisClient.swapdbAwait(index1 : Int, index2 : Int) : String {
-  return awaitResult{
+suspend fun RedisClient.swapdbAwait(index1: Int, index2: Int): String {
+  return awaitResult {
     this.swapdb(index1, index2, it)
   }
 }

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/redis/RedisTransaction.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/redis/RedisTransaction.kt
@@ -25,1586 +25,1573 @@ import io.vertx.redis.op.SlotCmd
 import io.vertx.redis.op.SortOptions
 
 /**
- * Close the client - when it is fully closed the handler will be called.
+ * Suspending version of method [io.vertx.redis.RedisTransaction.close]
  *
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.closeAwait() : Unit {
-  return awaitResult{
-    this.close({ ar -> it.handle(ar.mapEmpty()) })}
+suspend fun RedisTransaction.closeAwait(): Unit {
+  return awaitResult {
+    this.close { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Append a value to a key
+ * Suspending version of method [io.vertx.redis.RedisTransaction.append]
  *
  * @param key Key string
  * @param value Value to append
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.appendAwait(key : String, value : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.appendAwait(key: String, value: String): String {
+  return awaitResult {
     this.append(key, value, it)
   }
 }
 
 /**
- * Authenticate to the server
+ * Suspending version of method [io.vertx.redis.RedisTransaction.auth]
  *
  * @param password Password for authentication
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.authAwait(password : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.authAwait(password: String): String {
+  return awaitResult {
     this.auth(password, it)
   }
 }
 
 /**
- * Asynchronously rewrite the append-only file
+ * Suspending version of method [io.vertx.redis.RedisTransaction.bgrewriteaof]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.bgrewriteaofAwait() : String {
-  return awaitResult{
+suspend fun RedisTransaction.bgrewriteaofAwait(): String {
+  return awaitResult {
     this.bgrewriteaof(it)
   }
 }
 
 /**
- * Asynchronously save the dataset to disk
+ * Suspending version of method [io.vertx.redis.RedisTransaction.bgsave]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.bgsaveAwait() : String {
-  return awaitResult{
+suspend fun RedisTransaction.bgsaveAwait(): String {
+  return awaitResult {
     this.bgsave(it)
   }
 }
 
 /**
- * Count set bits in a string
+ * Suspending version of method [io.vertx.redis.RedisTransaction.bitcount]
  *
  * @param key Key string
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.bitcountAwait(key : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.bitcountAwait(key: String): String {
+  return awaitResult {
     this.bitcount(key, it)
   }
 }
 
 /**
- * Count set bits in a string
+ * Suspending version of method [io.vertx.redis.RedisTransaction.bitcountRange]
  *
  * @param key Key string
  * @param start Start index
  * @param end End index
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.bitcountRangeAwait(key : String, start : Long, end : Long) : String {
-  return awaitResult{
+suspend fun RedisTransaction.bitcountRangeAwait(key: String, start: Long, end: Long): String {
+  return awaitResult {
     this.bitcountRange(key, start, end, it)
   }
 }
 
 /**
- * Perform bitwise operations between strings
+ * Suspending version of method [io.vertx.redis.RedisTransaction.bitop]
  *
  * @param operation Bitwise operation to perform
  * @param destkey Destination key where result is stored
  * @param keys List of keys on which to perform the operation
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.bitopAwait(operation : BitOperation, destkey : String, keys : List<String>) : String {
-  return awaitResult{
+suspend fun RedisTransaction.bitopAwait(operation: BitOperation, destkey: String, keys: List<String>): String {
+  return awaitResult {
     this.bitop(operation, destkey, keys, it)
   }
 }
 
 /**
- * Find first bit set or clear in a string
+ * Suspending version of method [io.vertx.redis.RedisTransaction.bitpos]
  *
  * @param key Key string
  * @param bit What bit value to look for - must be 1, or 0
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.bitposAwait(key : String, bit : Int) : String {
-  return awaitResult{
+suspend fun RedisTransaction.bitposAwait(key: String, bit: Int): String {
+  return awaitResult {
     this.bitpos(key, bit, it)
   }
 }
 
 /**
- * Find first bit set or clear in a string
- * <p>
- * See also bitposRange() method, which takes start, and stop offset.
+ * Suspending version of method [io.vertx.redis.RedisTransaction.bitposFrom]
  *
  * @param key Key string
  * @param bit What bit value to look for - must be 1, or 0
  * @param start Start offset
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.bitposFromAwait(key : String, bit : Int, start : Int) : String {
-  return awaitResult{
+suspend fun RedisTransaction.bitposFromAwait(key: String, bit: Int, start: Int): String {
+  return awaitResult {
     this.bitposFrom(key, bit, start, it)
   }
 }
 
 /**
- * Find first bit set or clear in a string
- * <p>
- * Note: when both start, and stop offsets are specified,
- * behaviour is slightly different than if only start is specified
+ * Suspending version of method [io.vertx.redis.RedisTransaction.bitposRange]
  *
  * @param key Key string
  * @param bit What bit value to look for - must be 1, or 0
  * @param start Start offset
  * @param stop End offset - inclusive
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.bitposRangeAwait(key : String, bit : Int, start : Int, stop : Int) : String {
-  return awaitResult{
+suspend fun RedisTransaction.bitposRangeAwait(key: String, bit: Int, start: Int, stop: Int): String {
+  return awaitResult {
     this.bitposRange(key, bit, start, stop, it)
   }
 }
 
 /**
- * Remove and get the first element in a list, or block until one is available
+ * Suspending version of method [io.vertx.redis.RedisTransaction.blpop]
  *
  * @param key Key string identifying a list to watch
  * @param seconds Timeout in seconds
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.blpopAwait(key : String, seconds : Int) : String {
-  return awaitResult{
+suspend fun RedisTransaction.blpopAwait(key: String, seconds: Int): String {
+  return awaitResult {
     this.blpop(key, seconds, it)
   }
 }
 
 /**
- * Remove and get the first element in any of the lists, or block until one is available
+ * Suspending version of method [io.vertx.redis.RedisTransaction.blpopMany]
  *
  * @param keys List of key strings identifying lists to watch
  * @param seconds Timeout in seconds
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.blpopManyAwait(keys : List<String>, seconds : Int) : String {
-  return awaitResult{
+suspend fun RedisTransaction.blpopManyAwait(keys: List<String>, seconds: Int): String {
+  return awaitResult {
     this.blpopMany(keys, seconds, it)
   }
 }
 
 /**
- * Remove and get the last element in a list, or block until one is available
+ * Suspending version of method [io.vertx.redis.RedisTransaction.brpop]
  *
  * @param key Key string identifying a list to watch
  * @param seconds Timeout in seconds
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.brpopAwait(key : String, seconds : Int) : String {
-  return awaitResult{
+suspend fun RedisTransaction.brpopAwait(key: String, seconds: Int): String {
+  return awaitResult {
     this.brpop(key, seconds, it)
   }
 }
 
 /**
- * Remove and get the last element in any of the lists, or block until one is available
+ * Suspending version of method [io.vertx.redis.RedisTransaction.brpopMany]
  *
  * @param keys List of key strings identifying lists to watch
  * @param seconds Timeout in seconds
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.brpopManyAwait(keys : List<String>, seconds : Int) : String {
-  return awaitResult{
+suspend fun RedisTransaction.brpopManyAwait(keys: List<String>, seconds: Int): String {
+  return awaitResult {
     this.brpopMany(keys, seconds, it)
   }
 }
 
 /**
- * Pop a value from a list, push it to another list and return it; or block until one is available
+ * Suspending version of method [io.vertx.redis.RedisTransaction.brpoplpush]
  *
  * @param key Key string identifying the source list
  * @param destkey Key string identifying the destination list
  * @param seconds Timeout in seconds
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.brpoplpushAwait(key : String, destkey : String, seconds : Int) : String {
-  return awaitResult{
+suspend fun RedisTransaction.brpoplpushAwait(key: String, destkey: String, seconds: Int): String {
+  return awaitResult {
     this.brpoplpush(key, destkey, seconds, it)
   }
 }
 
 /**
- * Kill the connection of a client
+ * Suspending version of method [io.vertx.redis.RedisTransaction.clientKill]
  *
  * @param filter Filter options
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.clientKillAwait(filter : KillFilter) : String {
-  return awaitResult{
+suspend fun RedisTransaction.clientKillAwait(filter: KillFilter): String {
+  return awaitResult {
     this.clientKill(filter, it)
   }
 }
 
 /**
- * Get the list of client connections
+ * Suspending version of method [io.vertx.redis.RedisTransaction.clientList]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.clientListAwait() : String {
-  return awaitResult{
+suspend fun RedisTransaction.clientListAwait(): String {
+  return awaitResult {
     this.clientList(it)
   }
 }
 
 /**
- * Get the current connection name
+ * Suspending version of method [io.vertx.redis.RedisTransaction.clientGetname]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.clientGetnameAwait() : String {
-  return awaitResult{
+suspend fun RedisTransaction.clientGetnameAwait(): String {
+  return awaitResult {
     this.clientGetname(it)
   }
 }
 
 /**
- * Stop processing commands from clients for some time
+ * Suspending version of method [io.vertx.redis.RedisTransaction.clientPause]
  *
  * @param millis Pause time in milliseconds
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.clientPauseAwait(millis : Long) : String {
-  return awaitResult{
+suspend fun RedisTransaction.clientPauseAwait(millis: Long): String {
+  return awaitResult {
     this.clientPause(millis, it)
   }
 }
 
 /**
- * Set the current connection name
+ * Suspending version of method [io.vertx.redis.RedisTransaction.clientSetname]
  *
  * @param name New name for current connection
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.clientSetnameAwait(name : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.clientSetnameAwait(name: String): String {
+  return awaitResult {
     this.clientSetname(name, it)
   }
 }
 
 /**
- * Assign new hash slots to receiving node.
+ * Suspending version of method [io.vertx.redis.RedisTransaction.clusterAddslots]
  *
  * @param slots 
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.clusterAddslotsAwait(slots : List<String>) : String {
-  return awaitResult{
+suspend fun RedisTransaction.clusterAddslotsAwait(slots: List<String>): String {
+  return awaitResult {
     this.clusterAddslots(slots, it)
   }
 }
 
 /**
- * Return the number of failure reports active for a given node.
+ * Suspending version of method [io.vertx.redis.RedisTransaction.clusterCountFailureReports]
  *
  * @param nodeId 
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.clusterCountFailureReportsAwait(nodeId : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.clusterCountFailureReportsAwait(nodeId: String): String {
+  return awaitResult {
     this.clusterCountFailureReports(nodeId, it)
   }
 }
 
 /**
- * Return the number of local keys in the specified hash slot.
+ * Suspending version of method [io.vertx.redis.RedisTransaction.clusterCountkeysinslot]
  *
  * @param slot 
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.clusterCountkeysinslotAwait(slot : Long) : String {
-  return awaitResult{
+suspend fun RedisTransaction.clusterCountkeysinslotAwait(slot: Long): String {
+  return awaitResult {
     this.clusterCountkeysinslot(slot, it)
   }
 }
 
 /**
- * Set hash slots as unbound in receiving node.
+ * Suspending version of method [io.vertx.redis.RedisTransaction.clusterDelslots]
  *
  * @param slot 
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.clusterDelslotsAwait(slot : Long) : String {
-  return awaitResult{
+suspend fun RedisTransaction.clusterDelslotsAwait(slot: Long): String {
+  return awaitResult {
     this.clusterDelslots(slot, it)
   }
 }
 
 /**
- * Set hash slots as unbound in receiving node.
+ * Suspending version of method [io.vertx.redis.RedisTransaction.clusterDelslotsMany]
  *
  * @param slots 
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.clusterDelslotsManyAwait(slots : List<String>) : String {
-  return awaitResult{
+suspend fun RedisTransaction.clusterDelslotsManyAwait(slots: List<String>): String {
+  return awaitResult {
     this.clusterDelslotsMany(slots, it)
   }
 }
 
 /**
- * Forces a slave to perform a manual failover of its master.
+ * Suspending version of method [io.vertx.redis.RedisTransaction.clusterFailover]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.clusterFailoverAwait() : String {
-  return awaitResult{
+suspend fun RedisTransaction.clusterFailoverAwait(): String {
+  return awaitResult {
     this.clusterFailover(it)
   }
 }
 
 /**
- * Forces a slave to perform a manual failover of its master.
+ * Suspending version of method [io.vertx.redis.RedisTransaction.clusterFailOverWithOptions]
  *
  * @param options 
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.clusterFailOverWithOptionsAwait(options : FailoverOptions) : String {
-  return awaitResult{
+suspend fun RedisTransaction.clusterFailOverWithOptionsAwait(options: FailoverOptions): String {
+  return awaitResult {
     this.clusterFailOverWithOptions(options, it)
   }
 }
 
 /**
- * Remove a node from the nodes table.
+ * Suspending version of method [io.vertx.redis.RedisTransaction.clusterForget]
  *
  * @param nodeId 
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.clusterForgetAwait(nodeId : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.clusterForgetAwait(nodeId: String): String {
+  return awaitResult {
     this.clusterForget(nodeId, it)
   }
 }
 
 /**
- * Return local key names in the specified hash slot.
+ * Suspending version of method [io.vertx.redis.RedisTransaction.clusterGetkeysinslot]
  *
  * @param slot 
  * @param count 
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.clusterGetkeysinslotAwait(slot : Long, count : Long) : String {
-  return awaitResult{
+suspend fun RedisTransaction.clusterGetkeysinslotAwait(slot: Long, count: Long): String {
+  return awaitResult {
     this.clusterGetkeysinslot(slot, count, it)
   }
 }
 
 /**
- * Provides info about Redis Cluster node state.
+ * Suspending version of method [io.vertx.redis.RedisTransaction.clusterInfo]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.clusterInfoAwait() : String {
-  return awaitResult{
+suspend fun RedisTransaction.clusterInfoAwait(): String {
+  return awaitResult {
     this.clusterInfo(it)
   }
 }
 
 /**
- * Returns the hash slot of the specified key.
+ * Suspending version of method [io.vertx.redis.RedisTransaction.clusterKeyslot]
  *
  * @param key 
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.clusterKeyslotAwait(key : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.clusterKeyslotAwait(key: String): String {
+  return awaitResult {
     this.clusterKeyslot(key, it)
   }
 }
 
 /**
- * Force a node cluster to handshake with another node.
+ * Suspending version of method [io.vertx.redis.RedisTransaction.clusterMeet]
  *
  * @param ip 
  * @param port 
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.clusterMeetAwait(ip : String, port : Long) : String {
-  return awaitResult{
+suspend fun RedisTransaction.clusterMeetAwait(ip: String, port: Long): String {
+  return awaitResult {
     this.clusterMeet(ip, port, it)
   }
 }
 
 /**
- * Get Cluster config for the node.
+ * Suspending version of method [io.vertx.redis.RedisTransaction.clusterNodes]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.clusterNodesAwait() : String {
-  return awaitResult{
+suspend fun RedisTransaction.clusterNodesAwait(): String {
+  return awaitResult {
     this.clusterNodes(it)
   }
 }
 
 /**
- * Reconfigure a node as a slave of the specified master node.
+ * Suspending version of method [io.vertx.redis.RedisTransaction.clusterReplicate]
  *
  * @param nodeId 
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.clusterReplicateAwait(nodeId : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.clusterReplicateAwait(nodeId: String): String {
+  return awaitResult {
     this.clusterReplicate(nodeId, it)
   }
 }
 
 /**
- * Reset a Redis Cluster node.
+ * Suspending version of method [io.vertx.redis.RedisTransaction.clusterReset]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.clusterResetAwait() : String {
-  return awaitResult{
+suspend fun RedisTransaction.clusterResetAwait(): String {
+  return awaitResult {
     this.clusterReset(it)
   }
 }
 
 /**
- * Reset a Redis Cluster node.
+ * Suspending version of method [io.vertx.redis.RedisTransaction.clusterResetWithOptions]
  *
  * @param options 
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.clusterResetWithOptionsAwait(options : ResetOptions) : String {
-  return awaitResult{
+suspend fun RedisTransaction.clusterResetWithOptionsAwait(options: ResetOptions): String {
+  return awaitResult {
     this.clusterResetWithOptions(options, it)
   }
 }
 
 /**
- * Forces the node to save cluster state on disk.
+ * Suspending version of method [io.vertx.redis.RedisTransaction.clusterSaveconfig]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.clusterSaveconfigAwait() : String {
-  return awaitResult{
+suspend fun RedisTransaction.clusterSaveconfigAwait(): String {
+  return awaitResult {
     this.clusterSaveconfig(it)
   }
 }
 
 /**
- * Set the configuration epoch in a new node.
+ * Suspending version of method [io.vertx.redis.RedisTransaction.clusterSetConfigEpoch]
  *
  * @param epoch 
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.clusterSetConfigEpochAwait(epoch : Long) : String {
-  return awaitResult{
+suspend fun RedisTransaction.clusterSetConfigEpochAwait(epoch: Long): String {
+  return awaitResult {
     this.clusterSetConfigEpoch(epoch, it)
   }
 }
 
 /**
- * Bind an hash slot to a specific node.
+ * Suspending version of method [io.vertx.redis.RedisTransaction.clusterSetslot]
  *
  * @param slot 
  * @param subcommand 
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.clusterSetslotAwait(slot : Long, subcommand : SlotCmd) : String {
-  return awaitResult{
+suspend fun RedisTransaction.clusterSetslotAwait(slot: Long, subcommand: SlotCmd): String {
+  return awaitResult {
     this.clusterSetslot(slot, subcommand, it)
   }
 }
 
 /**
- * Bind an hash slot to a specific node.
+ * Suspending version of method [io.vertx.redis.RedisTransaction.clusterSetslotWithNode]
  *
  * @param slot 
  * @param subcommand 
  * @param nodeId 
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.clusterSetslotWithNodeAwait(slot : Long, subcommand : SlotCmd, nodeId : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.clusterSetslotWithNodeAwait(slot: Long, subcommand: SlotCmd, nodeId: String): String {
+  return awaitResult {
     this.clusterSetslotWithNode(slot, subcommand, nodeId, it)
   }
 }
 
 /**
- * List slave nodes of the specified master node.
+ * Suspending version of method [io.vertx.redis.RedisTransaction.clusterSlaves]
  *
  * @param nodeId 
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.clusterSlavesAwait(nodeId : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.clusterSlavesAwait(nodeId: String): String {
+  return awaitResult {
     this.clusterSlaves(nodeId, it)
   }
 }
 
 /**
- * Get array of Cluster slot to node mappings
+ * Suspending version of method [io.vertx.redis.RedisTransaction.clusterSlots]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.clusterSlotsAwait() : String {
-  return awaitResult{
+suspend fun RedisTransaction.clusterSlotsAwait(): String {
+  return awaitResult {
     this.clusterSlots(it)
   }
 }
 
 /**
- * Get array of Redis command details
+ * Suspending version of method [io.vertx.redis.RedisTransaction.command]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.commandAwait() : String {
-  return awaitResult{
+suspend fun RedisTransaction.commandAwait(): String {
+  return awaitResult {
     this.command(it)
   }
 }
 
 /**
- * Get total number of Redis commands
+ * Suspending version of method [io.vertx.redis.RedisTransaction.commandCount]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.commandCountAwait() : String {
-  return awaitResult{
+suspend fun RedisTransaction.commandCountAwait(): String {
+  return awaitResult {
     this.commandCount(it)
   }
 }
 
 /**
- * Extract keys given a full Redis command
+ * Suspending version of method [io.vertx.redis.RedisTransaction.commandGetkeys]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.commandGetkeysAwait() : String {
-  return awaitResult{
+suspend fun RedisTransaction.commandGetkeysAwait(): String {
+  return awaitResult {
     this.commandGetkeys(it)
   }
 }
 
 /**
- * Get array of specific Redis command details
+ * Suspending version of method [io.vertx.redis.RedisTransaction.commandInfo]
  *
  * @param commands List of commands to get info for
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.commandInfoAwait(commands : List<String>) : String {
-  return awaitResult{
+suspend fun RedisTransaction.commandInfoAwait(commands: List<String>): String {
+  return awaitResult {
     this.commandInfo(commands, it)
   }
 }
 
 /**
- * Get the value of a configuration parameter
+ * Suspending version of method [io.vertx.redis.RedisTransaction.configGet]
  *
  * @param parameter Configuration parameter
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.configGetAwait(parameter : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.configGetAwait(parameter: String): String {
+  return awaitResult {
     this.configGet(parameter, it)
   }
 }
 
 /**
- * Rewrite the configuration file with the in memory configuration
+ * Suspending version of method [io.vertx.redis.RedisTransaction.configRewrite]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.configRewriteAwait() : String {
-  return awaitResult{
+suspend fun RedisTransaction.configRewriteAwait(): String {
+  return awaitResult {
     this.configRewrite(it)
   }
 }
 
 /**
- * Set a configuration parameter to the given value
+ * Suspending version of method [io.vertx.redis.RedisTransaction.configSet]
  *
  * @param parameter Configuration parameter
  * @param value New value
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.configSetAwait(parameter : String, value : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.configSetAwait(parameter: String, value: String): String {
+  return awaitResult {
     this.configSet(parameter, value, it)
   }
 }
 
 /**
- * Reset the stats returned by INFO
+ * Suspending version of method [io.vertx.redis.RedisTransaction.configResetstat]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.configResetstatAwait() : String {
-  return awaitResult{
+suspend fun RedisTransaction.configResetstatAwait(): String {
+  return awaitResult {
     this.configResetstat(it)
   }
 }
 
 /**
- * Return the number of keys in the selected database
+ * Suspending version of method [io.vertx.redis.RedisTransaction.dbsize]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.dbsizeAwait() : String {
-  return awaitResult{
+suspend fun RedisTransaction.dbsizeAwait(): String {
+  return awaitResult {
     this.dbsize(it)
   }
 }
 
 /**
- * Get debugging information about a key
+ * Suspending version of method [io.vertx.redis.RedisTransaction.debugObject]
  *
  * @param key Key string
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.debugObjectAwait(key : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.debugObjectAwait(key: String): String {
+  return awaitResult {
     this.debugObject(key, it)
   }
 }
 
 /**
- * Make the server crash
+ * Suspending version of method [io.vertx.redis.RedisTransaction.debugSegfault]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.debugSegfaultAwait() : String {
-  return awaitResult{
+suspend fun RedisTransaction.debugSegfaultAwait(): String {
+  return awaitResult {
     this.debugSegfault(it)
   }
 }
 
 /**
- * Decrement the integer value of a key by one
+ * Suspending version of method [io.vertx.redis.RedisTransaction.decr]
  *
  * @param key Key string
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.decrAwait(key : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.decrAwait(key: String): String {
+  return awaitResult {
     this.decr(key, it)
   }
 }
 
 /**
- * Decrement the integer value of a key by the given number
+ * Suspending version of method [io.vertx.redis.RedisTransaction.decrby]
  *
  * @param key Key string
  * @param decrement Value by which to decrement
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.decrbyAwait(key : String, decrement : Long) : String {
-  return awaitResult{
+suspend fun RedisTransaction.decrbyAwait(key: String, decrement: Long): String {
+  return awaitResult {
     this.decrby(key, decrement, it)
   }
 }
 
 /**
- * Delete a key
+ * Suspending version of method [io.vertx.redis.RedisTransaction.del]
  *
  * @param key Keys to delete
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.delAwait(key : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.delAwait(key: String): String {
+  return awaitResult {
     this.del(key, it)
   }
 }
 
 /**
- * Delete many keys
+ * Suspending version of method [io.vertx.redis.RedisTransaction.delMany]
  *
  * @param keys List of keys to delete
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.delManyAwait(keys : List<String>) : String {
-  return awaitResult{
+suspend fun RedisTransaction.delManyAwait(keys: List<String>): String {
+  return awaitResult {
     this.delMany(keys, it)
   }
 }
 
 /**
- * Discard all commands issued after MULTI
+ * Suspending version of method [io.vertx.redis.RedisTransaction.discard]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.discardAwait() : String {
-  return awaitResult{
+suspend fun RedisTransaction.discardAwait(): String {
+  return awaitResult {
     this.discard(it)
   }
 }
 
 /**
- * Return a serialized version of the value stored at the specified key.
+ * Suspending version of method [io.vertx.redis.RedisTransaction.dump]
  *
  * @param key Key string
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.dumpAwait(key : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.dumpAwait(key: String): String {
+  return awaitResult {
     this.dump(key, it)
   }
 }
 
 /**
- * Echo the given string
+ * Suspending version of method [io.vertx.redis.RedisTransaction.echo]
  *
  * @param message String to echo
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.echoAwait(message : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.echoAwait(message: String): String {
+  return awaitResult {
     this.echo(message, it)
   }
 }
 
 /**
- * Execute a Lua script server side. Due to the dynamic nature of this command any response type could be returned
- * for This reason and to ensure type safety the reply is always guaranteed to be a JsonArray.
- * <p>
- * When a reply if for example a String the handler will be called with a JsonArray with a single element containing
- * the String.
+ * Suspending version of method [io.vertx.redis.RedisTransaction.eval]
  *
  * @param script Lua script to evaluate
  * @param keys List of keys
  * @param args List of argument values
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.evalAwait(script : String, keys : List<String>, args : List<String>) : String {
-  return awaitResult{
+suspend fun RedisTransaction.evalAwait(script: String, keys: List<String>, args: List<String>): String {
+  return awaitResult {
     this.eval(script, keys, args, it)
   }
 }
 
 /**
- * Execute a Lua script server side. Due to the dynamic nature of this command any response type could be returned
- * for This reason and to ensure type safety the reply is always guaranteed to be a JsonArray.
- * <p>
- * When a reply if for example a String the handler will be called with a JsonArray with a single element containing
- * the String.
+ * Suspending version of method [io.vertx.redis.RedisTransaction.evalsha]
  *
  * @param sha1 SHA1 digest of the script cached on the server
  * @param keys List of keys
  * @param values List of values
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.evalshaAwait(sha1 : String, keys : List<String>, values : List<String>) : String {
-  return awaitResult{
+suspend fun RedisTransaction.evalshaAwait(sha1: String, keys: List<String>, values: List<String>): String {
+  return awaitResult {
     this.evalsha(sha1, keys, values, it)
   }
 }
 
 /**
- * Execute all commands issued after MULTI
+ * Suspending version of method [io.vertx.redis.RedisTransaction.exec]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.execAwait() : JsonArray {
-  return awaitResult{
+suspend fun RedisTransaction.execAwait(): JsonArray {
+  return awaitResult {
     this.exec(it)
   }
 }
 
 /**
- * Determine if a key exists
+ * Suspending version of method [io.vertx.redis.RedisTransaction.exists]
  *
  * @param key Key string
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.existsAwait(key : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.existsAwait(key: String): String {
+  return awaitResult {
     this.exists(key, it)
   }
 }
 
 /**
- * Determine if one or many keys exist
+ * Suspending version of method [io.vertx.redis.RedisTransaction.existsMany]
  *
  * @param keys List of key strings
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.existsManyAwait(keys : List<String>) : String {
-  return awaitResult{
+suspend fun RedisTransaction.existsManyAwait(keys: List<String>): String {
+  return awaitResult {
     this.existsMany(keys, it)
   }
 }
 
 /**
- * Set a key's time to live in seconds
+ * Suspending version of method [io.vertx.redis.RedisTransaction.expire]
  *
  * @param key Key string
  * @param seconds Time to live in seconds
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.expireAwait(key : String, seconds : Int) : String {
-  return awaitResult{
+suspend fun RedisTransaction.expireAwait(key: String, seconds: Int): String {
+  return awaitResult {
     this.expire(key, seconds, it)
   }
 }
 
 /**
- * Set the expiration for a key as a UNIX timestamp
+ * Suspending version of method [io.vertx.redis.RedisTransaction.expireat]
  *
  * @param key Key string
  * @param seconds Expiry time as Unix timestamp in seconds
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.expireatAwait(key : String, seconds : Long) : String {
-  return awaitResult{
+suspend fun RedisTransaction.expireatAwait(key: String, seconds: Long): String {
+  return awaitResult {
     this.expireat(key, seconds, it)
   }
 }
 
 /**
- * Remove all keys from all databases
+ * Suspending version of method [io.vertx.redis.RedisTransaction.flushall]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.flushallAwait() : String {
-  return awaitResult{
+suspend fun RedisTransaction.flushallAwait(): String {
+  return awaitResult {
     this.flushall(it)
   }
 }
 
 /**
- * Remove all keys from the current database
+ * Suspending version of method [io.vertx.redis.RedisTransaction.flushdb]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.flushdbAwait() : String {
-  return awaitResult{
+suspend fun RedisTransaction.flushdbAwait(): String {
+  return awaitResult {
     this.flushdb(it)
   }
 }
 
 /**
- * Get the value of a key
+ * Suspending version of method [io.vertx.redis.RedisTransaction.get]
  *
  * @param key Key string
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.getAwait(key : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.getAwait(key: String): String {
+  return awaitResult {
     this.get(key, it)
   }
 }
 
 /**
- * Get the value of a key - without decoding as utf-8
+ * Suspending version of method [io.vertx.redis.RedisTransaction.getBinary]
  *
  * @param key Key string
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [Buffer]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.getBinaryAwait(key : String) : Buffer {
-  return awaitResult{
+suspend fun RedisTransaction.getBinaryAwait(key: String): Buffer {
+  return awaitResult {
     this.getBinary(key, it)
   }
 }
 
 /**
- * Returns the bit value at offset in the string value stored at key
+ * Suspending version of method [io.vertx.redis.RedisTransaction.getbit]
  *
  * @param key Key string
  * @param offset Offset in bits
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.getbitAwait(key : String, offset : Long) : String {
-  return awaitResult{
+suspend fun RedisTransaction.getbitAwait(key: String, offset: Long): String {
+  return awaitResult {
     this.getbit(key, offset, it)
   }
 }
 
 /**
- * Get a substring of the string stored at a key
+ * Suspending version of method [io.vertx.redis.RedisTransaction.getrange]
  *
  * @param key Key string
  * @param start Start offset
  * @param end End offset - inclusive
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.getrangeAwait(key : String, start : Long, end : Long) : String {
-  return awaitResult{
+suspend fun RedisTransaction.getrangeAwait(key: String, start: Long, end: Long): String {
+  return awaitResult {
     this.getrange(key, start, end, it)
   }
 }
 
 /**
- * Set the string value of a key and return its old value
+ * Suspending version of method [io.vertx.redis.RedisTransaction.getset]
  *
  * @param key Key of which value to set
  * @param value New value for the key
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.getsetAwait(key : String, value : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.getsetAwait(key: String, value: String): String {
+  return awaitResult {
     this.getset(key, value, it)
   }
 }
 
 /**
- * Delete one or more hash fields
+ * Suspending version of method [io.vertx.redis.RedisTransaction.hdel]
  *
  * @param key Key string
  * @param field Field name
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.hdelAwait(key : String, field : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.hdelAwait(key: String, field: String): String {
+  return awaitResult {
     this.hdel(key, field, it)
   }
 }
 
 /**
- * Delete one or more hash fields
+ * Suspending version of method [io.vertx.redis.RedisTransaction.hdelMany]
  *
  * @param key Key string
  * @param fields Field names
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.hdelManyAwait(key : String, fields : List<String>) : String {
-  return awaitResult{
+suspend fun RedisTransaction.hdelManyAwait(key: String, fields: List<String>): String {
+  return awaitResult {
     this.hdelMany(key, fields, it)
   }
 }
 
 /**
- * Determine if a hash field exists
+ * Suspending version of method [io.vertx.redis.RedisTransaction.hexists]
  *
  * @param key Key string
  * @param field Field name
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.hexistsAwait(key : String, field : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.hexistsAwait(key: String, field: String): String {
+  return awaitResult {
     this.hexists(key, field, it)
   }
 }
 
 /**
- * Get the value of a hash field
+ * Suspending version of method [io.vertx.redis.RedisTransaction.hget]
  *
  * @param key Key string
  * @param field Field name
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.hgetAwait(key : String, field : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.hgetAwait(key: String, field: String): String {
+  return awaitResult {
     this.hget(key, field, it)
   }
 }
 
 /**
- * Get all the fields and values in a hash
+ * Suspending version of method [io.vertx.redis.RedisTransaction.hgetall]
  *
  * @param key Key string
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.hgetallAwait(key : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.hgetallAwait(key: String): String {
+  return awaitResult {
     this.hgetall(key, it)
   }
 }
 
 /**
- * Increment the integer value of a hash field by the given number
+ * Suspending version of method [io.vertx.redis.RedisTransaction.hincrby]
  *
  * @param key Key string
  * @param field Field name
  * @param increment Value by which to increment
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.hincrbyAwait(key : String, field : String, increment : Long) : String {
-  return awaitResult{
+suspend fun RedisTransaction.hincrbyAwait(key: String, field: String, increment: Long): String {
+  return awaitResult {
     this.hincrby(key, field, increment, it)
   }
 }
 
 /**
- * Increment the float value of a hash field by the given amount
+ * Suspending version of method [io.vertx.redis.RedisTransaction.hincrbyfloat]
  *
  * @param key Key string
  * @param field Field name
  * @param increment Value by which to increment
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.hincrbyfloatAwait(key : String, field : String, increment : Double) : String {
-  return awaitResult{
+suspend fun RedisTransaction.hincrbyfloatAwait(key: String, field: String, increment: Double): String {
+  return awaitResult {
     this.hincrbyfloat(key, field, increment, it)
   }
 }
 
 /**
- * Get all the fields in a hash
+ * Suspending version of method [io.vertx.redis.RedisTransaction.hkeys]
  *
  * @param key Key string
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.hkeysAwait(key : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.hkeysAwait(key: String): String {
+  return awaitResult {
     this.hkeys(key, it)
   }
 }
 
 /**
- * Get the number of fields in a hash
+ * Suspending version of method [io.vertx.redis.RedisTransaction.hlen]
  *
  * @param key Key string
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.hlenAwait(key : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.hlenAwait(key: String): String {
+  return awaitResult {
     this.hlen(key, it)
   }
 }
 
 /**
- * Get the values of all the given hash fields
+ * Suspending version of method [io.vertx.redis.RedisTransaction.hmget]
  *
  * @param key Key string
  * @param fields Field names
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.hmgetAwait(key : String, fields : List<String>) : String {
-  return awaitResult{
+suspend fun RedisTransaction.hmgetAwait(key: String, fields: List<String>): String {
+  return awaitResult {
     this.hmget(key, fields, it)
   }
 }
 
 /**
- * Set multiple hash fields to multiple values
+ * Suspending version of method [io.vertx.redis.RedisTransaction.hmset]
  *
  * @param key Key string
  * @param values Map of field:value pairs
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.hmsetAwait(key : String, values : JsonObject) : String {
-  return awaitResult{
+suspend fun RedisTransaction.hmsetAwait(key: String, values: JsonObject): String {
+  return awaitResult {
     this.hmset(key, values, it)
   }
 }
 
 /**
- * Set the string value of a hash field
+ * Suspending version of method [io.vertx.redis.RedisTransaction.hset]
  *
  * @param key Key string
  * @param field Field name
  * @param value New value
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.hsetAwait(key : String, field : String, value : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.hsetAwait(key: String, field: String, value: String): String {
+  return awaitResult {
     this.hset(key, field, value, it)
   }
 }
 
 /**
- * Set the value of a hash field, only if the field does not exist
+ * Suspending version of method [io.vertx.redis.RedisTransaction.hsetnx]
  *
  * @param key Key string
  * @param field Field name
  * @param value New value
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.hsetnxAwait(key : String, field : String, value : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.hsetnxAwait(key: String, field: String, value: String): String {
+  return awaitResult {
     this.hsetnx(key, field, value, it)
   }
 }
 
 /**
- * Get all the values in a hash
+ * Suspending version of method [io.vertx.redis.RedisTransaction.hvals]
  *
  * @param key Key string
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.hvalsAwait(key : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.hvalsAwait(key: String): String {
+  return awaitResult {
     this.hvals(key, it)
   }
 }
 
 /**
- * Increment the integer value of a key by one
+ * Suspending version of method [io.vertx.redis.RedisTransaction.incr]
  *
  * @param key Key string
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.incrAwait(key : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.incrAwait(key: String): String {
+  return awaitResult {
     this.incr(key, it)
   }
 }
 
 /**
- * Increment the integer value of a key by the given amount
+ * Suspending version of method [io.vertx.redis.RedisTransaction.incrby]
  *
  * @param key Key string
  * @param increment Value by which to increment
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.incrbyAwait(key : String, increment : Long) : String {
-  return awaitResult{
+suspend fun RedisTransaction.incrbyAwait(key: String, increment: Long): String {
+  return awaitResult {
     this.incrby(key, increment, it)
   }
 }
 
 /**
- * Increment the float value of a key by the given amount
+ * Suspending version of method [io.vertx.redis.RedisTransaction.incrbyfloat]
  *
  * @param key Key string
  * @param increment Value by which to increment
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.incrbyfloatAwait(key : String, increment : Double) : String {
-  return awaitResult{
+suspend fun RedisTransaction.incrbyfloatAwait(key: String, increment: Double): String {
+  return awaitResult {
     this.incrbyfloat(key, increment, it)
   }
 }
 
 /**
- * Get information and statistics about the server
+ * Suspending version of method [io.vertx.redis.RedisTransaction.info]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.infoAwait() : String {
-  return awaitResult{
+suspend fun RedisTransaction.infoAwait(): String {
+  return awaitResult {
     this.info(it)
   }
 }
 
 /**
- * Get information and statistics about the server
+ * Suspending version of method [io.vertx.redis.RedisTransaction.infoSection]
  *
  * @param section Specific section of information to return
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.infoSectionAwait(section : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.infoSectionAwait(section: String): String {
+  return awaitResult {
     this.infoSection(section, it)
   }
 }
 
 /**
- * Find all keys matching the given pattern
+ * Suspending version of method [io.vertx.redis.RedisTransaction.keys]
  *
  * @param pattern Pattern to limit the keys returned
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.keysAwait(pattern : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.keysAwait(pattern: String): String {
+  return awaitResult {
     this.keys(pattern, it)
   }
 }
 
 /**
- * Get the UNIX time stamp of the last successful save to disk
+ * Suspending version of method [io.vertx.redis.RedisTransaction.lastsave]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.lastsaveAwait() : String {
-  return awaitResult{
+suspend fun RedisTransaction.lastsaveAwait(): String {
+  return awaitResult {
     this.lastsave(it)
   }
 }
 
 /**
- * Get an element from a list by its index
+ * Suspending version of method [io.vertx.redis.RedisTransaction.lindex]
  *
  * @param key Key string
  * @param index Index of list element to get
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.lindexAwait(key : String, index : Int) : String {
-  return awaitResult{
+suspend fun RedisTransaction.lindexAwait(key: String, index: Int): String {
+  return awaitResult {
     this.lindex(key, index, it)
   }
 }
 
 /**
- * Insert an element before or after another element in a list
+ * Suspending version of method [io.vertx.redis.RedisTransaction.linsert]
  *
  * @param key Key string
  * @param option BEFORE or AFTER
  * @param pivot Key to use as a pivot
  * @param value Value to be inserted before or after the pivot
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.linsertAwait(key : String, option : InsertOptions, pivot : String, value : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.linsertAwait(key: String, option: InsertOptions, pivot: String, value: String): String {
+  return awaitResult {
     this.linsert(key, option, pivot, value, it)
   }
 }
 
 /**
- * Get the length of a list
+ * Suspending version of method [io.vertx.redis.RedisTransaction.llen]
  *
  * @param key String key
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.llenAwait(key : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.llenAwait(key: String): String {
+  return awaitResult {
     this.llen(key, it)
   }
 }
 
 /**
- * Remove and get the first element in a list
+ * Suspending version of method [io.vertx.redis.RedisTransaction.lpop]
  *
  * @param key String key
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.lpopAwait(key : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.lpopAwait(key: String): String {
+  return awaitResult {
     this.lpop(key, it)
   }
 }
 
 /**
- * Prepend one or multiple values to a list
+ * Suspending version of method [io.vertx.redis.RedisTransaction.lpushMany]
  *
  * @param key Key string
  * @param values Values to be added at the beginning of the list, one by one
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.lpushManyAwait(key : String, values : List<String>) : String {
-  return awaitResult{
+suspend fun RedisTransaction.lpushManyAwait(key: String, values: List<String>): String {
+  return awaitResult {
     this.lpushMany(key, values, it)
   }
 }
 
 /**
- * Prepend one value to a list
+ * Suspending version of method [io.vertx.redis.RedisTransaction.lpush]
  *
  * @param key Key string
  * @param value Value to be added at the beginning of the list
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.lpushAwait(key : String, value : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.lpushAwait(key: String, value: String): String {
+  return awaitResult {
     this.lpush(key, value, it)
   }
 }
 
 /**
- * Prepend a value to a list, only if the list exists
+ * Suspending version of method [io.vertx.redis.RedisTransaction.lpushx]
  *
  * @param key Key string
  * @param value Value to add at the beginning of the list
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.lpushxAwait(key : String, value : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.lpushxAwait(key: String, value: String): String {
+  return awaitResult {
     this.lpushx(key, value, it)
   }
 }
 
 /**
- * Get a range of elements from a list
+ * Suspending version of method [io.vertx.redis.RedisTransaction.lrange]
  *
  * @param key Key string
  * @param from Start index
  * @param to Stop index
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.lrangeAwait(key : String, from : Long, to : Long) : String {
-  return awaitResult{
+suspend fun RedisTransaction.lrangeAwait(key: String, from: Long, to: Long): String {
+  return awaitResult {
     this.lrange(key, from, to, it)
   }
 }
 
 /**
- * Remove elements from a list
+ * Suspending version of method [io.vertx.redis.RedisTransaction.lrem]
  *
  * @param key Key string
  * @param count Number of first found occurrences equal to $value to remove from the list
  * @param value Value to be removed
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.lremAwait(key : String, count : Long, value : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.lremAwait(key: String, count: Long, value: String): String {
+  return awaitResult {
     this.lrem(key, count, value, it)
   }
 }
 
 /**
- * Set the value of an element in a list by its index
+ * Suspending version of method [io.vertx.redis.RedisTransaction.lset]
  *
  * @param key Key string
  * @param index Position within list
  * @param value New value
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.lsetAwait(key : String, index : Long, value : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.lsetAwait(key: String, index: Long, value: String): String {
+  return awaitResult {
     this.lset(key, index, value, it)
   }
 }
 
 /**
- * Trim a list to the specified range
+ * Suspending version of method [io.vertx.redis.RedisTransaction.ltrim]
  *
  * @param key Key string
  * @param from Start index
  * @param to Stop index
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.ltrimAwait(key : String, from : Long, to : Long) : String {
-  return awaitResult{
+suspend fun RedisTransaction.ltrimAwait(key: String, from: Long, to: Long): String {
+  return awaitResult {
     this.ltrim(key, from, to, it)
   }
 }
 
 /**
- * Get the value of the given key
+ * Suspending version of method [io.vertx.redis.RedisTransaction.mget]
  *
  * @param key Key string
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.mgetAwait(key : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.mgetAwait(key: String): String {
+  return awaitResult {
     this.mget(key, it)
   }
 }
 
 /**
- * Get the values of all the given keys
+ * Suspending version of method [io.vertx.redis.RedisTransaction.mgetMany]
  *
  * @param keys List of keys to get
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.mgetManyAwait(keys : List<String>) : String {
-  return awaitResult{
+suspend fun RedisTransaction.mgetManyAwait(keys: List<String>): String {
+  return awaitResult {
     this.mgetMany(keys, it)
   }
 }
 
 /**
- * Atomically transfer a key from a Redis instance to another one.
+ * Suspending version of method [io.vertx.redis.RedisTransaction.migrate]
  *
  * @param host Destination host
  * @param port Destination port
@@ -1612,1851 +1599,1845 @@ suspend fun RedisTransaction.mgetManyAwait(keys : List<String>) : String {
  * @param destdb Destination database index
  * @param timeout 
  * @param options Migrate options
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.migrateAwait(host : String, port : Int, key : String, destdb : Int, timeout : Long, options : MigrateOptions) : String {
-  return awaitResult{
+suspend fun RedisTransaction.migrateAwait(host: String, port: Int, key: String, destdb: Int, timeout: Long, options: MigrateOptions): String {
+  return awaitResult {
     this.migrate(host, port, key, destdb, timeout, options, it)
   }
 }
 
 /**
- * Listen for all requests received by the server in real time
+ * Suspending version of method [io.vertx.redis.RedisTransaction.monitor]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.monitorAwait() : String {
-  return awaitResult{
+suspend fun RedisTransaction.monitorAwait(): String {
+  return awaitResult {
     this.monitor(it)
   }
 }
 
 /**
- * Move a key to another database
+ * Suspending version of method [io.vertx.redis.RedisTransaction.move]
  *
  * @param key Key to migrate
  * @param destdb Destination database index
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.moveAwait(key : String, destdb : Int) : String {
-  return awaitResult{
+suspend fun RedisTransaction.moveAwait(key: String, destdb: Int): String {
+  return awaitResult {
     this.move(key, destdb, it)
   }
 }
 
 /**
- * Set multiple keys to multiple values
+ * Suspending version of method [io.vertx.redis.RedisTransaction.mset]
  *
  * @param keyvals Key value pairs to set
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.msetAwait(keyvals : JsonObject) : String {
-  return awaitResult{
+suspend fun RedisTransaction.msetAwait(keyvals: JsonObject): String {
+  return awaitResult {
     this.mset(keyvals, it)
   }
 }
 
 /**
- * Set multiple keys to multiple values, only if none of the keys exist
+ * Suspending version of method [io.vertx.redis.RedisTransaction.msetnx]
  *
  * @param keyvals Key value pairs to set
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.msetnxAwait(keyvals : JsonObject) : String {
-  return awaitResult{
+suspend fun RedisTransaction.msetnxAwait(keyvals: JsonObject): String {
+  return awaitResult {
     this.msetnx(keyvals, it)
   }
 }
 
 /**
- * Mark the start of a RedisTransaction block
+ * Suspending version of method [io.vertx.redis.RedisTransaction.multi]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.multiAwait() : String {
-  return awaitResult{
+suspend fun RedisTransaction.multiAwait(): String {
+  return awaitResult {
     this.multi(it)
   }
 }
 
 /**
- * Inspect the internals of Redis objects
+ * Suspending version of method [io.vertx.redis.RedisTransaction.object]
  *
  * @param key Key string
  * @param cmd Object sub command
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.objectAwait(key : String, cmd : ObjectCmd) : String {
-  return awaitResult{
+suspend fun RedisTransaction.objectAwait(key: String, cmd: ObjectCmd): String {
+  return awaitResult {
     this.`object`(key, cmd, it)
   }
 }
 
 /**
- * Remove the expiration from a key
+ * Suspending version of method [io.vertx.redis.RedisTransaction.persist]
  *
  * @param key Key string
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.persistAwait(key : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.persistAwait(key: String): String {
+  return awaitResult {
     this.persist(key, it)
   }
 }
 
 /**
- * Set a key's time to live in milliseconds
+ * Suspending version of method [io.vertx.redis.RedisTransaction.pexpire]
  *
  * @param key String key
  * @param millis Time to live in milliseconds
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.pexpireAwait(key : String, millis : Long) : String {
-  return awaitResult{
+suspend fun RedisTransaction.pexpireAwait(key: String, millis: Long): String {
+  return awaitResult {
     this.pexpire(key, millis, it)
   }
 }
 
 /**
- * Set the expiration for a key as a UNIX timestamp specified in milliseconds
+ * Suspending version of method [io.vertx.redis.RedisTransaction.pexpireat]
  *
  * @param key Key string
  * @param millis Expiry time as Unix timestamp in milliseconds
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.pexpireatAwait(key : String, millis : Long) : String {
-  return awaitResult{
+suspend fun RedisTransaction.pexpireatAwait(key: String, millis: Long): String {
+  return awaitResult {
     this.pexpireat(key, millis, it)
   }
 }
 
 /**
- * Adds the specified element to the specified HyperLogLog.
+ * Suspending version of method [io.vertx.redis.RedisTransaction.pfadd]
  *
  * @param key Key string
  * @param element Element to add
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.pfaddAwait(key : String, element : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.pfaddAwait(key: String, element: String): String {
+  return awaitResult {
     this.pfadd(key, element, it)
   }
 }
 
 /**
- * Adds the specified elements to the specified HyperLogLog.
+ * Suspending version of method [io.vertx.redis.RedisTransaction.pfaddMany]
  *
  * @param key Key string
  * @param elements Elementa to add
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.pfaddManyAwait(key : String, elements : List<String>) : String {
-  return awaitResult{
+suspend fun RedisTransaction.pfaddManyAwait(key: String, elements: List<String>): String {
+  return awaitResult {
     this.pfaddMany(key, elements, it)
   }
 }
 
 /**
- * Return the approximated cardinality of the set observed by the HyperLogLog at key.
+ * Suspending version of method [io.vertx.redis.RedisTransaction.pfcount]
  *
  * @param key Key string
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.pfcountAwait(key : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.pfcountAwait(key: String): String {
+  return awaitResult {
     this.pfcount(key, it)
   }
 }
 
 /**
- * Return the approximated cardinality of the set(s) observed by the HyperLogLog at key(s).
+ * Suspending version of method [io.vertx.redis.RedisTransaction.pfcountMany]
  *
  * @param keys List of keys
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.pfcountManyAwait(keys : List<String>) : String {
-  return awaitResult{
+suspend fun RedisTransaction.pfcountManyAwait(keys: List<String>): String {
+  return awaitResult {
     this.pfcountMany(keys, it)
   }
 }
 
 /**
- * Merge N different HyperLogLogs into a single one.
+ * Suspending version of method [io.vertx.redis.RedisTransaction.pfmerge]
  *
  * @param destkey Destination key
  * @param keys List of source keys
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.pfmergeAwait(destkey : String, keys : List<String>) : String {
-  return awaitResult{
+suspend fun RedisTransaction.pfmergeAwait(destkey: String, keys: List<String>): String {
+  return awaitResult {
     this.pfmerge(destkey, keys, it)
   }
 }
 
 /**
- * Ping the server
+ * Suspending version of method [io.vertx.redis.RedisTransaction.ping]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.pingAwait() : String {
-  return awaitResult{
+suspend fun RedisTransaction.pingAwait(): String {
+  return awaitResult {
     this.ping(it)
   }
 }
 
 /**
- * Set the value and expiration in milliseconds of a key
+ * Suspending version of method [io.vertx.redis.RedisTransaction.psetex]
  *
  * @param key Key string
  * @param millis Number of milliseconds until the key expires
  * @param value New value for key
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.psetexAwait(key : String, millis : Long, value : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.psetexAwait(key: String, millis: Long, value: String): String {
+  return awaitResult {
     this.psetex(key, millis, value, it)
   }
 }
 
 /**
- * Listen for messages published to channels matching the given pattern
+ * Suspending version of method [io.vertx.redis.RedisTransaction.psubscribe]
  *
  * @param pattern Pattern string
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.psubscribeAwait(pattern : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.psubscribeAwait(pattern: String): String {
+  return awaitResult {
     this.psubscribe(pattern, it)
   }
 }
 
 /**
- * Listen for messages published to channels matching the given patterns
+ * Suspending version of method [io.vertx.redis.RedisTransaction.psubscribeMany]
  *
  * @param patterns List of patterns
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.psubscribeManyAwait(patterns : List<String>) : String {
-  return awaitResult{
+suspend fun RedisTransaction.psubscribeManyAwait(patterns: List<String>): String {
+  return awaitResult {
     this.psubscribeMany(patterns, it)
   }
 }
 
 /**
- * Lists the currently active channels - only those matching the pattern
+ * Suspending version of method [io.vertx.redis.RedisTransaction.pubsubChannels]
  *
  * @param pattern A glob-style pattern - an empty string means no pattern
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.pubsubChannelsAwait(pattern : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.pubsubChannelsAwait(pattern: String): String {
+  return awaitResult {
     this.pubsubChannels(pattern, it)
   }
 }
 
 /**
- * Returns the number of subscribers (not counting clients subscribed to patterns) for the specified channels
+ * Suspending version of method [io.vertx.redis.RedisTransaction.pubsubNumsub]
  *
  * @param channels List of channels
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.pubsubNumsubAwait(channels : List<String>) : String {
-  return awaitResult{
+suspend fun RedisTransaction.pubsubNumsubAwait(channels: List<String>): String {
+  return awaitResult {
     this.pubsubNumsub(channels, it)
   }
 }
 
 /**
- * Returns the number of subscriptions to patterns (that are performed using the PSUBSCRIBE command)
+ * Suspending version of method [io.vertx.redis.RedisTransaction.pubsubNumpat]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.pubsubNumpatAwait() : String {
-  return awaitResult{
+suspend fun RedisTransaction.pubsubNumpatAwait(): String {
+  return awaitResult {
     this.pubsubNumpat(it)
   }
 }
 
 /**
- * Get the time to live for a key in milliseconds
+ * Suspending version of method [io.vertx.redis.RedisTransaction.pttl]
  *
  * @param key Key string
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.pttlAwait(key : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.pttlAwait(key: String): String {
+  return awaitResult {
     this.pttl(key, it)
   }
 }
 
 /**
- * Post a message to a channel
+ * Suspending version of method [io.vertx.redis.RedisTransaction.publish]
  *
  * @param channel Channel key
  * @param message Message to send to channel
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.publishAwait(channel : String, message : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.publishAwait(channel: String, message: String): String {
+  return awaitResult {
     this.publish(channel, message, it)
   }
 }
 
 /**
- * Stop listening for messages posted to channels matching the given patterns
+ * Suspending version of method [io.vertx.redis.RedisTransaction.punsubscribe]
  *
  * @param patterns List of patterns to match against
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.punsubscribeAwait(patterns : List<String>) : String {
-  return awaitResult{
+suspend fun RedisTransaction.punsubscribeAwait(patterns: List<String>): String {
+  return awaitResult {
     this.punsubscribe(patterns, it)
   }
 }
 
 /**
- * Return a random key from the keyspace
+ * Suspending version of method [io.vertx.redis.RedisTransaction.randomkey]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.randomkeyAwait() : String {
-  return awaitResult{
+suspend fun RedisTransaction.randomkeyAwait(): String {
+  return awaitResult {
     this.randomkey(it)
   }
 }
 
 /**
- * Rename a key
+ * Suspending version of method [io.vertx.redis.RedisTransaction.rename]
  *
  * @param key Key string to be renamed
  * @param newkey New key string
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.renameAwait(key : String, newkey : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.renameAwait(key: String, newkey: String): String {
+  return awaitResult {
     this.rename(key, newkey, it)
   }
 }
 
 /**
- * Rename a key, only if the new key does not exist
+ * Suspending version of method [io.vertx.redis.RedisTransaction.renamenx]
  *
  * @param key Key string to be renamed
  * @param newkey New key string
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.renamenxAwait(key : String, newkey : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.renamenxAwait(key: String, newkey: String): String {
+  return awaitResult {
     this.renamenx(key, newkey, it)
   }
 }
 
 /**
- * Create a key using the provided serialized value, previously obtained using DUMP.
+ * Suspending version of method [io.vertx.redis.RedisTransaction.restore]
  *
  * @param key Key string
  * @param millis Expiry time in milliseconds to set on the key
  * @param serialized Serialized form of the key value as obtained using DUMP
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.restoreAwait(key : String, millis : Long, serialized : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.restoreAwait(key: String, millis: Long, serialized: String): String {
+  return awaitResult {
     this.restore(key, millis, serialized, it)
   }
 }
 
 /**
- * Return the role of the instance in the context of replication
+ * Suspending version of method [io.vertx.redis.RedisTransaction.role]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.roleAwait() : String {
-  return awaitResult{
+suspend fun RedisTransaction.roleAwait(): String {
+  return awaitResult {
     this.role(it)
   }
 }
 
 /**
- * Remove and get the last element in a list
+ * Suspending version of method [io.vertx.redis.RedisTransaction.rpop]
  *
  * @param key Key string
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.rpopAwait(key : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.rpopAwait(key: String): String {
+  return awaitResult {
     this.rpop(key, it)
   }
 }
 
 /**
- * Remove the last element in a list, append it to another list and return it
+ * Suspending version of method [io.vertx.redis.RedisTransaction.rpoplpush]
  *
  * @param key Key string identifying source list
  * @param destkey Key string identifying destination list
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.rpoplpushAwait(key : String, destkey : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.rpoplpushAwait(key: String, destkey: String): String {
+  return awaitResult {
     this.rpoplpush(key, destkey, it)
   }
 }
 
 /**
- * Append one or multiple values to a list
+ * Suspending version of method [io.vertx.redis.RedisTransaction.rpushMany]
  *
  * @param key Key string
  * @param values List of values to add to the end of the list
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.rpushManyAwait(key : String, values : List<String>) : String {
-  return awaitResult{
+suspend fun RedisTransaction.rpushManyAwait(key: String, values: List<String>): String {
+  return awaitResult {
     this.rpushMany(key, values, it)
   }
 }
 
 /**
- * Append one or multiple values to a list
+ * Suspending version of method [io.vertx.redis.RedisTransaction.rpush]
  *
  * @param key Key string
  * @param value Value to be added to the end of the list
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.rpushAwait(key : String, value : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.rpushAwait(key: String, value: String): String {
+  return awaitResult {
     this.rpush(key, value, it)
   }
 }
 
 /**
- * Append a value to a list, only if the list exists
+ * Suspending version of method [io.vertx.redis.RedisTransaction.rpushx]
  *
  * @param key Key string
  * @param value Value to be added to the end of the list
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.rpushxAwait(key : String, value : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.rpushxAwait(key: String, value: String): String {
+  return awaitResult {
     this.rpushx(key, value, it)
   }
 }
 
 /**
- * Add a member to a set
+ * Suspending version of method [io.vertx.redis.RedisTransaction.sadd]
  *
  * @param key Key string
  * @param member Value to be added to the set
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.saddAwait(key : String, member : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.saddAwait(key: String, member: String): String {
+  return awaitResult {
     this.sadd(key, member, it)
   }
 }
 
 /**
- * Add one or more members to a set
+ * Suspending version of method [io.vertx.redis.RedisTransaction.saddMany]
  *
  * @param key Key string
  * @param members Values to be added to the set
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.saddManyAwait(key : String, members : List<String>) : String {
-  return awaitResult{
+suspend fun RedisTransaction.saddManyAwait(key: String, members: List<String>): String {
+  return awaitResult {
     this.saddMany(key, members, it)
   }
 }
 
 /**
- * Synchronously save the dataset to disk
+ * Suspending version of method [io.vertx.redis.RedisTransaction.save]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.saveAwait() : String {
-  return awaitResult{
+suspend fun RedisTransaction.saveAwait(): String {
+  return awaitResult {
     this.save(it)
   }
 }
 
 /**
- * Get the number of members in a set
+ * Suspending version of method [io.vertx.redis.RedisTransaction.scard]
  *
  * @param key Key string
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.scardAwait(key : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.scardAwait(key: String): String {
+  return awaitResult {
     this.scard(key, it)
   }
 }
 
 /**
- * Check existence of script in the script cache.
+ * Suspending version of method [io.vertx.redis.RedisTransaction.scriptExists]
  *
  * @param script SHA1 digest identifying a script in the script cache
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.scriptExistsAwait(script : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.scriptExistsAwait(script: String): String {
+  return awaitResult {
     this.scriptExists(script, it)
   }
 }
 
 /**
- * Check existence of scripts in the script cache.
+ * Suspending version of method [io.vertx.redis.RedisTransaction.scriptExistsMany]
  *
  * @param scripts List of SHA1 digests identifying scripts in the script cache
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.scriptExistsManyAwait(scripts : List<String>) : String {
-  return awaitResult{
+suspend fun RedisTransaction.scriptExistsManyAwait(scripts: List<String>): String {
+  return awaitResult {
     this.scriptExistsMany(scripts, it)
   }
 }
 
 /**
- * Remove all the scripts from the script cache.
+ * Suspending version of method [io.vertx.redis.RedisTransaction.scriptFlush]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.scriptFlushAwait() : String {
-  return awaitResult{
+suspend fun RedisTransaction.scriptFlushAwait(): String {
+  return awaitResult {
     this.scriptFlush(it)
   }
 }
 
 /**
- * Kill the script currently in execution.
+ * Suspending version of method [io.vertx.redis.RedisTransaction.scriptKill]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.scriptKillAwait() : String {
-  return awaitResult{
+suspend fun RedisTransaction.scriptKillAwait(): String {
+  return awaitResult {
     this.scriptKill(it)
   }
 }
 
 /**
- * Load the specified Lua script into the script cache.
+ * Suspending version of method [io.vertx.redis.RedisTransaction.scriptLoad]
  *
  * @param script Lua script
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.scriptLoadAwait(script : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.scriptLoadAwait(script: String): String {
+  return awaitResult {
     this.scriptLoad(script, it)
   }
 }
 
 /**
- * Subtract multiple sets
+ * Suspending version of method [io.vertx.redis.RedisTransaction.sdiff]
  *
  * @param key Key identifying the set to compare with all other sets combined
  * @param cmpkeys List of keys identifying sets to subtract from the key set
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.sdiffAwait(key : String, cmpkeys : List<String>) : String {
-  return awaitResult{
+suspend fun RedisTransaction.sdiffAwait(key: String, cmpkeys: List<String>): String {
+  return awaitResult {
     this.sdiff(key, cmpkeys, it)
   }
 }
 
 /**
- * Subtract multiple sets and store the resulting set in a key
+ * Suspending version of method [io.vertx.redis.RedisTransaction.sdiffstore]
  *
  * @param destkey Destination key where the result should be stored
  * @param key Key identifying the set to compare with all other sets combined
  * @param cmpkeys List of keys identifying sets to subtract from the key set
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.sdiffstoreAwait(destkey : String, key : String, cmpkeys : List<String>) : String {
-  return awaitResult{
+suspend fun RedisTransaction.sdiffstoreAwait(destkey: String, key: String, cmpkeys: List<String>): String {
+  return awaitResult {
     this.sdiffstore(destkey, key, cmpkeys, it)
   }
 }
 
 /**
- * Change the selected database for the current connection
+ * Suspending version of method [io.vertx.redis.RedisTransaction.select]
  *
  * @param dbindex Index identifying the new active database
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.selectAwait(dbindex : Int) : String {
-  return awaitResult{
+suspend fun RedisTransaction.selectAwait(dbindex: Int): String {
+  return awaitResult {
     this.select(dbindex, it)
   }
 }
 
 /**
- * Set the string value of a key
+ * Suspending version of method [io.vertx.redis.RedisTransaction.set]
  *
  * @param key Key of which value to set
  * @param value New value for the key
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.setAwait(key : String, value : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.setAwait(key: String, value: String): String {
+  return awaitResult {
     this.set(key, value, it)
   }
 }
 
 /**
- * Set the string value of a key
+ * Suspending version of method [io.vertx.redis.RedisTransaction.setWithOptions]
  *
  * @param key Key of which value to set
  * @param value New value for the key
  * @param options Set options
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.setWithOptionsAwait(key : String, value : String, options : SetOptions) : String {
-  return awaitResult{
+suspend fun RedisTransaction.setWithOptionsAwait(key: String, value: String, options: SetOptions): String {
+  return awaitResult {
     this.setWithOptions(key, value, options, it)
   }
 }
 
 /**
- * Set the binary string value of a key - without encoding as utf-8
+ * Suspending version of method [io.vertx.redis.RedisTransaction.setBinary]
  *
  * @param key Key of which value to set
  * @param value New value for the key
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.setBinaryAwait(key : String, value : Buffer) : String {
-  return awaitResult{
+suspend fun RedisTransaction.setBinaryAwait(key: String, value: Buffer): String {
+  return awaitResult {
     this.setBinary(key, value, it)
   }
 }
 
 /**
- * Set the string value of a key
+ * Suspending version of method [io.vertx.redis.RedisTransaction.setBinaryWithOptions]
  *
  * @param key Key of which value to set
  * @param value New value for the key
  * @param options Set options
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.setBinaryWithOptionsAwait(key : String, value : Buffer, options : SetOptions) : String {
-  return awaitResult{
+suspend fun RedisTransaction.setBinaryWithOptionsAwait(key: String, value: Buffer, options: SetOptions): String {
+  return awaitResult {
     this.setBinaryWithOptions(key, value, options, it)
   }
 }
 
 /**
- * Sets or clears the bit at offset in the string value stored at key
+ * Suspending version of method [io.vertx.redis.RedisTransaction.setbit]
  *
  * @param key Key string
  * @param offset Bit offset
  * @param bit New value - must be 1 or 0
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.setbitAwait(key : String, offset : Long, bit : Int) : String {
-  return awaitResult{
+suspend fun RedisTransaction.setbitAwait(key: String, offset: Long, bit: Int): String {
+  return awaitResult {
     this.setbit(key, offset, bit, it)
   }
 }
 
 /**
- * Set the value and expiration of a key
+ * Suspending version of method [io.vertx.redis.RedisTransaction.setex]
  *
  * @param key Key string
  * @param seconds Number of seconds until the key expires
  * @param value New value for key
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.setexAwait(key : String, seconds : Long, value : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.setexAwait(key: String, seconds: Long, value: String): String {
+  return awaitResult {
     this.setex(key, seconds, value, it)
   }
 }
 
 /**
- * Set the value of a key, only if the key does not exist
+ * Suspending version of method [io.vertx.redis.RedisTransaction.setnx]
  *
  * @param key Key of which value to set
  * @param value New value for the key
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.setnxAwait(key : String, value : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.setnxAwait(key: String, value: String): String {
+  return awaitResult {
     this.setnx(key, value, it)
   }
 }
 
 /**
- * Overwrite part of a string at key starting at the specified offset
+ * Suspending version of method [io.vertx.redis.RedisTransaction.setrange]
  *
  * @param key Key string
  * @param offset Offset - the maximum offset that you can set is 2^29 -1 (536870911), as Redis Strings are limited to 512 megabytes
  * @param value Value to overwrite with
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.setrangeAwait(key : String, offset : Int, value : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.setrangeAwait(key: String, offset: Int, value: String): String {
+  return awaitResult {
     this.setrange(key, offset, value, it)
   }
 }
 
 /**
- * Intersect multiple sets
+ * Suspending version of method [io.vertx.redis.RedisTransaction.sinter]
  *
  * @param keys List of keys to perform intersection on
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.sinterAwait(keys : List<String>) : String {
-  return awaitResult{
+suspend fun RedisTransaction.sinterAwait(keys: List<String>): String {
+  return awaitResult {
     this.sinter(keys, it)
   }
 }
 
 /**
- * Intersect multiple sets and store the resulting set in a key
+ * Suspending version of method [io.vertx.redis.RedisTransaction.sinterstore]
  *
  * @param destkey Key where to store the results
  * @param keys List of keys to perform intersection on
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.sinterstoreAwait(destkey : String, keys : List<String>) : String {
-  return awaitResult{
+suspend fun RedisTransaction.sinterstoreAwait(destkey: String, keys: List<String>): String {
+  return awaitResult {
     this.sinterstore(destkey, keys, it)
   }
 }
 
 /**
- * Determine if a given value is a member of a set
+ * Suspending version of method [io.vertx.redis.RedisTransaction.sismember]
  *
  * @param key Key string
  * @param member Member to look for
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.sismemberAwait(key : String, member : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.sismemberAwait(key: String, member: String): String {
+  return awaitResult {
     this.sismember(key, member, it)
   }
 }
 
 /**
- * Make the server a slave of another instance
+ * Suspending version of method [io.vertx.redis.RedisTransaction.slaveof]
  *
  * @param host Host to become this server's master
  * @param port Port of our new master
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.slaveofAwait(host : String, port : Int) : String {
-  return awaitResult{
+suspend fun RedisTransaction.slaveofAwait(host: String, port: Int): String {
+  return awaitResult {
     this.slaveof(host, port, it)
   }
 }
 
 /**
- * Make this server a master
+ * Suspending version of method [io.vertx.redis.RedisTransaction.slaveofNoone]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.slaveofNooneAwait() : String {
-  return awaitResult{
+suspend fun RedisTransaction.slaveofNooneAwait(): String {
+  return awaitResult {
     this.slaveofNoone(it)
   }
 }
 
 /**
- * Read the Redis slow queries log
+ * Suspending version of method [io.vertx.redis.RedisTransaction.slowlogGet]
  *
  * @param limit Number of log entries to return. If value is less than zero all entries are returned
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.slowlogGetAwait(limit : Int) : String {
-  return awaitResult{
+suspend fun RedisTransaction.slowlogGetAwait(limit: Int): String {
+  return awaitResult {
     this.slowlogGet(limit, it)
   }
 }
 
 /**
- * Get the length of the Redis slow queries log
+ * Suspending version of method [io.vertx.redis.RedisTransaction.slowlogLen]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.slowlogLenAwait() : String {
-  return awaitResult{
+suspend fun RedisTransaction.slowlogLenAwait(): String {
+  return awaitResult {
     this.slowlogLen(it)
   }
 }
 
 /**
- * Reset the Redis slow queries log
+ * Suspending version of method [io.vertx.redis.RedisTransaction.slowlogReset]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.slowlogResetAwait() : String {
-  return awaitResult{
+suspend fun RedisTransaction.slowlogResetAwait(): String {
+  return awaitResult {
     this.slowlogReset(it)
   }
 }
 
 /**
- * Get all the members in a set
+ * Suspending version of method [io.vertx.redis.RedisTransaction.smembers]
  *
  * @param key Key string
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.smembersAwait(key : String) : JsonArray {
-  return awaitResult{
+suspend fun RedisTransaction.smembersAwait(key: String): JsonArray {
+  return awaitResult {
     this.smembers(key, it)
   }
 }
 
 /**
- * Move a member from one set to another
+ * Suspending version of method [io.vertx.redis.RedisTransaction.smove]
  *
  * @param key Key of source set currently containing the member
  * @param destkey Key identifying the destination set
  * @param member Member to move
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.smoveAwait(key : String, destkey : String, member : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.smoveAwait(key: String, destkey: String, member: String): String {
+  return awaitResult {
     this.smove(key, destkey, member, it)
   }
 }
 
 /**
- * Sort the elements in a list, set or sorted set
+ * Suspending version of method [io.vertx.redis.RedisTransaction.sort]
  *
  * @param key Key string
  * @param options Sort options
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.sortAwait(key : String, options : SortOptions) : String {
-  return awaitResult{
+suspend fun RedisTransaction.sortAwait(key: String, options: SortOptions): String {
+  return awaitResult {
     this.sort(key, options, it)
   }
 }
 
 /**
- * Remove and return a random member from a set
+ * Suspending version of method [io.vertx.redis.RedisTransaction.spop]
  *
  * @param key Key string
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.spopAwait(key : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.spopAwait(key: String): String {
+  return awaitResult {
     this.spop(key, it)
   }
 }
 
 /**
- * Remove and return random members from a set
+ * Suspending version of method [io.vertx.redis.RedisTransaction.spopMany]
  *
  * @param key Key string
  * @param count Number of members to remove
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.spopManyAwait(key : String, count : Int) : String {
-  return awaitResult{
+suspend fun RedisTransaction.spopManyAwait(key: String, count: Int): String {
+  return awaitResult {
     this.spopMany(key, count, it)
   }
 }
 
 /**
- * Get one or multiple random members from a set
+ * Suspending version of method [io.vertx.redis.RedisTransaction.srandmember]
  *
  * @param key Key string
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.srandmemberAwait(key : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.srandmemberAwait(key: String): String {
+  return awaitResult {
     this.srandmember(key, it)
   }
 }
 
 /**
- * Get one or multiple random members from a set
+ * Suspending version of method [io.vertx.redis.RedisTransaction.srandmemberCount]
  *
  * @param key Key string
  * @param count Number of members to get
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.srandmemberCountAwait(key : String, count : Int) : String {
-  return awaitResult{
+suspend fun RedisTransaction.srandmemberCountAwait(key: String, count: Int): String {
+  return awaitResult {
     this.srandmemberCount(key, count, it)
   }
 }
 
 /**
- * Remove one member from a set
+ * Suspending version of method [io.vertx.redis.RedisTransaction.srem]
  *
  * @param key Key string
  * @param member Member to remove
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.sremAwait(key : String, member : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.sremAwait(key: String, member: String): String {
+  return awaitResult {
     this.srem(key, member, it)
   }
 }
 
 /**
- * Remove one or more members from a set
+ * Suspending version of method [io.vertx.redis.RedisTransaction.sremMany]
  *
  * @param key Key string
  * @param members Members to remove
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.sremManyAwait(key : String, members : List<String>) : String {
-  return awaitResult{
+suspend fun RedisTransaction.sremManyAwait(key: String, members: List<String>): String {
+  return awaitResult {
     this.sremMany(key, members, it)
   }
 }
 
 /**
- * Get the length of the value stored in a key
+ * Suspending version of method [io.vertx.redis.RedisTransaction.strlen]
  *
  * @param key Key string
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.strlenAwait(key : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.strlenAwait(key: String): String {
+  return awaitResult {
     this.strlen(key, it)
   }
 }
 
 /**
- * Listen for messages published to the given channels
+ * Suspending version of method [io.vertx.redis.RedisTransaction.subscribe]
  *
  * @param channel Channel to subscribe to
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.subscribeAwait(channel : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.subscribeAwait(channel: String): String {
+  return awaitResult {
     this.subscribe(channel, it)
   }
 }
 
 /**
- * Listen for messages published to the given channels
+ * Suspending version of method [io.vertx.redis.RedisTransaction.subscribeMany]
  *
  * @param channels List of channels to subscribe to
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.subscribeManyAwait(channels : List<String>) : String {
-  return awaitResult{
+suspend fun RedisTransaction.subscribeManyAwait(channels: List<String>): String {
+  return awaitResult {
     this.subscribeMany(channels, it)
   }
 }
 
 /**
- * Add multiple sets
+ * Suspending version of method [io.vertx.redis.RedisTransaction.sunion]
  *
  * @param keys List of keys identifying sets to add up
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.sunionAwait(keys : List<String>) : String {
-  return awaitResult{
+suspend fun RedisTransaction.sunionAwait(keys: List<String>): String {
+  return awaitResult {
     this.sunion(keys, it)
   }
 }
 
 /**
- * Add multiple sets and store the resulting set in a key
+ * Suspending version of method [io.vertx.redis.RedisTransaction.sunionstore]
  *
  * @param destkey Destination key
  * @param keys List of keys identifying sets to add up
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.sunionstoreAwait(destkey : String, keys : List<String>) : String {
-  return awaitResult{
+suspend fun RedisTransaction.sunionstoreAwait(destkey: String, keys: List<String>): String {
+  return awaitResult {
     this.sunionstore(destkey, keys, it)
   }
 }
 
 /**
- * Internal command used for replication
+ * Suspending version of method [io.vertx.redis.RedisTransaction.sync]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.syncAwait() : String {
-  return awaitResult{
+suspend fun RedisTransaction.syncAwait(): String {
+  return awaitResult {
     this.sync(it)
   }
 }
 
 /**
- * Return the current server time
+ * Suspending version of method [io.vertx.redis.RedisTransaction.time]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.timeAwait() : String {
-  return awaitResult{
+suspend fun RedisTransaction.timeAwait(): String {
+  return awaitResult {
     this.time(it)
   }
 }
 
 /**
- * Get the time to live for a key
+ * Suspending version of method [io.vertx.redis.RedisTransaction.ttl]
  *
  * @param key Key string
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.ttlAwait(key : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.ttlAwait(key: String): String {
+  return awaitResult {
     this.ttl(key, it)
   }
 }
 
 /**
- * Determine the type stored at key
+ * Suspending version of method [io.vertx.redis.RedisTransaction.type]
  *
  * @param key Key string
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.typeAwait(key : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.typeAwait(key: String): String {
+  return awaitResult {
     this.type(key, it)
   }
 }
 
 /**
- * Stop listening for messages posted to the given channels
+ * Suspending version of method [io.vertx.redis.RedisTransaction.unsubscribe]
  *
  * @param channels List of channels to subscribe to
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.unsubscribeAwait(channels : List<String>) : String {
-  return awaitResult{
+suspend fun RedisTransaction.unsubscribeAwait(channels: List<String>): String {
+  return awaitResult {
     this.unsubscribe(channels, it)
   }
 }
 
 /**
- * Forget about all watched keys
+ * Suspending version of method [io.vertx.redis.RedisTransaction.unwatch]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.unwatchAwait() : String {
-  return awaitResult{
+suspend fun RedisTransaction.unwatchAwait(): String {
+  return awaitResult {
     this.unwatch(it)
   }
 }
 
 /**
- * Wait for the synchronous replication of all the write commands sent in the context of the current connection.
+ * Suspending version of method [io.vertx.redis.RedisTransaction.wait]
  *
  * @param numSlaves 
  * @param timeout 
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.waitAwait(numSlaves : Long, timeout : Long) : String {
-  return awaitResult{
+suspend fun RedisTransaction.waitAwait(numSlaves: Long, timeout: Long): String {
+  return awaitResult {
     this.wait(numSlaves, timeout, it)
   }
 }
 
 /**
- * Watch the given keys to determine execution of the MULTI/EXEC block
+ * Suspending version of method [io.vertx.redis.RedisTransaction.watch]
  *
  * @param key Key to watch
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.watchAwait(key : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.watchAwait(key: String): String {
+  return awaitResult {
     this.watch(key, it)
   }
 }
 
 /**
- * Watch the given keys to determine execution of the MULTI/EXEC block
+ * Suspending version of method [io.vertx.redis.RedisTransaction.watchMany]
  *
  * @param keys List of keys to watch
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.watchManyAwait(keys : List<String>) : String {
-  return awaitResult{
+suspend fun RedisTransaction.watchManyAwait(keys: List<String>): String {
+  return awaitResult {
     this.watchMany(keys, it)
   }
 }
 
 /**
- * Add one or more members to a sorted set, or update its score if it already exists
+ * Suspending version of method [io.vertx.redis.RedisTransaction.zadd]
  *
  * @param key Key string
  * @param score Score used for sorting
  * @param member New member key
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.zaddAwait(key : String, score : Double, member : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.zaddAwait(key: String, score: Double, member: String): String {
+  return awaitResult {
     this.zadd(key, score, member, it)
   }
 }
 
 /**
- * Add one or more members to a sorted set, or update its score if it already exists
+ * Suspending version of method [io.vertx.redis.RedisTransaction.zaddMany]
  *
  * @param key Key string
  * @param members New member keys and their scores
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.zaddManyAwait(key : String, members : Map<String,Double>) : String {
-  return awaitResult{
+suspend fun RedisTransaction.zaddManyAwait(key: String, members: Map<String,Double>): String {
+  return awaitResult {
     this.zaddMany(key, members, it)
   }
 }
 
 /**
- * Get the number of members in a sorted set
+ * Suspending version of method [io.vertx.redis.RedisTransaction.zcard]
  *
  * @param key Key string
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.zcardAwait(key : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.zcardAwait(key: String): String {
+  return awaitResult {
     this.zcard(key, it)
   }
 }
 
 /**
- * Count the members in a sorted set with scores within the given values
+ * Suspending version of method [io.vertx.redis.RedisTransaction.zcount]
  *
  * @param key Key string
  * @param min Minimum score
  * @param max Maximum score
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.zcountAwait(key : String, min : Double, max : Double) : String {
-  return awaitResult{
+suspend fun RedisTransaction.zcountAwait(key: String, min: Double, max: Double): String {
+  return awaitResult {
     this.zcount(key, min, max, it)
   }
 }
 
 /**
- * Increment the score of a member in a sorted set
+ * Suspending version of method [io.vertx.redis.RedisTransaction.zincrby]
  *
  * @param key Key string
  * @param increment Increment amount
  * @param member Member key
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.zincrbyAwait(key : String, increment : Double, member : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.zincrbyAwait(key: String, increment: Double, member: String): String {
+  return awaitResult {
     this.zincrby(key, increment, member, it)
   }
 }
 
 /**
- * Intersect multiple sorted sets and store the resulting sorted set in a new key
+ * Suspending version of method [io.vertx.redis.RedisTransaction.zinterstore]
  *
  * @param destkey Destination key
  * @param sets List of keys identifying sorted sets to intersect
  * @param options Aggregation options
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.zinterstoreAwait(destkey : String, sets : List<String>, options : AggregateOptions) : String {
-  return awaitResult{
+suspend fun RedisTransaction.zinterstoreAwait(destkey: String, sets: List<String>, options: AggregateOptions): String {
+  return awaitResult {
     this.zinterstore(destkey, sets, options, it)
   }
 }
 
 /**
- * Intersect multiple sorted sets and store the resulting sorted set in a new key using weights for scoring
+ * Suspending version of method [io.vertx.redis.RedisTransaction.zinterstoreWeighed]
  *
  * @param destkey Destination key
  * @param sets List of keys identifying sorted sets to intersect
  * @param options Aggregation options
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.zinterstoreWeighedAwait(destkey : String, sets : Map<String,Double>, options : AggregateOptions) : String {
-  return awaitResult{
+suspend fun RedisTransaction.zinterstoreWeighedAwait(destkey: String, sets: Map<String,Double>, options: AggregateOptions): String {
+  return awaitResult {
     this.zinterstoreWeighed(destkey, sets, options, it)
   }
 }
 
 /**
- * Count the number of members in a sorted set between a given lexicographical range
+ * Suspending version of method [io.vertx.redis.RedisTransaction.zlexcount]
  *
  * @param key Key string
  * @param min Pattern to compare against for minimum value
  * @param max Pattern to compare against for maximum value
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.zlexcountAwait(key : String, min : String, max : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.zlexcountAwait(key: String, min: String, max: String): String {
+  return awaitResult {
     this.zlexcount(key, min, max, it)
   }
 }
 
 /**
- * Return a range of members in a sorted set, by index
+ * Suspending version of method [io.vertx.redis.RedisTransaction.zrange]
  *
  * @param key Key string
  * @param start Start index for the range
  * @param stop Stop index for the range - inclusive
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.zrangeAwait(key : String, start : Long, stop : Long) : String {
-  return awaitResult{
+suspend fun RedisTransaction.zrangeAwait(key: String, start: Long, stop: Long): String {
+  return awaitResult {
     this.zrange(key, start, stop, it)
   }
 }
 
 /**
- * Return a range of members in a sorted set, by index
+ * Suspending version of method [io.vertx.redis.RedisTransaction.zrangeWithOptions]
  *
  * @param key Key string
  * @param start Start index for the range
  * @param stop Stop index for the range - inclusive
  * @param options Range options
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.zrangeWithOptionsAwait(key : String, start : Long, stop : Long, options : RangeOptions) : String {
-  return awaitResult{
+suspend fun RedisTransaction.zrangeWithOptionsAwait(key: String, start: Long, stop: Long, options: RangeOptions): String {
+  return awaitResult {
     this.zrangeWithOptions(key, start, stop, options, it)
   }
 }
 
 /**
- * Return a range of members in a sorted set, by lexicographical range
+ * Suspending version of method [io.vertx.redis.RedisTransaction.zrangebylex]
  *
  * @param key Key string
  * @param min Pattern representing a minimum allowed value
  * @param max Pattern representing a maximum allowed value
  * @param options Limit options where limit can be specified
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.zrangebylexAwait(key : String, min : String, max : String, options : LimitOptions) : String {
-  return awaitResult{
+suspend fun RedisTransaction.zrangebylexAwait(key: String, min: String, max: String, options: LimitOptions): String {
+  return awaitResult {
     this.zrangebylex(key, min, max, options, it)
   }
 }
 
 /**
- * Return a range of members in a sorted set, by score
+ * Suspending version of method [io.vertx.redis.RedisTransaction.zrangebyscore]
  *
  * @param key Key string
  * @param min Pattern defining a minimum value
  * @param max Pattern defining a maximum value
  * @param options Range and limit options
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.zrangebyscoreAwait(key : String, min : String, max : String, options : RangeLimitOptions) : String {
-  return awaitResult{
+suspend fun RedisTransaction.zrangebyscoreAwait(key: String, min: String, max: String, options: RangeLimitOptions): String {
+  return awaitResult {
     this.zrangebyscore(key, min, max, options, it)
   }
 }
 
 /**
- * Determine the index of a member in a sorted set
+ * Suspending version of method [io.vertx.redis.RedisTransaction.zrank]
  *
  * @param key Key string
  * @param member Member in the sorted set identified by key
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.zrankAwait(key : String, member : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.zrankAwait(key: String, member: String): String {
+  return awaitResult {
     this.zrank(key, member, it)
   }
 }
 
 /**
- * Remove one member from a sorted set
+ * Suspending version of method [io.vertx.redis.RedisTransaction.zrem]
  *
  * @param key Key string
  * @param member Member in the sorted set identified by key
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.zremAwait(key : String, member : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.zremAwait(key: String, member: String): String {
+  return awaitResult {
     this.zrem(key, member, it)
   }
 }
 
 /**
- * Remove one or more members from a sorted set
+ * Suspending version of method [io.vertx.redis.RedisTransaction.zremMany]
  *
  * @param key Key string
  * @param members Members in the sorted set identified by key
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.zremManyAwait(key : String, members : List<String>) : String {
-  return awaitResult{
+suspend fun RedisTransaction.zremManyAwait(key: String, members: List<String>): String {
+  return awaitResult {
     this.zremMany(key, members, it)
   }
 }
 
 /**
- * Remove all members in a sorted set between the given lexicographical range
+ * Suspending version of method [io.vertx.redis.RedisTransaction.zremrangebylex]
  *
  * @param key Key string
  * @param min Pattern defining a minimum value
  * @param max Pattern defining a maximum value
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.zremrangebylexAwait(key : String, min : String, max : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.zremrangebylexAwait(key: String, min: String, max: String): String {
+  return awaitResult {
     this.zremrangebylex(key, min, max, it)
   }
 }
 
 /**
- * Remove all members in a sorted set within the given indexes
+ * Suspending version of method [io.vertx.redis.RedisTransaction.zremrangebyrank]
  *
  * @param key Key string
  * @param start Start index
  * @param stop Stop index
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.zremrangebyrankAwait(key : String, start : Long, stop : Long) : String {
-  return awaitResult{
+suspend fun RedisTransaction.zremrangebyrankAwait(key: String, start: Long, stop: Long): String {
+  return awaitResult {
     this.zremrangebyrank(key, start, stop, it)
   }
 }
 
 /**
- * Remove all members in a sorted set within the given scores
+ * Suspending version of method [io.vertx.redis.RedisTransaction.zremrangebyscore]
  *
  * @param key Key string
  * @param min Pattern defining a minimum value
  * @param max Pattern defining a maximum value
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.zremrangebyscoreAwait(key : String, min : String, max : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.zremrangebyscoreAwait(key: String, min: String, max: String): String {
+  return awaitResult {
     this.zremrangebyscore(key, min, max, it)
   }
 }
 
 /**
- * Return a range of members in a sorted set, by index, with scores ordered from high to low
+ * Suspending version of method [io.vertx.redis.RedisTransaction.zrevrange]
  *
  * @param key Key string
  * @param start Start index for the range
  * @param stop Stop index for the range - inclusive
  * @param options Range options
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.zrevrangeAwait(key : String, start : Long, stop : Long, options : RangeOptions) : String {
-  return awaitResult{
+suspend fun RedisTransaction.zrevrangeAwait(key: String, start: Long, stop: Long, options: RangeOptions): String {
+  return awaitResult {
     this.zrevrange(key, start, stop, options, it)
   }
 }
 
 /**
- * Return a range of members in a sorted set, by score, between the given lexicographical range with scores ordered from high to low
+ * Suspending version of method [io.vertx.redis.RedisTransaction.zrevrangebylex]
  *
  * @param key Key string
  * @param max Pattern defining a maximum value
  * @param min Pattern defining a minimum value
  * @param options Limit options
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.zrevrangebylexAwait(key : String, max : String, min : String, options : LimitOptions) : String {
-  return awaitResult{
+suspend fun RedisTransaction.zrevrangebylexAwait(key: String, max: String, min: String, options: LimitOptions): String {
+  return awaitResult {
     this.zrevrangebylex(key, max, min, options, it)
   }
 }
 
 /**
- * Return a range of members in a sorted set, by score, with scores ordered from high to low
+ * Suspending version of method [io.vertx.redis.RedisTransaction.zrevrangebyscore]
  *
  * @param key Key string
  * @param max Pattern defining a maximum value
  * @param min Pattern defining a minimum value
  * @param options Range and limit options
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.zrevrangebyscoreAwait(key : String, max : String, min : String, options : RangeLimitOptions) : String {
-  return awaitResult{
+suspend fun RedisTransaction.zrevrangebyscoreAwait(key: String, max: String, min: String, options: RangeLimitOptions): String {
+  return awaitResult {
     this.zrevrangebyscore(key, max, min, options, it)
   }
 }
 
 /**
- * Determine the index of a member in a sorted set, with scores ordered from high to low
+ * Suspending version of method [io.vertx.redis.RedisTransaction.zrevrank]
  *
  * @param key Key string
  * @param member Member in the sorted set identified by key
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.zrevrankAwait(key : String, member : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.zrevrankAwait(key: String, member: String): String {
+  return awaitResult {
     this.zrevrank(key, member, it)
   }
 }
 
 /**
- * Get the score associated with the given member in a sorted set
+ * Suspending version of method [io.vertx.redis.RedisTransaction.zscore]
  *
  * @param key Key string
  * @param member Member in the sorted set identified by key
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.zscoreAwait(key : String, member : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.zscoreAwait(key: String, member: String): String {
+  return awaitResult {
     this.zscore(key, member, it)
   }
 }
 
 /**
- * Add multiple sorted sets and store the resulting sorted set in a new key
+ * Suspending version of method [io.vertx.redis.RedisTransaction.zunionstore]
  *
  * @param destkey Destination key
  * @param sets List of keys identifying sorted sets
  * @param options Aggregation options
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.zunionstoreAwait(destkey : String, sets : List<String>, options : AggregateOptions) : String {
-  return awaitResult{
+suspend fun RedisTransaction.zunionstoreAwait(destkey: String, sets: List<String>, options: AggregateOptions): String {
+  return awaitResult {
     this.zunionstore(destkey, sets, options, it)
   }
 }
 
 /**
- * Add multiple sorted sets using weights, and store the resulting sorted set in a new key
+ * Suspending version of method [io.vertx.redis.RedisTransaction.zunionstoreWeighed]
  *
  * @param key Destination key
  * @param sets Map containing set-key:weight pairs
  * @param options Aggregation options
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.zunionstoreWeighedAwait(key : String, sets : Map<String,Double>, options : AggregateOptions) : String {
-  return awaitResult{
+suspend fun RedisTransaction.zunionstoreWeighedAwait(key: String, sets: Map<String,Double>, options: AggregateOptions): String {
+  return awaitResult {
     this.zunionstoreWeighed(key, sets, options, it)
   }
 }
 
 /**
- * Incrementally iterate the keys space
+ * Suspending version of method [io.vertx.redis.RedisTransaction.scan]
  *
  * @param cursor Cursor id
  * @param options Scan options
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.scanAwait(cursor : String, options : ScanOptions) : String {
-  return awaitResult{
+suspend fun RedisTransaction.scanAwait(cursor: String, options: ScanOptions): String {
+  return awaitResult {
     this.scan(cursor, options, it)
   }
 }
 
 /**
- * Incrementally iterate Set elements
+ * Suspending version of method [io.vertx.redis.RedisTransaction.sscan]
  *
  * @param key Key string
  * @param cursor Cursor id
  * @param options Scan options
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.sscanAwait(key : String, cursor : String, options : ScanOptions) : String {
-  return awaitResult{
+suspend fun RedisTransaction.sscanAwait(key: String, cursor: String, options: ScanOptions): String {
+  return awaitResult {
     this.sscan(key, cursor, options, it)
   }
 }
 
 /**
- * Incrementally iterate hash fields and associated values
+ * Suspending version of method [io.vertx.redis.RedisTransaction.hscan]
  *
  * @param key Key string
  * @param cursor Cursor id
  * @param options Scan options
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.hscanAwait(key : String, cursor : String, options : ScanOptions) : String {
-  return awaitResult{
+suspend fun RedisTransaction.hscanAwait(key: String, cursor: String, options: ScanOptions): String {
+  return awaitResult {
     this.hscan(key, cursor, options, it)
   }
 }
 
 /**
- * Incrementally iterate sorted sets elements and associated scores
+ * Suspending version of method [io.vertx.redis.RedisTransaction.zscan]
  *
  * @param key Key string
  * @param cursor Cursor id
  * @param options Scan options
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.zscanAwait(key : String, cursor : String, options : ScanOptions) : String {
-  return awaitResult{
+suspend fun RedisTransaction.zscanAwait(key: String, cursor: String, options: ScanOptions): String {
+  return awaitResult {
     this.zscan(key, cursor, options, it)
   }
 }
 
 /**
- * Add one or more geospatial items in the geospatial index represented using a sorted set.
+ * Suspending version of method [io.vertx.redis.RedisTransaction.geoadd]
  *
  * @param key Key string
  * @param longitude longitude
  * @param latitude latitude
  * @param member member
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.geoaddAwait(key : String, longitude : Double, latitude : Double, member : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.geoaddAwait(key: String, longitude: Double, latitude: Double, member: String): String {
+  return awaitResult {
     this.geoadd(key, longitude, latitude, member, it)
   }
 }
 
 /**
- * Add one or more geospatial items in the geospatial index represented using a sorted set.
+ * Suspending version of method [io.vertx.redis.RedisTransaction.geoaddMany]
  *
  * @param key Key string
  * @param members list of &lt;lon, lat, member&gt;
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.geoaddManyAwait(key : String, members : List<GeoMember>) : String {
-  return awaitResult{
+suspend fun RedisTransaction.geoaddManyAwait(key: String, members: List<GeoMember>): String {
+  return awaitResult {
     this.geoaddMany(key, members, it)
   }
 }
 
 /**
- * Return valid Geohash strings representing the position of one or more elements in a sorted set value representing
- * a geospatial index (where elements were added using GEOADD).
+ * Suspending version of method [io.vertx.redis.RedisTransaction.geohash]
  *
  * @param key Key string
  * @param member member
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.geohashAwait(key : String, member : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.geohashAwait(key: String, member: String): String {
+  return awaitResult {
     this.geohash(key, member, it)
   }
 }
 
 /**
- * Return valid Geohash strings representing the position of one or more elements in a sorted set value representing
- * a geospatial index (where elements were added using GEOADD).
+ * Suspending version of method [io.vertx.redis.RedisTransaction.geohashMany]
  *
  * @param key Key string
  * @param members list of members
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.geohashManyAwait(key : String, members : List<String>) : String {
-  return awaitResult{
+suspend fun RedisTransaction.geohashManyAwait(key: String, members: List<String>): String {
+  return awaitResult {
     this.geohashMany(key, members, it)
   }
 }
 
 /**
- * Return the positions (longitude,latitude) of all the specified members of the geospatial index represented by the
- * sorted set at key.
+ * Suspending version of method [io.vertx.redis.RedisTransaction.geopos]
  *
  * @param key Key string
  * @param member member
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.geoposAwait(key : String, member : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.geoposAwait(key: String, member: String): String {
+  return awaitResult {
     this.geopos(key, member, it)
   }
 }
 
 /**
- * Return the positions (longitude,latitude) of all the specified members of the geospatial index represented by the
- * sorted set at key.
+ * Suspending version of method [io.vertx.redis.RedisTransaction.geoposMany]
  *
  * @param key Key string
  * @param members list of members
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.geoposManyAwait(key : String, members : List<String>) : String {
-  return awaitResult{
+suspend fun RedisTransaction.geoposManyAwait(key: String, members: List<String>): String {
+  return awaitResult {
     this.geoposMany(key, members, it)
   }
 }
 
 /**
- * Return the distance between two members in the geospatial index represented by the sorted set.
+ * Suspending version of method [io.vertx.redis.RedisTransaction.geodist]
  *
  * @param key Key string
  * @param member1 member 1
  * @param member2 member 2
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.geodistAwait(key : String, member1 : String, member2 : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.geodistAwait(key: String, member1: String, member2: String): String {
+  return awaitResult {
     this.geodist(key, member1, member2, it)
   }
 }
 
 /**
- * Return the distance between two members in the geospatial index represented by the sorted set.
+ * Suspending version of method [io.vertx.redis.RedisTransaction.geodistWithUnit]
  *
  * @param key Key string
  * @param member1 member 1
  * @param member2 member 2
  * @param unit geo unit
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.geodistWithUnitAwait(key : String, member1 : String, member2 : String, unit : GeoUnit) : String {
-  return awaitResult{
+suspend fun RedisTransaction.geodistWithUnitAwait(key: String, member1: String, member2: String, unit: GeoUnit): String {
+  return awaitResult {
     this.geodistWithUnit(key, member1, member2, unit, it)
   }
 }
 
 /**
- * Return the members of a sorted set populated with geospatial information using GEOADD, which are within the borders
- * of the area specified with the center location and the maximum distance from the center (the radius).
+ * Suspending version of method [io.vertx.redis.RedisTransaction.georadius]
  *
  * @param key Key string
  * @param longitude longitude
  * @param latitude latitude
  * @param radius radius
  * @param unit geo unit
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.georadiusAwait(key : String, longitude : Double, latitude : Double, radius : Double, unit : GeoUnit) : String {
-  return awaitResult{
+suspend fun RedisTransaction.georadiusAwait(key: String, longitude: Double, latitude: Double, radius: Double, unit: GeoUnit): String {
+  return awaitResult {
     this.georadius(key, longitude, latitude, radius, unit, it)
   }
 }
 
 /**
- * Return the members of a sorted set populated with geospatial information using GEOADD, which are within the borders
- * of the area specified with the center location and the maximum distance from the center (the radius).
+ * Suspending version of method [io.vertx.redis.RedisTransaction.georadiusWithOptions]
  *
  * @param key Key string
  * @param longitude longitude
@@ -3464,94 +3445,90 @@ suspend fun RedisTransaction.georadiusAwait(key : String, longitude : Double, la
  * @param radius radius
  * @param unit geo unit
  * @param options geo radius options
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.georadiusWithOptionsAwait(key : String, longitude : Double, latitude : Double, radius : Double, unit : GeoUnit, options : GeoRadiusOptions) : String {
-  return awaitResult{
+suspend fun RedisTransaction.georadiusWithOptionsAwait(key: String, longitude: Double, latitude: Double, radius: Double, unit: GeoUnit, options: GeoRadiusOptions): String {
+  return awaitResult {
     this.georadiusWithOptions(key, longitude, latitude, radius, unit, options, it)
   }
 }
 
 /**
- * This command is exactly like GEORADIUS with the sole difference that instead of taking, as the center of the area
- * to query, a longitude and latitude value, it takes the name of a member already existing inside the geospatial
- * index represented by the sorted set.
+ * Suspending version of method [io.vertx.redis.RedisTransaction.georadiusbymember]
  *
  * @param key Key string
  * @param member member
  * @param radius radius
  * @param unit geo unit
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.georadiusbymemberAwait(key : String, member : String, radius : Double, unit : GeoUnit) : String {
-  return awaitResult{
+suspend fun RedisTransaction.georadiusbymemberAwait(key: String, member: String, radius: Double, unit: GeoUnit): String {
+  return awaitResult {
     this.georadiusbymember(key, member, radius, unit, it)
   }
 }
 
 /**
- * This command is exactly like GEORADIUS with the sole difference that instead of taking, as the center of the area
- * to query, a longitude and latitude value, it takes the name of a member already existing inside the geospatial
- * index represented by the sorted set.
+ * Suspending version of method [io.vertx.redis.RedisTransaction.georadiusbymemberWithOptions]
  *
  * @param key Key string
  * @param member member
  * @param radius radius
  * @param unit geo unit
  * @param options geo radius options
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.georadiusbymemberWithOptionsAwait(key : String, member : String, radius : Double, unit : GeoUnit, options : GeoRadiusOptions) : String {
-  return awaitResult{
+suspend fun RedisTransaction.georadiusbymemberWithOptionsAwait(key: String, member: String, radius: Double, unit: GeoUnit, options: GeoRadiusOptions): String {
+  return awaitResult {
     this.georadiusbymemberWithOptions(key, member, radius, unit, options, it)
   }
 }
 
 /**
- * Delete a key asynchronously in another thread. Otherwise it is just as DEL, but non blocking.
+ * Suspending version of method [io.vertx.redis.RedisTransaction.unlink]
  *
  * @param key Key string
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.unlinkAwait(key : String) : String {
-  return awaitResult{
+suspend fun RedisTransaction.unlinkAwait(key: String): String {
+  return awaitResult {
     this.unlink(key, it)
   }
 }
 
 /**
- * Delete multiple keys asynchronously in another thread. Otherwise it is just as DEL, but non blocking.
+ * Suspending version of method [io.vertx.redis.RedisTransaction.unlinkMany]
  *
  * @param keys List of keys to delete
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.unlinkManyAwait(keys : List<String>) : String {
-  return awaitResult{
+suspend fun RedisTransaction.unlinkManyAwait(keys: List<String>): String {
+  return awaitResult {
     this.unlinkMany(keys, it)
   }
 }
 
 /**
- * Swaps two Redis databases
+ * Suspending version of method [io.vertx.redis.RedisTransaction.swapdb]
  *
  * @param index1 index of first database to swap
  * @param index2 index of second database to swap
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.RedisTransaction original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.RedisTransaction] using Vert.x codegen.
  */
-suspend fun RedisTransaction.swapdbAwait(index1 : Int, index2 : Int) : String {
-  return awaitResult{
+suspend fun RedisTransaction.swapdbAwait(index1: Int, index2: Int): String {
+  return awaitResult {
     this.swapdb(index1, index2, it)
   }
 }

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/redis/sentinel/RedisSentinel.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/redis/sentinel/RedisSentinel.kt
@@ -5,150 +5,136 @@ import io.vertx.kotlin.coroutines.awaitResult
 import io.vertx.redis.sentinel.RedisSentinel
 
 /**
- * Close the client - when it is fully closed the handler will be called.
+ * Suspending version of method [io.vertx.redis.sentinel.RedisSentinel.close]
  *
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.sentinel.RedisSentinel original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.redis.sentinel.RedisSentinel] using Vert.x codegen.
  */
-suspend fun RedisSentinel.closeAwait() : Unit {
-  return awaitResult{
-    this.close({ ar -> it.handle(ar.mapEmpty()) })}
+suspend fun RedisSentinel.closeAwait(): Unit {
+  return awaitResult {
+    this.close { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Show a list of monitored masters and their state
+ * Suspending version of method [io.vertx.redis.sentinel.RedisSentinel.masters]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.sentinel.RedisSentinel original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.sentinel.RedisSentinel] using Vert.x codegen.
  */
-suspend fun RedisSentinel.mastersAwait() : JsonArray {
-  return awaitResult{
+suspend fun RedisSentinel.mastersAwait(): JsonArray {
+  return awaitResult {
     this.masters(it)
   }
 }
 
 /**
- * Show the state and info of the specified master
+ * Suspending version of method [io.vertx.redis.sentinel.RedisSentinel.master]
  *
  * @param name master name
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.sentinel.RedisSentinel original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.sentinel.RedisSentinel] using Vert.x codegen.
  */
-suspend fun RedisSentinel.masterAwait(name : String) : JsonArray {
-  return awaitResult{
+suspend fun RedisSentinel.masterAwait(name: String): JsonArray {
+  return awaitResult {
     this.master(name, it)
   }
 }
 
 /**
- * Show a list of slaves for this master, and their state
+ * Suspending version of method [io.vertx.redis.sentinel.RedisSentinel.slaves]
  *
  * @param name master name
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.sentinel.RedisSentinel original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.sentinel.RedisSentinel] using Vert.x codegen.
  */
-suspend fun RedisSentinel.slavesAwait(name : String) : JsonArray {
-  return awaitResult{
+suspend fun RedisSentinel.slavesAwait(name: String): JsonArray {
+  return awaitResult {
     this.slaves(name, it)
   }
 }
 
 /**
- * Show a list of sentinel instances for this master, and their state
+ * Suspending version of method [io.vertx.redis.sentinel.RedisSentinel.sentinels]
  *
  * @param name master name
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.sentinel.RedisSentinel original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.sentinel.RedisSentinel] using Vert.x codegen.
  */
-suspend fun RedisSentinel.sentinelsAwait(name : String) : JsonArray {
-  return awaitResult{
+suspend fun RedisSentinel.sentinelsAwait(name: String): JsonArray {
+  return awaitResult {
     this.sentinels(name, it)
   }
 }
 
 /**
- * Return the ip and port number of the master with that name.
- * If a failover is in progress or terminated successfully for this master
- * it returns the address and port of the promoted slave
+ * Suspending version of method [io.vertx.redis.sentinel.RedisSentinel.getMasterAddrByName]
  *
  * @param name master name
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.sentinel.RedisSentinel original] using Vert.x codegen.
+ * @return [JsonArray]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.sentinel.RedisSentinel] using Vert.x codegen.
  */
-suspend fun RedisSentinel.getMasterAddrByNameAwait(name : String) : JsonArray {
-  return awaitResult{
+suspend fun RedisSentinel.getMasterAddrByNameAwait(name: String): JsonArray {
+  return awaitResult {
     this.getMasterAddrByName(name, it)
   }
 }
 
 /**
- * Reset all the masters with matching name.
- * The pattern argument is a glob-style pattern.
- * The reset process clears any previous state in a master (including a failover in pro
+ * Suspending version of method [io.vertx.redis.sentinel.RedisSentinel.reset]
  *
  * @param pattern pattern String
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.sentinel.RedisSentinel original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.sentinel.RedisSentinel] using Vert.x codegen.
  */
-suspend fun RedisSentinel.resetAwait(pattern : String) : Unit {
-  return awaitResult{
-    this.reset(pattern, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun RedisSentinel.resetAwait(pattern: String): Unit {
+  return awaitResult {
+    this.reset(pattern) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Force a failover as if the master was not reachable, and without asking for agreement to other Sentinels
- * (however a new version of the configuration will be published so that the other Sentinels
- * will update their configurations)
+ * Suspending version of method [io.vertx.redis.sentinel.RedisSentinel.failover]
  *
  * @param name master name
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.sentinel.RedisSentinel original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.sentinel.RedisSentinel] using Vert.x codegen.
  */
-suspend fun RedisSentinel.failoverAwait(name : String) : String {
-  return awaitResult{
+suspend fun RedisSentinel.failoverAwait(name: String): String {
+  return awaitResult {
     this.failover(name, it)
   }
 }
 
 /**
- * Check if the current Sentinel configuration is able to reach the quorum needed to failover a master,
- * and the majority needed to authorize the failover. This command should be used in monitoring systems
- * to check if a Sentinel deployment is ok.
+ * Suspending version of method [io.vertx.redis.sentinel.RedisSentinel.ckquorum]
  *
  * @param name master name
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.sentinel.RedisSentinel original] using Vert.x codegen.
+ * @return [String]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.sentinel.RedisSentinel] using Vert.x codegen.
  */
-suspend fun RedisSentinel.ckquorumAwait(name : String) : String {
-  return awaitResult{
+suspend fun RedisSentinel.ckquorumAwait(name: String): String {
+  return awaitResult {
     this.ckquorum(name, it)
   }
 }
 
 /**
- * Force Sentinel to rewrite its configuration on disk, including the current Sentinel state.
- * Normally Sentinel rewrites the configuration every time something changes in its state
- * (in the context of the subset of the state which is persisted on disk across restart).
- * However sometimes it is possible that the configuration file is lost because of operation errors,
- * disk failures, package upgrade scripts or configuration managers. In those cases a way to to force Sentinel to
- * rewrite the configuration file is handy. This command works even if the previous configuration file
- * is completely missing.
+ * Suspending version of method [io.vertx.redis.sentinel.RedisSentinel.flushConfig]
  *
- * @return  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.redis.sentinel.RedisSentinel original] using Vert.x codegen.
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.redis.sentinel.RedisSentinel] using Vert.x codegen.
  */
-suspend fun RedisSentinel.flushConfigAwait() : Unit {
-  return awaitResult{
-    this.flushConfig({ ar -> it.handle(ar.mapEmpty()) })}
+suspend fun RedisSentinel.flushConfigAwait(): Unit {
+  return awaitResult {
+    this.flushConfig { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/servicediscovery/ServiceDiscovery.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/servicediscovery/ServiceDiscovery.kt
@@ -7,169 +7,128 @@ import io.vertx.servicediscovery.ServiceDiscovery
 import java.util.function.Function
 
 /**
- * Publishes a record.
+ * Suspending version of method [io.vertx.servicediscovery.ServiceDiscovery.publish]
  *
  * @param record the record
+ * @return [Record]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.servicediscovery.ServiceDiscovery original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.ServiceDiscovery] using Vert.x codegen.
  */
-suspend fun ServiceDiscovery.publishAwait(record : Record) : Record {
-  return awaitResult{
+suspend fun ServiceDiscovery.publishAwait(record: Record): Record {
+  return awaitResult {
     this.publish(record, it)
   }
 }
 
 /**
- * Un-publishes a record.
+ * Suspending version of method [io.vertx.servicediscovery.ServiceDiscovery.unpublish]
  *
  * @param id the registration id
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.servicediscovery.ServiceDiscovery original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.ServiceDiscovery] using Vert.x codegen.
  */
-suspend fun ServiceDiscovery.unpublishAwait(id : String) : Unit {
-  return awaitResult{
-    this.unpublish(id, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun ServiceDiscovery.unpublishAwait(id: String): Unit {
+  return awaitResult {
+    this.unpublish(id) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Lookups for a single record.
- * <p>
- * Filters are expressed using a Json object. Each entry of the given filter will be checked against the record.
- * All entry must match exactly the record. The entry can use the special "*" value to denotes a requirement on the
- * key, but not on the value.
- * <p>
- * Let's take some example:
- * <pre>
- *   { "name" = "a" } => matches records with name set fo "a"
- *   { "color" = "*" } => matches records with "color" set
- *   { "color" = "red" } => only matches records with "color" set to "red"
- *   { "color" = "red", "name" = "a"} => only matches records with name set to "a", and color set to "red"
- * </pre>
- * <p>
- * If the filter is not set (<code>null</code> or empty), it accepts all records.
- * <p>
- * This method returns the first matching record.
+ * Suspending version of method [io.vertx.servicediscovery.ServiceDiscovery.getRecord]
  *
  * @param filter the filter.
+ * @return [Record?]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.servicediscovery.ServiceDiscovery original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.ServiceDiscovery] using Vert.x codegen.
  */
-suspend fun ServiceDiscovery.getRecordAwait(filter : JsonObject) : Record? {
-  return awaitResult{
+suspend fun ServiceDiscovery.getRecordAwait(filter: JsonObject): Record? {
+  return awaitResult {
     this.getRecord(filter, it)
   }
 }
 
 /**
- * Lookups for a single record.
- * <p>
- * The filter is a  taking a [io.vertx.servicediscovery.Record] as argument and returning a boolean. You should see it
- * as an <code>accept</code> method of a filter. This method return a record passing the filter.
- * <p>
- * This method only looks for records with a <code>UP</code> status.
+ * Suspending version of method [io.vertx.servicediscovery.ServiceDiscovery.getRecord]
  *
  * @param filter the filter, must not be <code>null</code>. To return all records, use a function accepting all records
+ * @return [Record?]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.servicediscovery.ServiceDiscovery original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.ServiceDiscovery] using Vert.x codegen.
  */
-suspend fun ServiceDiscovery.getRecordAwait(filter : (Record) -> Boolean) : Record? {
-  return awaitResult{
+suspend fun ServiceDiscovery.getRecordAwait(filter: (Record) -> Boolean): Record? {
+  return awaitResult {
     this.getRecord(filter, it::handle)
   }
 }
 
 /**
- * Lookups for a single record.
- * <p>
- * The filter is a  taking a [io.vertx.servicediscovery.Record] as argument and returning a boolean. You should see it
- * as an <code>accept</code> method of a filter. This method return a record passing the filter.
- * <p>
- * Unlike [io.vertx.servicediscovery.ServiceDiscovery], this method may accept records with a <code>OUT OF SERVICE</code>
- * status, if the <code>includeOutOfService</code> parameter is set to <code>true</code>.
+ * Suspending version of method [io.vertx.servicediscovery.ServiceDiscovery.getRecord]
  *
  * @param filter the filter, must not be <code>null</code>. To return all records, use a function accepting all records
  * @param includeOutOfService whether or not the filter accepts <code>OUT OF SERVICE</code> records
+ * @return [Record?]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.servicediscovery.ServiceDiscovery original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.ServiceDiscovery] using Vert.x codegen.
  */
-suspend fun ServiceDiscovery.getRecordAwait(filter : (Record) -> Boolean, includeOutOfService : Boolean) : Record? {
-  return awaitResult{
+suspend fun ServiceDiscovery.getRecordAwait(filter: (Record) -> Boolean, includeOutOfService: Boolean): Record? {
+  return awaitResult {
     this.getRecord(filter, includeOutOfService, it::handle)
   }
 }
 
 /**
- * Lookups for a set of records. Unlike [io.vertx.servicediscovery.ServiceDiscovery], this method returns all matching
- * records.
+ * Suspending version of method [io.vertx.servicediscovery.ServiceDiscovery.getRecords]
  *
  * @param filter the filter - see [io.vertx.servicediscovery.ServiceDiscovery]
+ * @return [List<Record>]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.servicediscovery.ServiceDiscovery original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.ServiceDiscovery] using Vert.x codegen.
  */
-suspend fun ServiceDiscovery.getRecordsAwait(filter : JsonObject) : List<Record> {
-  return awaitResult{
+suspend fun ServiceDiscovery.getRecordsAwait(filter: JsonObject): List<Record> {
+  return awaitResult {
     this.getRecords(filter, it)
   }
 }
 
 /**
- * Lookups for a set of records. Unlike [io.vertx.servicediscovery.ServiceDiscovery], this method returns all matching
- * records.
- * <p>
- * The filter is a  taking a [io.vertx.servicediscovery.Record] as argument and returning a boolean. You should see it
- * as an <code>accept</code> method of a filter. This method return a record passing the filter.
- * <p>
- * This method only looks for records with a <code>UP</code> status.
+ * Suspending version of method [io.vertx.servicediscovery.ServiceDiscovery.getRecords]
  *
  * @param filter the filter, must not be <code>null</code>. To return all records, use a function accepting all records
+ * @return [List<Record>]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.servicediscovery.ServiceDiscovery original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.ServiceDiscovery] using Vert.x codegen.
  */
-suspend fun ServiceDiscovery.getRecordsAwait(filter : (Record) -> Boolean) : List<Record> {
-  return awaitResult{
+suspend fun ServiceDiscovery.getRecordsAwait(filter: (Record) -> Boolean): List<Record> {
+  return awaitResult {
     this.getRecords(filter, it::handle)
   }
 }
 
 /**
- * Lookups for a set of records. Unlike [io.vertx.servicediscovery.ServiceDiscovery], this method returns all matching
- * records.
- * <p>
- * The filter is a  taking a [io.vertx.servicediscovery.Record] as argument and returning a boolean. You should see it
- * as an <code>accept</code> method of a filter. This method return a record passing the filter.
- * <p>
- * Unlike [io.vertx.servicediscovery.ServiceDiscovery], this method may accept records with a <code>OUT OF SERVICE</code>
- * status, if the <code>includeOutOfService</code> parameter is set to <code>true</code>.
+ * Suspending version of method [io.vertx.servicediscovery.ServiceDiscovery.getRecords]
  *
  * @param filter the filter, must not be <code>null</code>. To return all records, use a function accepting all records
  * @param includeOutOfService whether or not the filter accepts <code>OUT OF SERVICE</code> records
+ * @return [List<Record>]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.servicediscovery.ServiceDiscovery original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.ServiceDiscovery] using Vert.x codegen.
  */
-suspend fun ServiceDiscovery.getRecordsAwait(filter : (Record) -> Boolean, includeOutOfService : Boolean) : List<Record> {
-  return awaitResult{
+suspend fun ServiceDiscovery.getRecordsAwait(filter: (Record) -> Boolean, includeOutOfService: Boolean): List<Record> {
+  return awaitResult {
     this.getRecords(filter, includeOutOfService, it::handle)
   }
 }
 
 /**
- * Updates the given record. The record must has been published, and has it's registration id set.
+ * Suspending version of method [io.vertx.servicediscovery.ServiceDiscovery.update]
  *
  * @param record the updated record
+ * @return [Record]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.servicediscovery.ServiceDiscovery original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.ServiceDiscovery] using Vert.x codegen.
  */
-suspend fun ServiceDiscovery.updateAwait(record : Record) : Record {
-  return awaitResult{
+suspend fun ServiceDiscovery.updateAwait(record: Record): Record {
+  return awaitResult {
     this.update(record, it)
   }
 }

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/servicediscovery/spi/ServicePublisher.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/servicediscovery/spi/ServicePublisher.kt
@@ -5,42 +5,42 @@ import io.vertx.servicediscovery.Record
 import io.vertx.servicediscovery.spi.ServicePublisher
 
 /**
- * Publishes a record.
+ * Suspending version of method [io.vertx.servicediscovery.spi.ServicePublisher.publish]
  *
  * @param record the record
+ * @return [Record]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.servicediscovery.spi.ServicePublisher original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.spi.ServicePublisher] using Vert.x codegen.
  */
-suspend fun ServicePublisher.publishAwait(record : Record) : Record {
-  return awaitResult{
+suspend fun ServicePublisher.publishAwait(record: Record): Record {
+  return awaitResult {
     this.publish(record, it)
   }
 }
 
 /**
- * Un-publishes a record.
+ * Suspending version of method [io.vertx.servicediscovery.spi.ServicePublisher.unpublish]
  *
  * @param id the registration id
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.servicediscovery.spi.ServicePublisher original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.spi.ServicePublisher] using Vert.x codegen.
  */
-suspend fun ServicePublisher.unpublishAwait(id : String) : Unit {
-  return awaitResult{
-    this.unpublish(id, { ar -> it.handle(ar.mapEmpty()) })}
+suspend fun ServicePublisher.unpublishAwait(id: String): Unit {
+  return awaitResult {
+    this.unpublish(id) { ar -> it.handle(ar.mapEmpty()) }
+  }
 }
 
 /**
- * Updates an existing record.
+ * Suspending version of method [io.vertx.servicediscovery.spi.ServicePublisher.update]
  *
  * @param record the record
+ * @return [Record]
  *
- * <p/>
- * NOTE: This function has been automatically generated from the [io.vertx.servicediscovery.spi.ServicePublisher original] using Vert.x codegen.
+ * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.spi.ServicePublisher] using Vert.x codegen.
  */
-suspend fun ServicePublisher.updateAwait(record : Record) : Record {
-  return awaitResult{
+suspend fun ServicePublisher.updateAwait(record: Record): Record {
+  return awaitResult {
     this.update(record, it)
   }
 }

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/servicediscovery/types/HttpEndpoint.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/servicediscovery/types/HttpEndpoint.kt
@@ -11,137 +11,125 @@ import java.util.function.Function
 
 object HttpEndpoint {
   /**
-   * Convenient method that looks for a HTTP endpoint and provides the configured . The async result
-   * is marked as failed is there are no matching services, or if the lookup fails.
+   * Suspending version of method [io.vertx.servicediscovery.types.HttpEndpoint.getClient]
    *
    * @param discovery The service discovery instance
    * @param filter The filter, optional
+   * @return [HttpClient]
    *
-   * <p/>
-   * NOTE: This function has been automatically generated from the [io.vertx.servicediscovery.types.HttpEndpoint original] using Vert.x codegen.
+   * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.types.HttpEndpoint] using Vert.x codegen.
    */
-  suspend fun getClientAwait(discovery : ServiceDiscovery, filter : JsonObject) : HttpClient {
-    return awaitResult{
+  suspend fun getClientAwait(discovery: ServiceDiscovery, filter: JsonObject): HttpClient {
+    return awaitResult {
       HttpEndpointVertxAlias.getClient(discovery, filter, it)
     }
   }
 
   /**
-   * Convenient method that looks for a HTTP endpoint and provides the configured . The async result
-   * is marked as failed is there are no matching services, or if the lookup fails.
+   * Suspending version of method [io.vertx.servicediscovery.types.HttpEndpoint.getWebClient]
    *
    * @param discovery The service discovery instance
    * @param filter The filter, optional
+   * @return [WebClient]
    *
-   * <p/>
-   * NOTE: This function has been automatically generated from the [io.vertx.servicediscovery.types.HttpEndpoint original] using Vert.x codegen.
+   * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.types.HttpEndpoint] using Vert.x codegen.
    */
-  suspend fun getWebClientAwait(discovery : ServiceDiscovery, filter : JsonObject) : WebClient {
-    return awaitResult{
+  suspend fun getWebClientAwait(discovery: ServiceDiscovery, filter: JsonObject): WebClient {
+    return awaitResult {
       HttpEndpointVertxAlias.getWebClient(discovery, filter, it)
     }
   }
 
   /**
-   * Convenient method that looks for a HTTP endpoint and provides the configured . The async result
-   * is marked as failed is there are no matching services, or if the lookup fails. This method accepts a
-   * configuration for the HTTP client
+   * Suspending version of method [io.vertx.servicediscovery.types.HttpEndpoint.getClient]
    *
    * @param discovery The service discovery instance
    * @param filter The filter, optional
    * @param conf the configuration of the client
+   * @return [HttpClient]
    *
-   * <p/>
-   * NOTE: This function has been automatically generated from the [io.vertx.servicediscovery.types.HttpEndpoint original] using Vert.x codegen.
+   * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.types.HttpEndpoint] using Vert.x codegen.
    */
-  suspend fun getClientAwait(discovery : ServiceDiscovery, filter : JsonObject, conf : JsonObject) : HttpClient {
-    return awaitResult{
+  suspend fun getClientAwait(discovery: ServiceDiscovery, filter: JsonObject, conf: JsonObject): HttpClient {
+    return awaitResult {
       HttpEndpointVertxAlias.getClient(discovery, filter, conf, it)
     }
   }
 
   /**
-   * Convenient method that looks for a HTTP endpoint and provides the configured . The async result
-   * is marked as failed is there are no matching services, or if the lookup fails. This method accepts a
-   * configuration for the HTTP client
+   * Suspending version of method [io.vertx.servicediscovery.types.HttpEndpoint.getWebClient]
    *
    * @param discovery The service discovery instance
    * @param filter The filter, optional
    * @param conf the configuration of the client
+   * @return [WebClient]
    *
-   * <p/>
-   * NOTE: This function has been automatically generated from the [io.vertx.servicediscovery.types.HttpEndpoint original] using Vert.x codegen.
+   * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.types.HttpEndpoint] using Vert.x codegen.
    */
-  suspend fun getWebClientAwait(discovery : ServiceDiscovery, filter : JsonObject, conf : JsonObject) : WebClient {
-    return awaitResult{
+  suspend fun getWebClientAwait(discovery: ServiceDiscovery, filter: JsonObject, conf: JsonObject): WebClient {
+    return awaitResult {
       HttpEndpointVertxAlias.getWebClient(discovery, filter, conf, it)
     }
   }
 
   /**
-   * Convenient method that looks for a HTTP endpoint and provides the configured . The async result
-   * is marked as failed is there are no matching services, or if the lookup fails.
+   * Suspending version of method [io.vertx.servicediscovery.types.HttpEndpoint.getClient]
    *
    * @param discovery The service discovery instance
    * @param filter The filter
+   * @return [HttpClient]
    *
-   * <p/>
-   * NOTE: This function has been automatically generated from the [io.vertx.servicediscovery.types.HttpEndpoint original] using Vert.x codegen.
+   * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.types.HttpEndpoint] using Vert.x codegen.
    */
-  suspend fun getClientAwait(discovery : ServiceDiscovery, filter : (Record) -> Boolean) : HttpClient {
-    return awaitResult{
+  suspend fun getClientAwait(discovery: ServiceDiscovery, filter: (Record) -> Boolean): HttpClient {
+    return awaitResult {
       HttpEndpointVertxAlias.getClient(discovery, filter, it::handle)
     }
   }
 
   /**
-   * Convenient method that looks for a HTTP endpoint and provides the configured . The async result
-   * is marked as failed is there are no matching services, or if the lookup fails.
+   * Suspending version of method [io.vertx.servicediscovery.types.HttpEndpoint.getWebClient]
    *
    * @param discovery The service discovery instance
    * @param filter The filter
+   * @return [WebClient]
    *
-   * <p/>
-   * NOTE: This function has been automatically generated from the [io.vertx.servicediscovery.types.HttpEndpoint original] using Vert.x codegen.
+   * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.types.HttpEndpoint] using Vert.x codegen.
    */
-  suspend fun getWebClientAwait(discovery : ServiceDiscovery, filter : (Record) -> Boolean) : WebClient {
-    return awaitResult{
+  suspend fun getWebClientAwait(discovery: ServiceDiscovery, filter: (Record) -> Boolean): WebClient {
+    return awaitResult {
       HttpEndpointVertxAlias.getWebClient(discovery, filter, it::handle)
     }
   }
 
   /**
-   * Convenient method that looks for a HTTP endpoint and provides the configured . The async result
-   * is marked as failed is there are no matching services, or if the lookup fails. This method accepts a
-   * configuration for the HTTP client.
+   * Suspending version of method [io.vertx.servicediscovery.types.HttpEndpoint.getClient]
    *
    * @param discovery The service discovery instance
    * @param filter The filter
    * @param conf the configuration of the client
+   * @return [HttpClient]
    *
-   * <p/>
-   * NOTE: This function has been automatically generated from the [io.vertx.servicediscovery.types.HttpEndpoint original] using Vert.x codegen.
+   * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.types.HttpEndpoint] using Vert.x codegen.
    */
-  suspend fun getClientAwait(discovery : ServiceDiscovery, filter : (Record) -> Boolean, conf : JsonObject) : HttpClient {
-    return awaitResult{
+  suspend fun getClientAwait(discovery: ServiceDiscovery, filter: (Record) -> Boolean, conf: JsonObject): HttpClient {
+    return awaitResult {
       HttpEndpointVertxAlias.getClient(discovery, filter, conf, it::handle)
     }
   }
 
   /**
-   * Convenient method that looks for a HTTP endpoint and provides the configured . The async result
-   * is marked as failed is there are no matching services, or if the lookup fails. This method accepts a
-   * configuration for the HTTP client.
+   * Suspending version of method [io.vertx.servicediscovery.types.HttpEndpoint.getWebClient]
    *
    * @param discovery The service discovery instance
    * @param filter The filter
    * @param conf the configuration of the client
+   * @return [WebClient]
    *
-   * <p/>
-   * NOTE: This function has been automatically generated from the [io.vertx.servicediscovery.types.HttpEndpoint original] using Vert.x codegen.
+   * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.types.HttpEndpoint] using Vert.x codegen.
    */
-  suspend fun getWebClientAwait(discovery : ServiceDiscovery, filter : (Record) -> Boolean, conf : JsonObject) : WebClient {
-    return awaitResult{
+  suspend fun getWebClientAwait(discovery: ServiceDiscovery, filter: (Record) -> Boolean, conf: JsonObject): WebClient {
+    return awaitResult {
       HttpEndpointVertxAlias.getWebClient(discovery, filter, conf, it::handle)
     }
   }

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/servicediscovery/types/JDBCDataSource.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/servicediscovery/types/JDBCDataSource.kt
@@ -10,67 +10,63 @@ import java.util.function.Function
 
 object JDBCDataSource {
   /**
-   * Convenient method that looks for a JDBC datasource source and provides the configured [io.vertx.ext.jdbc.JDBCClient]. The
-   * async result is marked as failed is there are no matching services, or if the lookup fails.
+   * Suspending version of method [io.vertx.servicediscovery.types.JDBCDataSource.getJDBCClient]
    *
    * @param discovery The service discovery instance
    * @param filter The filter, optional
+   * @return [JDBCClient]
    *
-   * <p/>
-   * NOTE: This function has been automatically generated from the [io.vertx.servicediscovery.types.JDBCDataSource original] using Vert.x codegen.
+   * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.types.JDBCDataSource] using Vert.x codegen.
    */
-  suspend fun getJDBCClientAwait(discovery : ServiceDiscovery, filter : JsonObject) : JDBCClient {
-    return awaitResult{
+  suspend fun getJDBCClientAwait(discovery: ServiceDiscovery, filter: JsonObject): JDBCClient {
+    return awaitResult {
       JDBCDataSourceVertxAlias.getJDBCClient(discovery, filter, it)
     }
   }
 
   /**
-   * Convenient method that looks for a JDBC datasource source and provides the configured [io.vertx.ext.jdbc.JDBCClient]. The
-   * async result is marked as failed is there are no matching services, or if the lookup fails.
+   * Suspending version of method [io.vertx.servicediscovery.types.JDBCDataSource.getJDBCClient]
    *
    * @param discovery The service discovery instance
    * @param filter The filter (must not be <code>null</code>)
+   * @return [JDBCClient]
    *
-   * <p/>
-   * NOTE: This function has been automatically generated from the [io.vertx.servicediscovery.types.JDBCDataSource original] using Vert.x codegen.
+   * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.types.JDBCDataSource] using Vert.x codegen.
    */
-  suspend fun getJDBCClientAwait(discovery : ServiceDiscovery, filter : (Record) -> Boolean) : JDBCClient {
-    return awaitResult{
+  suspend fun getJDBCClientAwait(discovery: ServiceDiscovery, filter: (Record) -> Boolean): JDBCClient {
+    return awaitResult {
       JDBCDataSourceVertxAlias.getJDBCClient(discovery, filter, it::handle)
     }
   }
 
   /**
-   * Convenient method that looks for a JDBC datasource source and provides the configured [io.vertx.ext.jdbc.JDBCClient]. The
-   * async result is marked as failed is there are no matching services, or if the lookup fails.
+   * Suspending version of method [io.vertx.servicediscovery.types.JDBCDataSource.getJDBCClient]
    *
    * @param discovery The service discovery instance
    * @param filter The filter, optional
    * @param consumerConfiguration the consumer configuration
+   * @return [JDBCClient]
    *
-   * <p/>
-   * NOTE: This function has been automatically generated from the [io.vertx.servicediscovery.types.JDBCDataSource original] using Vert.x codegen.
+   * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.types.JDBCDataSource] using Vert.x codegen.
    */
-  suspend fun getJDBCClientAwait(discovery : ServiceDiscovery, filter : JsonObject, consumerConfiguration : JsonObject) : JDBCClient {
-    return awaitResult{
+  suspend fun getJDBCClientAwait(discovery: ServiceDiscovery, filter: JsonObject, consumerConfiguration: JsonObject): JDBCClient {
+    return awaitResult {
       JDBCDataSourceVertxAlias.getJDBCClient(discovery, filter, consumerConfiguration, it)
     }
   }
 
   /**
-   * Convenient method that looks for a JDBC datasource source and provides the configured [io.vertx.ext.jdbc.JDBCClient]. The
-   * async result is marked as failed is there are no matching services, or if the lookup fails.
+   * Suspending version of method [io.vertx.servicediscovery.types.JDBCDataSource.getJDBCClient]
    *
    * @param discovery The service discovery instance
    * @param filter The filter, must not be <code>null</code>
    * @param consumerConfiguration the consumer configuration
+   * @return [JDBCClient]
    *
-   * <p/>
-   * NOTE: This function has been automatically generated from the [io.vertx.servicediscovery.types.JDBCDataSource original] using Vert.x codegen.
+   * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.types.JDBCDataSource] using Vert.x codegen.
    */
-  suspend fun getJDBCClientAwait(discovery : ServiceDiscovery, filter : (Record) -> Boolean, consumerConfiguration : JsonObject) : JDBCClient {
-    return awaitResult{
+  suspend fun getJDBCClientAwait(discovery: ServiceDiscovery, filter: (Record) -> Boolean, consumerConfiguration: JsonObject): JDBCClient {
+    return awaitResult {
       JDBCDataSourceVertxAlias.getJDBCClient(discovery, filter, consumerConfiguration, it::handle)
     }
   }

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/servicediscovery/types/MessageSource.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/servicediscovery/types/MessageSource.kt
@@ -10,33 +10,31 @@ import java.util.function.Function
 
 object MessageSource {
   /**
-   * Convenient method that looks for a message source and provides the configured . The
-   * async result is marked as failed is there are no matching services, or if the lookup fails.
+   * Suspending version of method [io.vertx.servicediscovery.types.MessageSource.getConsumer]
    *
    * @param discovery The service discovery instance
    * @param filter The filter, optional
+   * @return [MessageConsumer<T>]
    *
-   * <p/>
-   * NOTE: This function has been automatically generated from the [io.vertx.servicediscovery.types.MessageSource original] using Vert.x codegen.
+   * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.types.MessageSource] using Vert.x codegen.
    */
-  suspend fun <T> getConsumerAwait(discovery : ServiceDiscovery, filter : JsonObject) : MessageConsumer<T> {
-    return awaitResult{
+  suspend fun <T> getConsumerAwait(discovery: ServiceDiscovery, filter: JsonObject): MessageConsumer<T> {
+    return awaitResult {
       MessageSourceVertxAlias.getConsumer(discovery, filter, it)
     }
   }
 
   /**
-   * Convenient method that looks for a message source and provides the configured . The
-   * async result is marked as failed is there are no matching services, or if the lookup fails.
+   * Suspending version of method [io.vertx.servicediscovery.types.MessageSource.getConsumer]
    *
    * @param discovery The service discovery instance
    * @param filter The filter, must not be <code>null</code>
+   * @return [MessageConsumer<T>]
    *
-   * <p/>
-   * NOTE: This function has been automatically generated from the [io.vertx.servicediscovery.types.MessageSource original] using Vert.x codegen.
+   * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.types.MessageSource] using Vert.x codegen.
    */
-  suspend fun <T> getConsumerAwait(discovery : ServiceDiscovery, filter : (Record) -> Boolean) : MessageConsumer<T> {
-    return awaitResult{
+  suspend fun <T> getConsumerAwait(discovery: ServiceDiscovery, filter: (Record) -> Boolean): MessageConsumer<T> {
+    return awaitResult {
       MessageSourceVertxAlias.getConsumer(discovery, filter, it::handle)
     }
   }

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/servicediscovery/types/MongoDataSource.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/servicediscovery/types/MongoDataSource.kt
@@ -10,51 +10,47 @@ import java.util.function.Function
 
 object MongoDataSource {
   /**
-   * Convenient method that looks for a Mongo datasource source and provides the configured [io.vertx.ext.mongo.MongoClient]. The
-   * async result is marked as failed is there are no matching services, or if the lookup fails.
+   * Suspending version of method [io.vertx.servicediscovery.types.MongoDataSource.getMongoClient]
    *
    * @param discovery The service discovery instance
    * @param filter The filter, optional
+   * @return [MongoClient]
    *
-   * <p/>
-   * NOTE: This function has been automatically generated from the [io.vertx.servicediscovery.types.MongoDataSource original] using Vert.x codegen.
+   * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.types.MongoDataSource] using Vert.x codegen.
    */
-  suspend fun getMongoClientAwait(discovery : ServiceDiscovery, filter : JsonObject) : MongoClient {
-    return awaitResult{
+  suspend fun getMongoClientAwait(discovery: ServiceDiscovery, filter: JsonObject): MongoClient {
+    return awaitResult {
       MongoDataSourceVertxAlias.getMongoClient(discovery, filter, it)
     }
   }
 
   /**
-   * Convenient method that looks for a Mongo datasource source and provides the configured
-   * [io.vertx.ext.mongo.MongoClient]. The
-   * async result is marked as failed is there are no matching services, or if the lookup fails.
+   * Suspending version of method [io.vertx.servicediscovery.types.MongoDataSource.getMongoClient]
    *
    * @param discovery The service discovery instance
    * @param filter The filter
+   * @return [MongoClient]
    *
-   * <p/>
-   * NOTE: This function has been automatically generated from the [io.vertx.servicediscovery.types.MongoDataSource original] using Vert.x codegen.
+   * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.types.MongoDataSource] using Vert.x codegen.
    */
-  suspend fun getMongoClientAwait(discovery : ServiceDiscovery, filter : (Record) -> Boolean) : MongoClient {
-    return awaitResult{
+  suspend fun getMongoClientAwait(discovery: ServiceDiscovery, filter: (Record) -> Boolean): MongoClient {
+    return awaitResult {
       MongoDataSourceVertxAlias.getMongoClient(discovery, filter, it::handle)
     }
   }
 
   /**
-   * Convenient method that looks for a Mongo datasource source and provides the configured [io.vertx.ext.mongo.MongoClient]. The
-   * async result is marked as failed is there are no matching services, or if the lookup fails.
+   * Suspending version of method [io.vertx.servicediscovery.types.MongoDataSource.getMongoClient]
    *
    * @param discovery The service discovery instance
    * @param filter The filter, optional
    * @param consumerConfiguration the consumer configuration
+   * @return [MongoClient]
    *
-   * <p/>
-   * NOTE: This function has been automatically generated from the [io.vertx.servicediscovery.types.MongoDataSource original] using Vert.x codegen.
+   * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.types.MongoDataSource] using Vert.x codegen.
    */
-  suspend fun getMongoClientAwait(discovery : ServiceDiscovery, filter : JsonObject, consumerConfiguration : JsonObject) : MongoClient {
-    return awaitResult{
+  suspend fun getMongoClientAwait(discovery: ServiceDiscovery, filter: JsonObject, consumerConfiguration: JsonObject): MongoClient {
+    return awaitResult {
       MongoDataSourceVertxAlias.getMongoClient(discovery, filter, consumerConfiguration, it)
     }
   }

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/servicediscovery/types/RedisDataSource.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/servicediscovery/types/RedisDataSource.kt
@@ -10,67 +10,63 @@ import java.util.function.Function
 
 object RedisDataSource {
   /**
-   * Convenient method that looks for a Redis data source and provides the configured [io.vertx.redis.RedisClient].
-   * The async result is marked as failed is there are no matching services, or if the lookup fails.
+   * Suspending version of method [io.vertx.servicediscovery.types.RedisDataSource.getRedisClient]
    *
    * @param discovery The service discovery instance
    * @param filter The filter, optional
+   * @return [RedisClient]
    *
-   * <p/>
-   * NOTE: This function has been automatically generated from the [io.vertx.servicediscovery.types.RedisDataSource original] using Vert.x codegen.
+   * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.types.RedisDataSource] using Vert.x codegen.
    */
-  suspend fun getRedisClientAwait(discovery : ServiceDiscovery, filter : JsonObject) : RedisClient {
-    return awaitResult{
+  suspend fun getRedisClientAwait(discovery: ServiceDiscovery, filter: JsonObject): RedisClient {
+    return awaitResult {
       RedisDataSourceVertxAlias.getRedisClient(discovery, filter, it)
     }
   }
 
   /**
-   * Convenient method that looks for a Redis data source and provides the configured [io.vertx.redis.RedisClient].
-   * The async result is marked as failed is there are no matching services, or if the lookup fails.
+   * Suspending version of method [io.vertx.servicediscovery.types.RedisDataSource.getRedisClient]
    *
    * @param discovery The service discovery instance
    * @param filter The filter, cannot be <code>null</code>
+   * @return [RedisClient]
    *
-   * <p/>
-   * NOTE: This function has been automatically generated from the [io.vertx.servicediscovery.types.RedisDataSource original] using Vert.x codegen.
+   * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.types.RedisDataSource] using Vert.x codegen.
    */
-  suspend fun getRedisClientAwait(discovery : ServiceDiscovery, filter : (Record) -> Boolean) : RedisClient {
-    return awaitResult{
+  suspend fun getRedisClientAwait(discovery: ServiceDiscovery, filter: (Record) -> Boolean): RedisClient {
+    return awaitResult {
       RedisDataSourceVertxAlias.getRedisClient(discovery, filter, it::handle)
     }
   }
 
   /**
-   * Convenient method that looks for a Redis data source and provides the configured [io.vertx.redis.RedisClient].
-   * The async result is marked as failed is there are no matching services, or if the lookup fails.
+   * Suspending version of method [io.vertx.servicediscovery.types.RedisDataSource.getRedisClient]
    *
    * @param discovery The service discovery instance
    * @param filter The filter, optional
    * @param consumerConfiguration The additional consumer configuration
+   * @return [RedisClient]
    *
-   * <p/>
-   * NOTE: This function has been automatically generated from the [io.vertx.servicediscovery.types.RedisDataSource original] using Vert.x codegen.
+   * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.types.RedisDataSource] using Vert.x codegen.
    */
-  suspend fun getRedisClientAwait(discovery : ServiceDiscovery, filter : JsonObject, consumerConfiguration : JsonObject) : RedisClient {
-    return awaitResult{
+  suspend fun getRedisClientAwait(discovery: ServiceDiscovery, filter: JsonObject, consumerConfiguration: JsonObject): RedisClient {
+    return awaitResult {
       RedisDataSourceVertxAlias.getRedisClient(discovery, filter, consumerConfiguration, it)
     }
   }
 
   /**
-   * Convenient method that looks for a Redis data source and provides the configured [io.vertx.redis.RedisClient].
-   * The async result is marked as failed is there are no matching services, or if the lookup fails.
+   * Suspending version of method [io.vertx.servicediscovery.types.RedisDataSource.getRedisClient]
    *
    * @param discovery The service discovery instance
    * @param filter The filter, cannot be <code>null</code>
    * @param consumerConfiguration The additional consumer configuration
+   * @return [RedisClient]
    *
-   * <p/>
-   * NOTE: This function has been automatically generated from the [io.vertx.servicediscovery.types.RedisDataSource original] using Vert.x codegen.
+   * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.types.RedisDataSource] using Vert.x codegen.
    */
-  suspend fun getRedisClientAwait(discovery : ServiceDiscovery, filter : (Record) -> Boolean, consumerConfiguration : JsonObject) : RedisClient {
-    return awaitResult{
+  suspend fun getRedisClientAwait(discovery: ServiceDiscovery, filter: (Record) -> Boolean, consumerConfiguration: JsonObject): RedisClient {
+    return awaitResult {
       RedisDataSourceVertxAlias.getRedisClient(discovery, filter, consumerConfiguration, it::handle)
     }
   }


### PR DESCRIPTION
I took a bit of time to refactor the code generation part, hopefully, it should now be more explicit what each block is doing.

A couple of things are still missing:
- Cleanup imports from unused directives (like `io.vertx.core.Handler`)
- Improve method documentation

What do you think @vietj and @okou19900722?

Closes #121 