### PR TITLE
fix kotlinVerticleFactory bug

### DIFF
--- a/vertx-lang-kotlin-compiler/src/main/kotlin/io/vertx/lang/kotlin/KotlinVerticleFactory.kt
+++ b/vertx-lang-kotlin-compiler/src/main/kotlin/io/vertx/lang/kotlin/KotlinVerticleFactory.kt
@@ -29,6 +29,11 @@ open class KotlinVerticleFactory : VerticleFactory {
   override fun createVerticle(verticleName: String, classLoader: ClassLoader): Verticle {
     val resourceName = VerticleFactory.removePrefix(verticleName)
 
+    //fix only kt: prefix, no kt|kts suffix case, as class to deal with
+    if(!resourceName.endsWith(".kt") && !resourceName.endsWith(".kts")) {
+      return classLoader.loadClass(resourceName).let { it.newInstance() as Verticle }
+    }
+
     var url = classLoader.getResource(resourceName)
     if (url == null) {
       var f = File(resourceName)

--- a/vertx-lang-kotlin-compiler/src/test/kotlin/io/vertx/DemoVerticlekt.kt
+++ b/vertx-lang-kotlin-compiler/src/test/kotlin/io/vertx/DemoVerticlekt.kt
@@ -1,0 +1,13 @@
+package io.vertx
+
+import io.vertx.core.AbstractVerticle
+
+/**
+ *  created by wang007 on 2019/3/18
+ */
+class DemoVerticlekt: AbstractVerticle() {
+
+  override fun start() {
+    println("fix bug")
+  }
+}

--- a/vertx-lang-kotlin-compiler/src/test/kotlin/io/vertx/KotlinVerticleFactoryFixTest.kt
+++ b/vertx-lang-kotlin-compiler/src/test/kotlin/io/vertx/KotlinVerticleFactoryFixTest.kt
@@ -1,0 +1,24 @@
+package io.vertx
+
+import io.vertx.core.Vertx
+import org.junit.After
+import org.junit.Test
+
+/**
+ *  created by wang007 on 2019/3/18
+ */
+class KotlinVerticleFactoryFixTest {
+
+  val vertx = Vertx.vertx()!!
+
+  @After
+  fun tearDown() {
+    vertx.close()
+  }
+
+  @Test
+  fun kotlinVerticlFactoryFixTest() {
+    vertx.deployVerticle("kt:io.vertx.DemoVerticlekt")
+  }
+
+}


### PR DESCRIPTION
if deploy by prefix kt:， throw IllegalStateException("Cannot find verticle script: $verticleName on classpath").  
because not considering deploying class directly.
so fix it.