### PR TITLE
Add SupervisorJob to CoroutineVerticle.coroutineContext.

### DIFF
--- a/vertx-lang-kotlin-coroutines/src/main/java/io/vertx/kotlin/coroutines/CoroutineVerticle.kt
+++ b/vertx-lang-kotlin-coroutines/src/main/java/io/vertx/kotlin/coroutines/CoroutineVerticle.kt
@@ -17,8 +17,7 @@ package io.vertx.kotlin.coroutines
 
 import io.vertx.core.*
 import io.vertx.core.json.JsonObject
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.*
 import kotlin.coroutines.CoroutineContext
 
 /**
@@ -35,7 +34,7 @@ abstract class CoroutineVerticle : Verticle, CoroutineScope {
   private lateinit var vertxInstance: Vertx
   protected lateinit var context: Context
 
-  override val coroutineContext: CoroutineContext by lazy { context.dispatcher() }
+  override val coroutineContext: CoroutineContext by lazy { context.dispatcher() + SupervisorJob() }
 
   override fun init(vertx: Vertx, context: Context) {
     this.vertxInstance = vertx
@@ -59,6 +58,7 @@ abstract class CoroutineVerticle : Verticle, CoroutineScope {
     launch {
       try {
         stop()
+        this.coroutineContext[Job]?.cancelAndJoin()
         stopFuture?.complete()
       } catch (t: Throwable) {
         stopFuture?.fail(t)


### PR DESCRIPTION
Add SupervisorJob to CoroutineVerticle.coroutineContext and cancel it when stop verticle.

Motivation:

It's better to use structured concurrency. By adding SupervisorJob, all coroutines in the CoroutineVerticle will be closed when undeploying the verticle.
[structured-concurrency-with-async](https://github.com/Kotlin/kotlinx.coroutines/blob/master/docs/composing-suspending-functions.md#structured-concurrency-with-async
)

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
