### PR TITLE
Support suspending functions in setPeriodic

### DIFF
--- a/vertx-lang-kotlin-coroutines/src/main/java/io/vertx/kotlin/coroutines/SetPeriodic.kt
+++ b/vertx-lang-kotlin-coroutines/src/main/java/io/vertx/kotlin/coroutines/SetPeriodic.kt
@@ -2,7 +2,6 @@ package io.vertx.kotlin.coroutines
 
 import io.vertx.core.Vertx
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 /**
@@ -13,7 +12,7 @@ import kotlinx.coroutines.launch
  * @return the unique ID of the timer
  */
 fun Vertx.setPeriodicAwait(delay: Long, handler: suspend (Long) -> Unit): Long {
-  val coroutineScope = CoroutineScope(Dispatchers.Default)
+  val coroutineScope = CoroutineScope(this.dispatcher())
   return this.setPeriodic(delay) { timerId ->
     coroutineScope.launch {
       handler(timerId)

--- a/vertx-lang-kotlin-coroutines/src/main/java/io/vertx/kotlin/coroutines/SetPeriodic.kt
+++ b/vertx-lang-kotlin-coroutines/src/main/java/io/vertx/kotlin/coroutines/SetPeriodic.kt
@@ -1,0 +1,22 @@
+package io.vertx.kotlin.coroutines
+
+import io.vertx.core.Vertx
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+/**
+ * Set a periodic timer to fire every {@code delay} milliseconds, at which point a suspending function will be invoked
+ *
+ * @param delay  the delay in milliseconds, after which the timer will fire
+ * @param handler  the handler that will be called with the timer ID when the timer fires
+ * @return the unique ID of the timer
+ */
+fun Vertx.setPeriodicAwait(delay: Long, handler: suspend (Long) -> Unit): Long {
+  val coroutineScope = CoroutineScope(Dispatchers.Default)
+  return this.setPeriodic(delay) { timerId ->
+    coroutineScope.launch {
+      handler(timerId)
+    }
+  }
+}

--- a/vertx-lang-kotlin-coroutines/src/test/kotlin/io/vertx/kotlin/coroutines/PeriodicTest.kt
+++ b/vertx-lang-kotlin-coroutines/src/test/kotlin/io/vertx/kotlin/coroutines/PeriodicTest.kt
@@ -15,11 +15,9 @@
  */
 package io.vertx.kotlin.coroutines
 
-import io.vertx.core.Promise
 import io.vertx.core.Vertx
 import io.vertx.ext.unit.TestContext
 import io.vertx.ext.unit.junit.VertxUnitRunner
-import junit.framework.Assert.assertTrue
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import org.junit.After

--- a/vertx-lang-kotlin-coroutines/src/test/kotlin/io/vertx/kotlin/coroutines/PeriodicTest.kt
+++ b/vertx-lang-kotlin-coroutines/src/test/kotlin/io/vertx/kotlin/coroutines/PeriodicTest.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package io.vertx.kotlin.coroutines
+
+import io.vertx.core.Promise
+import io.vertx.core.Vertx
+import io.vertx.ext.unit.TestContext
+import io.vertx.ext.unit.junit.VertxUnitRunner
+import junit.framework.Assert.assertTrue
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * @author <a href="mailto:alexey.soshin@gmail.com">Alexey Soshin</a>
+ */
+@RunWith(VertxUnitRunner::class)
+class PeriodicTest {
+
+  private lateinit var vertx: Vertx
+
+  @Before
+  fun before() {
+    vertx = Vertx.vertx()
+  }
+
+  @After
+  fun after(testContext: TestContext) {
+    vertx.close(testContext.asyncAssertSuccess())
+  }
+
+  @Test
+  fun `test await function can be invoked from setPeriodic`(testContext: TestContext) {
+    val async = testContext.async()
+    runBlocking {
+      vertx.setPeriodicAwait(100) {
+        // Introduce some kind of suspending function
+        delay(10)
+        async.complete()
+      }
+    }
+
+    async.awaitSuccess(1000)
+  }
+}
+


### PR DESCRIPTION
Resolves #171

Motivation: 

There was a request to support Kotlin suspending functions in Vertx `setPeriodic` function.

My suggestion is to add a new extension method, `setPeriodicAwait`, that will receive a suspending block.
Since we are not necessarily in a scope of coroutine, we create a new scope for this periodic task.

This is just a suggestion, and any comments regarding approach and implementation are more than welcome.

If this approach looks fine, we could extend it to `setTimer` as well. 