### PR TITLE
Fix jsonObjectOf() binary data encoding

### DIFF
--- a/vertx-lang-kotlin/src/main/java/io/vertx/kotlin/core/json/json.kt
+++ b/vertx-lang-kotlin/src/main/java/io/vertx/kotlin/core/json/json.kt
@@ -15,6 +15,7 @@
  */
 package io.vertx.kotlin.core.json
 
+import io.vertx.core.json.impl.JsonUtil
 import io.vertx.core.json.JsonArray
 import io.vertx.core.json.JsonObject
 import java.time.Instant
@@ -35,7 +36,7 @@ fun jsonObjectOf(vararg fields: Pair<String, Any?>): JsonObject {
             // @See io.vertx.core.json.JsonObject.put(java.lang.String, java.time.Instant)
             it.second is Instant -> return@map (Pair(it.first, DateTimeFormatter.ISO_INSTANT.format(it.second as Instant)))
             // @See   io.vertx.core.json.JsonObject.put(java.lang.String, byte[])
-            it.second is ByteArray -> return@map(Pair(it.first, Base64.getEncoder().encodeToString(it.second as ByteArray)))
+            it.second is ByteArray -> return@map(Pair(it.first, JsonUtil.BASE64_ENCODER.encodeToString(it.second as ByteArray)))
             else -> return@map it
         }
 


### PR DESCRIPTION
A fix for a problem mentioned in the [issue #202](https://github.com/vert-x3/vertx-lang-kotlin/issues/202).

Use JsonUtil.BASE64_ENCODER to match the JsonObject binary data encoding format (see https://github.com/eclipse-vertx/vert.x/blob/11ab144725e551be591118831377101015e1392c/src/main/java/io/vertx/core/json/impl/JsonUtil.java#L43)

JsonObject uses JsonUtil.BASE64_ENCODER to encode binary data. Depending of system property "vertx.json.base64" value, it can be set to either Base64.getUrlEncoder().withoutPadding() (the default one) or Base64.getEncoder().

This change should make the jsonObjectOf() helper to match the JsonObject() behavior. 
