### PR TITLE
Cancel child coroutines when undeploying a coroutine verticle

### DIFF
--- a/vertx-lang-kotlin-coroutines/src/main/java/io/vertx/kotlin/coroutines/CoroutineVerticle.kt
+++ b/vertx-lang-kotlin-coroutines/src/main/java/io/vertx/kotlin/coroutines/CoroutineVerticle.kt
@@ -31,6 +31,7 @@ import kotlin.coroutines.CoroutineContext
  *
  * @author <a href="http://www.streamis.me">Stream Liu</a>
  * @author [Guido Pio Mariotti](https://github.com/gmariotti)
+ * @author [Daniil Chalov](https://github.com/cyber-barrista)
  */
 abstract class CoroutineVerticle : Verticle, CoroutineScope {
 

--- a/vertx-lang-kotlin-coroutines/src/test/kotlin/io/vertx/kotlin/coroutines/CoroutineVerticleTest.kt
+++ b/vertx-lang-kotlin-coroutines/src/test/kotlin/io/vertx/kotlin/coroutines/CoroutineVerticleTest.kt
@@ -1,0 +1,56 @@
+package io.vertx.kotlin.coroutines
+
+import io.vertx.core.Vertx
+import kotlinx.coroutines.*
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import java.time.Duration
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class CoroutineVerticleTest {
+  private lateinit var vertx: Vertx
+
+  @Before
+  fun `initialize vertx`() { vertx = Vertx.vertx() }
+
+  @After
+  fun `close vertx`() { vertx.close() }
+
+  @Test
+  fun `a child coroutine launched from a coroutine verticle gets canceled upon vertx undeployment`() {
+    runBlocking {
+      val deploymentId = vertx.deployVerticle(coroutineVerticleMock).await();
+      assertTrue { coroutineVerticleMock.isStartCalled }
+      assertFalse { coroutineVerticleMock.isStopCalled }
+      assertTrue { coroutineVerticleMock.childJob.isActive }
+
+      vertx.undeploy(deploymentId).await();
+      assertTrue { coroutineVerticleMock.isStopCalled }
+      assertEventually(delay = Duration.ofSeconds(1)) { coroutineVerticleMock.childJob.isCancelled }
+    }
+  }
+}
+
+private val coroutineVerticleMock = object : CoroutineVerticle() {
+  var isStartCalled = false
+  var isStopCalled = false
+  lateinit var childJob: Job
+
+
+  override suspend fun start() {
+    isStartCalled = true
+    childJob = launch { while (true) { delay(1000) } }
+  }
+
+  override suspend fun stop() { isStopCalled = true }
+}
+
+private fun assertEventually(delay: Duration, condition: () -> Boolean) = runBlocking {
+  try {
+    withTimeout(delay.toMillis()) { while (!condition()) { ensureActive() } }
+  } catch (_: CancellationException) {
+    throw AssertionError("Assertion was not fulfilled within $delay timeout.")
+  }
+}

--- a/vertx-lang-kotlin-coroutines/src/test/kotlin/io/vertx/kotlin/coroutines/CoroutineVerticleTest.kt
+++ b/vertx-lang-kotlin-coroutines/src/test/kotlin/io/vertx/kotlin/coroutines/CoroutineVerticleTest.kt
@@ -9,6 +9,9 @@ import java.time.Duration
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
+/**
+ * @author <a href="mailto:cyber-barrista@protonmail.com">Daniil Chalov</a>
+ */
 class CoroutineVerticleTest {
   private lateinit var vertx: Vertx
 


### PR DESCRIPTION
#### Motivation:

This PR addresses https://github.com/vert-x3/vertx-lang-kotlin/issues/189. Up until now, any child coroutine launched from a coroutine verticle has been left uncanceled (even if it adheres to the coroutine "cooperative" concurrency principle). That would cause "process leaks".

#### Solution:

Explicit specification of the `Job` the coroutine verticle is running upon and explicit cancelation of this job within the `stop` method.
