### PR TITLE
Fix example in documentation

### DIFF
--- a/vertx-lang-kotlin/src/main/asciidoc/vertx-core/kotlin/index.adoc
+++ b/vertx-lang-kotlin/src/main/asciidoc/vertx-core/kotlin/index.adoc
@@ -147,11 +147,12 @@ Of course it is possible to mix objects and arrays
 ----
 // The json builder declares a JSON structure
 val result = json {
-
-  "firstName" to "Dale",
-  "lastName" to "Cooper",
-  "age" to 64,
-  "names" to array("Dale", "Bartholomew")
+      obj(
+        "firstName" to "Dale",
+        "lastName" to "Cooper",
+        "age" to 64,
+        "names" to array("Dale", "Bartholomew")
+      )
 }
 ----
 


### PR DESCRIPTION
Motivation:

There is an example of `json` builder in the documentation. It doesn't even compile, there should be `obj()` wrapper.

```java  
  @Test
  fun testJsonBlock() {
    val result = json {
      obj(
        "firstName" to "Dale",
        "lastName" to "Cooper",
        "age" to 64,
        "names" to array("Dale", "Bartholomew")
      )
    }

    assertEquals(
      """{"firstName":"Dale","lastName":"Cooper","age":64,"names":["Dale","Bartholomew"]}""",
      result.toString()
    )
  }
```
