### PR TITLE
Fix typos in Channels section

### DIFF
--- a/vertx-lang-kotlin-coroutines/src/main/asciidoc/index.adoc
+++ b/vertx-lang-kotlin-coroutines/src/main/asciidoc/index.adoc
@@ -141,11 +141,11 @@ include::Example.kt[tags=generatedSuspendingExtensionMethod]
 
 == Channels
 
-Channels are similar to Java `BlockingQueue` except that they do not block and instead suspend the coroutine
-instead of blocking:
+Channels are similar to Java `BlockingQueue` except that they suspend the coroutine
+instead of blocking the thread:
 
 - sending a value to full channel suspends the coroutine
-- receving a value from an empty channels also suspends the coroutine
+- receiving a value from an empty channel also suspends the coroutine
 
 Vert.x `ReadStream` and `WriteStream` can be adapted to channels with the `toChannel` extension method.
 


### PR DESCRIPTION
Motivation:

The section about channels contains some confusing grammar and some typos. This PR provides a fix.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
