### PR TITLE
StackOverflowError caused by two yield calls

### DIFF
--- a/vertx-lang-kotlin-coroutines/src/test/kotlin/io/vertx/kotlin/coroutines/VertxCoroutineTest.kt
+++ b/vertx-lang-kotlin-coroutines/src/test/kotlin/io/vertx/kotlin/coroutines/VertxCoroutineTest.kt
@@ -37,6 +37,7 @@ import java.util.concurrent.atomic.AtomicInteger
 /**
  * @author <a href="http://www.streamis.me">Stream Liu</a>
  */
+@OptIn(DelicateCoroutinesApi::class)
 @RunWith(VertxUnitRunner::class)
 class VertxCoroutineTest {
 
@@ -429,5 +430,15 @@ class VertxCoroutineTest {
     future.onComplete(testContext.asyncAssertFailure() {
       testContext.assertEquals(it.message, "Boom")
     })
+  }
+
+  @Test
+  fun `test no StackOverflowError caused by two yield calls`(testContext: TestContext) {
+    GlobalScope.launch(vertx.dispatcher()) {
+      repeat(1000) {
+        yield()
+        yield()
+      }
+    }
   }
 }


### PR DESCRIPTION
See #233

As an optimization, `VertxCoroutineExecutor` used to execute the command immediately if running on the right context (the context provided at creation time or one of its duplicates).

But this is not compliant with the `CoroutineDispacther` contract: invocations of `dispatch` should actually defer execution.

Instead, we introduce a custom `CoroutineDispatcher` that implements `isDispatchNeeded`. This method shall return `false` in the optimization can be applied.