### PR TITLE
Coroutine execution performed with dispatch in executeBlocking

### DIFF
--- a/vertx-lang-kotlin-coroutines/src/main/java/io/vertx/kotlin/coroutines/VertxCoroutine.kt
+++ b/vertx-lang-kotlin-coroutines/src/main/java/io/vertx/kotlin/coroutines/VertxCoroutine.kt
@@ -161,7 +161,7 @@ private class ContextCoroutineDispatcher(val vertxContext: ContextInternal) : Co
 
   override fun isDispatchNeeded(context: CoroutineContext): Boolean {
     val current = ContextInternal.current() ?: return true
-    return current != vertxContext && current.unwrap() != vertxContext
+    return (current != vertxContext && current.unwrap() != vertxContext) || !vertxContext.inThread()
   }
 
   override fun dispatch(context: CoroutineContext, block: Runnable) {


### PR DESCRIPTION
When a coroutine is launched in executeBlocking, execution must be performed with dispatch.