### PR TITLE
Generated await extension methods should suggest replacement by coAwait() and not await()

### DIFF
--- a/vertx-lang-kotlin-gen/src/main/java/io/vertx/lang/kotlin/KotlinCoroutineGenerator.java
+++ b/vertx-lang-kotlin-gen/src/main/java/io/vertx/lang/kotlin/KotlinCoroutineGenerator.java
@@ -255,13 +255,13 @@ public class KotlinCoroutineGenerator extends KotlinGeneratorBase<ClassModel> {
   ) {
     writer.print("@Deprecated(message = \"Instead use ");
     writer.print(method.getName());
-    writer.print(" returning a future and chain with await()\", replaceWith = ReplaceWith(\"");
+    writer.print(" returning a future and chain with coAwait()\", replaceWith = ReplaceWith(\"");
     writer.print(method.getName());
     writer.print(method.getParams()
       .stream()
       .limit(method.getParams().size() - 1)
       .map(ParamInfo::getName).collect(Collectors
-      .joining(", ", "(", ").await()")));
+      .joining(", ", "(", ").coAwait()")));
     writer.println("\"))");
     writer.print("suspend fun ");
     if (!method.getTypeParams().isEmpty() || !type.getParams().isEmpty()) {

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/amqp/AmqpClient.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/amqp/AmqpClient.kt
@@ -30,7 +30,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.amqp.AmqpClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use connect returning a future and chain with await()", replaceWith = ReplaceWith("connect().await()"))
+@Deprecated(message = "Instead use connect returning a future and chain with coAwait()", replaceWith = ReplaceWith("connect().coAwait()"))
 suspend fun AmqpClient.connectAwait(): AmqpConnection {
   return awaitResult {
     this.connect(it)
@@ -43,7 +43,7 @@ suspend fun AmqpClient.connectAwait(): AmqpConnection {
  *
  * NOTE: This function has been automatically generated from [io.vertx.amqp.AmqpClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use close returning a future and chain with await()", replaceWith = ReplaceWith("close().await()"))
+@Deprecated(message = "Instead use close returning a future and chain with coAwait()", replaceWith = ReplaceWith("close().coAwait()"))
 suspend fun AmqpClient.closeAwait(): Unit {
   return awaitResult {
     this.close(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -58,7 +58,7 @@ suspend fun AmqpClient.closeAwait(): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.amqp.AmqpClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use createReceiver returning a future and chain with await()", replaceWith = ReplaceWith("createReceiver(address).await()"))
+@Deprecated(message = "Instead use createReceiver returning a future and chain with coAwait()", replaceWith = ReplaceWith("createReceiver(address).coAwait()"))
 suspend fun AmqpClient.createReceiverAwait(address: String): AmqpReceiver {
   return awaitResult {
     this.createReceiver(address, it)
@@ -74,7 +74,7 @@ suspend fun AmqpClient.createReceiverAwait(address: String): AmqpReceiver {
  *
  * NOTE: This function has been automatically generated from [io.vertx.amqp.AmqpClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use createReceiver returning a future and chain with await()", replaceWith = ReplaceWith("createReceiver(address, receiverOptions).await()"))
+@Deprecated(message = "Instead use createReceiver returning a future and chain with coAwait()", replaceWith = ReplaceWith("createReceiver(address, receiverOptions).coAwait()"))
 suspend fun AmqpClient.createReceiverAwait(address: String, receiverOptions: AmqpReceiverOptions): AmqpReceiver {
   return awaitResult {
     this.createReceiver(address, receiverOptions, it)
@@ -89,7 +89,7 @@ suspend fun AmqpClient.createReceiverAwait(address: String, receiverOptions: Amq
  *
  * NOTE: This function has been automatically generated from [io.vertx.amqp.AmqpClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use createSender returning a future and chain with await()", replaceWith = ReplaceWith("createSender(address).await()"))
+@Deprecated(message = "Instead use createSender returning a future and chain with coAwait()", replaceWith = ReplaceWith("createSender(address).coAwait()"))
 suspend fun AmqpClient.createSenderAwait(address: String): AmqpSender {
   return awaitResult {
     this.createSender(address, it)
@@ -105,7 +105,7 @@ suspend fun AmqpClient.createSenderAwait(address: String): AmqpSender {
  *
  * NOTE: This function has been automatically generated from [io.vertx.amqp.AmqpClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use createSender returning a future and chain with await()", replaceWith = ReplaceWith("createSender(address, options).await()"))
+@Deprecated(message = "Instead use createSender returning a future and chain with coAwait()", replaceWith = ReplaceWith("createSender(address, options).coAwait()"))
 suspend fun AmqpClient.createSenderAwait(address: String, options: AmqpSenderOptions): AmqpSender {
   return awaitResult {
     this.createSender(address, options, it)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/amqp/AmqpConnection.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/amqp/AmqpConnection.kt
@@ -28,7 +28,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.amqp.AmqpConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use close returning a future and chain with await()", replaceWith = ReplaceWith("close().await()"))
+@Deprecated(message = "Instead use close returning a future and chain with coAwait()", replaceWith = ReplaceWith("close().coAwait()"))
 suspend fun AmqpConnection.closeAwait(): Unit {
   return awaitResult {
     this.close(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -43,7 +43,7 @@ suspend fun AmqpConnection.closeAwait(): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.amqp.AmqpConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use createReceiver returning a future and chain with await()", replaceWith = ReplaceWith("createReceiver(address).await()"))
+@Deprecated(message = "Instead use createReceiver returning a future and chain with coAwait()", replaceWith = ReplaceWith("createReceiver(address).coAwait()"))
 suspend fun AmqpConnection.createReceiverAwait(address: String): AmqpReceiver {
   return awaitResult {
     this.createReceiver(address, it)
@@ -59,7 +59,7 @@ suspend fun AmqpConnection.createReceiverAwait(address: String): AmqpReceiver {
  *
  * NOTE: This function has been automatically generated from [io.vertx.amqp.AmqpConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use createReceiver returning a future and chain with await()", replaceWith = ReplaceWith("createReceiver(address, receiverOptions).await()"))
+@Deprecated(message = "Instead use createReceiver returning a future and chain with coAwait()", replaceWith = ReplaceWith("createReceiver(address, receiverOptions).coAwait()"))
 suspend fun AmqpConnection.createReceiverAwait(address: String, receiverOptions: AmqpReceiverOptions): AmqpReceiver {
   return awaitResult {
     this.createReceiver(address, receiverOptions, it)
@@ -73,7 +73,7 @@ suspend fun AmqpConnection.createReceiverAwait(address: String, receiverOptions:
  *
  * NOTE: This function has been automatically generated from [io.vertx.amqp.AmqpConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use createDynamicReceiver returning a future and chain with await()", replaceWith = ReplaceWith("createDynamicReceiver().await()"))
+@Deprecated(message = "Instead use createDynamicReceiver returning a future and chain with coAwait()", replaceWith = ReplaceWith("createDynamicReceiver().coAwait()"))
 suspend fun AmqpConnection.createDynamicReceiverAwait(): AmqpReceiver {
   return awaitResult {
     this.createDynamicReceiver(it)
@@ -88,7 +88,7 @@ suspend fun AmqpConnection.createDynamicReceiverAwait(): AmqpReceiver {
  *
  * NOTE: This function has been automatically generated from [io.vertx.amqp.AmqpConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use createSender returning a future and chain with await()", replaceWith = ReplaceWith("createSender(address).await()"))
+@Deprecated(message = "Instead use createSender returning a future and chain with coAwait()", replaceWith = ReplaceWith("createSender(address).coAwait()"))
 suspend fun AmqpConnection.createSenderAwait(address: String): AmqpSender {
   return awaitResult {
     this.createSender(address, it)
@@ -104,7 +104,7 @@ suspend fun AmqpConnection.createSenderAwait(address: String): AmqpSender {
  *
  * NOTE: This function has been automatically generated from [io.vertx.amqp.AmqpConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use createSender returning a future and chain with await()", replaceWith = ReplaceWith("createSender(address, options).await()"))
+@Deprecated(message = "Instead use createSender returning a future and chain with coAwait()", replaceWith = ReplaceWith("createSender(address, options).coAwait()"))
 suspend fun AmqpConnection.createSenderAwait(address: String, options: AmqpSenderOptions): AmqpSender {
   return awaitResult {
     this.createSender(address, options, it)
@@ -118,7 +118,7 @@ suspend fun AmqpConnection.createSenderAwait(address: String, options: AmqpSende
  *
  * NOTE: This function has been automatically generated from [io.vertx.amqp.AmqpConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use createAnonymousSender returning a future and chain with await()", replaceWith = ReplaceWith("createAnonymousSender().await()"))
+@Deprecated(message = "Instead use createAnonymousSender returning a future and chain with coAwait()", replaceWith = ReplaceWith("createAnonymousSender().coAwait()"))
 suspend fun AmqpConnection.createAnonymousSenderAwait(): AmqpSender {
   return awaitResult {
     this.createAnonymousSender(it)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/amqp/AmqpReceiver.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/amqp/AmqpReceiver.kt
@@ -27,7 +27,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.amqp.AmqpReceiver] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use pipeTo returning a future and chain with await()", replaceWith = ReplaceWith("pipeTo(dst).await()"))
+@Deprecated(message = "Instead use pipeTo returning a future and chain with coAwait()", replaceWith = ReplaceWith("pipeTo(dst).coAwait()"))
 suspend fun AmqpReceiver.pipeToAwait(dst: WriteStream<AmqpMessage>): Unit {
   return awaitResult {
     this.pipeTo(dst, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -40,7 +40,7 @@ suspend fun AmqpReceiver.pipeToAwait(dst: WriteStream<AmqpMessage>): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.amqp.AmqpReceiver] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use close returning a future and chain with await()", replaceWith = ReplaceWith("close().await()"))
+@Deprecated(message = "Instead use close returning a future and chain with coAwait()", replaceWith = ReplaceWith("close().coAwait()"))
 suspend fun AmqpReceiver.closeAwait(): Unit {
   return awaitResult {
     this.close(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/amqp/AmqpSender.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/amqp/AmqpSender.kt
@@ -26,7 +26,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.amqp.AmqpSender] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use write returning a future and chain with await()", replaceWith = ReplaceWith("write(data).await()"))
+@Deprecated(message = "Instead use write returning a future and chain with coAwait()", replaceWith = ReplaceWith("write(data).coAwait()"))
 suspend fun AmqpSender.writeAwait(data: AmqpMessage): Unit {
   return awaitResult {
     this.write(data, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -39,7 +39,7 @@ suspend fun AmqpSender.writeAwait(data: AmqpMessage): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.amqp.AmqpSender] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use end returning a future and chain with await()", replaceWith = ReplaceWith("end().await()"))
+@Deprecated(message = "Instead use end returning a future and chain with coAwait()", replaceWith = ReplaceWith("end().coAwait()"))
 suspend fun AmqpSender.endAwait(): Unit {
   return awaitResult {
     this.end(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -53,7 +53,7 @@ suspend fun AmqpSender.endAwait(): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.amqp.AmqpSender] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use end returning a future and chain with await()", replaceWith = ReplaceWith("end(data).await()"))
+@Deprecated(message = "Instead use end returning a future and chain with coAwait()", replaceWith = ReplaceWith("end(data).coAwait()"))
 suspend fun AmqpSender.endAwait(data: AmqpMessage): Unit {
   return awaitResult {
     this.end(data, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -67,7 +67,7 @@ suspend fun AmqpSender.endAwait(data: AmqpMessage): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.amqp.AmqpSender] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use sendWithAck returning a future and chain with await()", replaceWith = ReplaceWith("sendWithAck(message).await()"))
+@Deprecated(message = "Instead use sendWithAck returning a future and chain with coAwait()", replaceWith = ReplaceWith("sendWithAck(message).coAwait()"))
 suspend fun AmqpSender.sendWithAckAwait(message: AmqpMessage): Unit {
   return awaitResult {
     this.sendWithAck(message, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -80,7 +80,7 @@ suspend fun AmqpSender.sendWithAckAwait(message: AmqpMessage): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.amqp.AmqpSender] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use close returning a future and chain with await()", replaceWith = ReplaceWith("close().await()"))
+@Deprecated(message = "Instead use close returning a future and chain with coAwait()", replaceWith = ReplaceWith("close().coAwait()"))
 suspend fun AmqpSender.closeAwait(): Unit {
   return awaitResult {
     this.close(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/cassandra/CassandraClient.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/cassandra/CassandraClient.kt
@@ -33,7 +33,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.cassandra.CassandraClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use execute returning a future and chain with await()", replaceWith = ReplaceWith("execute(query).await()"))
+@Deprecated(message = "Instead use execute returning a future and chain with coAwait()", replaceWith = ReplaceWith("execute(query).coAwait()"))
 suspend fun CassandraClient.executeAwait(query: String): ResultSet {
   return awaitResult {
     this.execute(query, it)
@@ -48,7 +48,7 @@ suspend fun CassandraClient.executeAwait(query: String): ResultSet {
  *
  * NOTE: This function has been automatically generated from [io.vertx.cassandra.CassandraClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use queryStream returning a future and chain with await()", replaceWith = ReplaceWith("queryStream(sql).await()"))
+@Deprecated(message = "Instead use queryStream returning a future and chain with coAwait()", replaceWith = ReplaceWith("queryStream(sql).coAwait()"))
 suspend fun CassandraClient.queryStreamAwait(sql: String): CassandraRowStream {
   return awaitResult {
     this.queryStream(sql, it)
@@ -61,7 +61,7 @@ suspend fun CassandraClient.queryStreamAwait(sql: String): CassandraRowStream {
  *
  * NOTE: This function has been automatically generated from [io.vertx.cassandra.CassandraClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use close returning a future and chain with await()", replaceWith = ReplaceWith("close().await()"))
+@Deprecated(message = "Instead use close returning a future and chain with coAwait()", replaceWith = ReplaceWith("close().coAwait()"))
 suspend fun CassandraClient.closeAwait(): Unit {
   return awaitResult {
     this.close(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -76,7 +76,7 @@ suspend fun CassandraClient.closeAwait(): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.cassandra.CassandraClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use executeWithFullFetch returning a future and chain with await()", replaceWith = ReplaceWith("executeWithFullFetch(query).await()"))
+@Deprecated(message = "Instead use executeWithFullFetch returning a future and chain with coAwait()", replaceWith = ReplaceWith("executeWithFullFetch(query).coAwait()"))
 suspend fun CassandraClient.executeWithFullFetchAwait(query: String): List<Row> {
   return awaitResult {
     this.executeWithFullFetch(query, it)
@@ -91,7 +91,7 @@ suspend fun CassandraClient.executeWithFullFetchAwait(query: String): List<Row> 
  *
  * NOTE: This function has been automatically generated from [io.vertx.cassandra.CassandraClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use executeWithFullFetch returning a future and chain with await()", replaceWith = ReplaceWith("executeWithFullFetch(statement).await()"))
+@Deprecated(message = "Instead use executeWithFullFetch returning a future and chain with coAwait()", replaceWith = ReplaceWith("executeWithFullFetch(statement).coAwait()"))
 suspend fun CassandraClient.executeWithFullFetchAwait(statement: Statement<*>): List<Row> {
   return awaitResult {
     this.executeWithFullFetch(statement, it)
@@ -106,7 +106,7 @@ suspend fun CassandraClient.executeWithFullFetchAwait(statement: Statement<*>): 
  *
  * NOTE: This function has been automatically generated from [io.vertx.cassandra.CassandraClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use execute returning a future and chain with await()", replaceWith = ReplaceWith("execute(statement).await()"))
+@Deprecated(message = "Instead use execute returning a future and chain with coAwait()", replaceWith = ReplaceWith("execute(statement).coAwait()"))
 suspend fun CassandraClient.executeAwait(statement: Statement<*>): ResultSet {
   return awaitResult {
     this.execute(statement, it)
@@ -121,7 +121,7 @@ suspend fun CassandraClient.executeAwait(statement: Statement<*>): ResultSet {
  *
  * NOTE: This function has been automatically generated from [io.vertx.cassandra.CassandraClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use prepare returning a future and chain with await()", replaceWith = ReplaceWith("prepare(query).await()"))
+@Deprecated(message = "Instead use prepare returning a future and chain with coAwait()", replaceWith = ReplaceWith("prepare(query).coAwait()"))
 suspend fun CassandraClient.prepareAwait(query: String): PreparedStatement {
   return awaitResult {
     this.prepare(query, it)
@@ -136,7 +136,7 @@ suspend fun CassandraClient.prepareAwait(query: String): PreparedStatement {
  *
  * NOTE: This function has been automatically generated from [io.vertx.cassandra.CassandraClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use prepare returning a future and chain with await()", replaceWith = ReplaceWith("prepare(statement).await()"))
+@Deprecated(message = "Instead use prepare returning a future and chain with coAwait()", replaceWith = ReplaceWith("prepare(statement).coAwait()"))
 suspend fun CassandraClient.prepareAwait(statement: SimpleStatement): PreparedStatement {
   return awaitResult {
     this.prepare(statement, it)
@@ -151,7 +151,7 @@ suspend fun CassandraClient.prepareAwait(statement: SimpleStatement): PreparedSt
  *
  * NOTE: This function has been automatically generated from [io.vertx.cassandra.CassandraClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use queryStream returning a future and chain with await()", replaceWith = ReplaceWith("queryStream(statement).await()"))
+@Deprecated(message = "Instead use queryStream returning a future and chain with coAwait()", replaceWith = ReplaceWith("queryStream(statement).coAwait()"))
 suspend fun CassandraClient.queryStreamAwait(statement: Statement<*>): CassandraRowStream {
   return awaitResult {
     this.queryStream(statement, it)
@@ -165,7 +165,7 @@ suspend fun CassandraClient.queryStreamAwait(statement: Statement<*>): Cassandra
  *
  * NOTE: This function has been automatically generated from [io.vertx.cassandra.CassandraClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use metadata returning a future and chain with await()", replaceWith = ReplaceWith("metadata().await()"))
+@Deprecated(message = "Instead use metadata returning a future and chain with coAwait()", replaceWith = ReplaceWith("metadata().coAwait()"))
 suspend fun CassandraClient.metadataAwait(): Metadata {
   return awaitResult {
     this.metadata(it)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/cassandra/ResultSet.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/cassandra/ResultSet.kt
@@ -26,7 +26,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.cassandra.ResultSet] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use fetchNextPage returning a future and chain with await()", replaceWith = ReplaceWith("fetchNextPage().await()"))
+@Deprecated(message = "Instead use fetchNextPage returning a future and chain with coAwait()", replaceWith = ReplaceWith("fetchNextPage().coAwait()"))
 suspend fun ResultSet.fetchNextPageAwait(): ResultSet {
   return awaitResult {
     this.fetchNextPage(it)
@@ -40,7 +40,7 @@ suspend fun ResultSet.fetchNextPageAwait(): ResultSet {
  *
  * NOTE: This function has been automatically generated from [io.vertx.cassandra.ResultSet] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use all returning a future and chain with await()", replaceWith = ReplaceWith("all().await()"))
+@Deprecated(message = "Instead use all returning a future and chain with coAwait()", replaceWith = ReplaceWith("all().coAwait()"))
 suspend fun ResultSet.allAwait(): List<Row> {
   return awaitResult {
     this.all(it)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/circuitbreaker/CircuitBreaker.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/circuitbreaker/CircuitBreaker.kt
@@ -29,7 +29,7 @@ import java.util.function.Function
  *
  * NOTE: This function has been automatically generated from [io.vertx.circuitbreaker.CircuitBreaker] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use executeWithFallback returning a future and chain with await()", replaceWith = ReplaceWith("executeWithFallback(command, fallback).await()"))
+@Deprecated(message = "Instead use executeWithFallback returning a future and chain with coAwait()", replaceWith = ReplaceWith("executeWithFallback(command, fallback).coAwait()"))
 suspend fun <T> CircuitBreaker.executeWithFallbackAwait(command: (Promise<T>) -> Unit, fallback: (Throwable) -> T): T {
   return awaitResult {
     this.executeWithFallback(command, fallback, it::handle)
@@ -44,7 +44,7 @@ suspend fun <T> CircuitBreaker.executeWithFallbackAwait(command: (Promise<T>) ->
  *
  * NOTE: This function has been automatically generated from [io.vertx.circuitbreaker.CircuitBreaker] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use execute returning a future and chain with await()", replaceWith = ReplaceWith("execute(command).await()"))
+@Deprecated(message = "Instead use execute returning a future and chain with coAwait()", replaceWith = ReplaceWith("execute(command).coAwait()"))
 suspend fun <T> CircuitBreaker.executeAwait(command: (Promise<T>) -> Unit): T {
   return awaitResult {
     this.execute(command, it::handle)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/config/ConfigRetriever.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/config/ConfigRetriever.kt
@@ -26,7 +26,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.config.ConfigRetriever] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use getConfig returning a future and chain with await()", replaceWith = ReplaceWith("getConfig().await()"))
+@Deprecated(message = "Instead use getConfig returning a future and chain with coAwait()", replaceWith = ReplaceWith("getConfig().coAwait()"))
 suspend fun ConfigRetriever.getConfigAwait(): JsonObject {
   return awaitResult {
     this.getConfig(it)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/Vertx.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/Vertx.kt
@@ -29,7 +29,7 @@ import java.util.function.Supplier
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.Vertx] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use close returning a future and chain with await()", replaceWith = ReplaceWith("close().await()"))
+@Deprecated(message = "Instead use close returning a future and chain with coAwait()", replaceWith = ReplaceWith("close().coAwait()"))
 suspend fun VertxVertxAlias.closeAwait(): Unit {
   return awaitResult {
     this.close(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -44,7 +44,7 @@ suspend fun VertxVertxAlias.closeAwait(): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.Vertx] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use deployVerticle returning a future and chain with await()", replaceWith = ReplaceWith("deployVerticle(name).await()"))
+@Deprecated(message = "Instead use deployVerticle returning a future and chain with coAwait()", replaceWith = ReplaceWith("deployVerticle(name).coAwait()"))
 suspend fun VertxVertxAlias.deployVerticleAwait(name: String): String {
   return awaitResult {
     this.deployVerticle(name, it)
@@ -60,7 +60,7 @@ suspend fun VertxVertxAlias.deployVerticleAwait(name: String): String {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.Vertx] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use deployVerticle returning a future and chain with await()", replaceWith = ReplaceWith("deployVerticle(name, options).await()"))
+@Deprecated(message = "Instead use deployVerticle returning a future and chain with coAwait()", replaceWith = ReplaceWith("deployVerticle(name, options).coAwait()"))
 suspend fun VertxVertxAlias.deployVerticleAwait(name: String, options: DeploymentOptions): String {
   return awaitResult {
     this.deployVerticle(name, options, it)
@@ -74,7 +74,7 @@ suspend fun VertxVertxAlias.deployVerticleAwait(name: String, options: Deploymen
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.Vertx] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use undeploy returning a future and chain with await()", replaceWith = ReplaceWith("undeploy(deploymentID).await()"))
+@Deprecated(message = "Instead use undeploy returning a future and chain with coAwait()", replaceWith = ReplaceWith("undeploy(deploymentID).coAwait()"))
 suspend fun VertxVertxAlias.undeployAwait(deploymentID: String): Unit {
   return awaitResult {
     this.undeploy(deploymentID, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -89,7 +89,7 @@ suspend fun VertxVertxAlias.undeployAwait(deploymentID: String): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.Vertx] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use deployVerticle returning a future and chain with await()", replaceWith = ReplaceWith("deployVerticle(verticle).await()"))
+@Deprecated(message = "Instead use deployVerticle returning a future and chain with coAwait()", replaceWith = ReplaceWith("deployVerticle(verticle).coAwait()"))
 suspend fun VertxVertxAlias.deployVerticleAwait(verticle: Verticle): String {
   return awaitResult {
     this.deployVerticle(verticle, it)
@@ -105,7 +105,7 @@ suspend fun VertxVertxAlias.deployVerticleAwait(verticle: Verticle): String {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.Vertx] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use deployVerticle returning a future and chain with await()", replaceWith = ReplaceWith("deployVerticle(verticle, options).await()"))
+@Deprecated(message = "Instead use deployVerticle returning a future and chain with coAwait()", replaceWith = ReplaceWith("deployVerticle(verticle, options).coAwait()"))
 suspend fun VertxVertxAlias.deployVerticleAwait(verticle: Verticle, options: DeploymentOptions): String {
   return awaitResult {
     this.deployVerticle(verticle, options, it)
@@ -121,7 +121,7 @@ suspend fun VertxVertxAlias.deployVerticleAwait(verticle: Verticle, options: Dep
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.Vertx] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use deployVerticle returning a future and chain with await()", replaceWith = ReplaceWith("deployVerticle(verticleSupplier, options).await()"))
+@Deprecated(message = "Instead use deployVerticle returning a future and chain with coAwait()", replaceWith = ReplaceWith("deployVerticle(verticleSupplier, options).coAwait()"))
 suspend fun VertxVertxAlias.deployVerticleAwait(verticleSupplier: Supplier<Verticle>, options: DeploymentOptions): String {
   return awaitResult {
     this.deployVerticle(verticleSupplier, options, it)
@@ -136,7 +136,7 @@ suspend fun VertxVertxAlias.deployVerticleAwait(verticleSupplier: Supplier<Verti
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.Vertx] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use executeBlocking returning a future and chain with await()", replaceWith = ReplaceWith("executeBlocking(blockingCodeHandler).await()"))
+@Deprecated(message = "Instead use executeBlocking returning a future and chain with coAwait()", replaceWith = ReplaceWith("executeBlocking(blockingCodeHandler).coAwait()"))
 suspend fun <T> VertxVertxAlias.executeBlockingAwait(blockingCodeHandler: Callable<T>): T? {
   return awaitResult {
     this.executeBlocking(blockingCodeHandler, it)
@@ -152,7 +152,7 @@ suspend fun <T> VertxVertxAlias.executeBlockingAwait(blockingCodeHandler: Callab
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.Vertx] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use executeBlocking returning a future and chain with await()", replaceWith = ReplaceWith("executeBlocking(blockingCodeHandler, ordered).await()"))
+@Deprecated(message = "Instead use executeBlocking returning a future and chain with coAwait()", replaceWith = ReplaceWith("executeBlocking(blockingCodeHandler, ordered).coAwait()"))
 suspend fun <T> VertxVertxAlias.executeBlockingAwait(blockingCodeHandler: Callable<T>, ordered: Boolean): T? {
   return awaitResult {
     this.executeBlocking(blockingCodeHandler, ordered, it)
@@ -168,7 +168,7 @@ object Vertx {
    *
    * NOTE: This function has been automatically generated from [io.vertx.core.Vertx] using Vert.x codegen.
    */
-  @Deprecated(message = "Instead use clusteredVertx returning a future and chain with await()", replaceWith = ReplaceWith("clusteredVertx(options).await()"))
+  @Deprecated(message = "Instead use clusteredVertx returning a future and chain with coAwait()", replaceWith = ReplaceWith("clusteredVertx(options).coAwait()"))
   suspend fun clusteredVertxAwait(options: VertxOptions): VertxVertxAlias {
     return awaitResult {
       VertxVertxAlias.clusteredVertx(options, it)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/VertxBuilder.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/VertxBuilder.kt
@@ -26,7 +26,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.VertxBuilder] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use buildClustered returning a future and chain with await()", replaceWith = ReplaceWith("buildClustered().await()"))
+@Deprecated(message = "Instead use buildClustered returning a future and chain with coAwait()", replaceWith = ReplaceWith("buildClustered().coAwait()"))
 suspend fun VertxBuilder.buildClusteredAwait(): Vertx {
   return awaitResult {
     this.buildClustered(it)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/WorkerExecutor.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/WorkerExecutor.kt
@@ -25,7 +25,7 @@ import java.util.concurrent.Callable
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.WorkerExecutor] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use close returning a future and chain with await()", replaceWith = ReplaceWith("close().await()"))
+@Deprecated(message = "Instead use close returning a future and chain with coAwait()", replaceWith = ReplaceWith("close().coAwait()"))
 suspend fun WorkerExecutor.closeAwait(): Unit {
   return awaitResult {
     this.close(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -40,7 +40,7 @@ suspend fun WorkerExecutor.closeAwait(): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.WorkerExecutor] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use executeBlocking returning a future and chain with await()", replaceWith = ReplaceWith("executeBlocking(blockingCodeHandler).await()"))
+@Deprecated(message = "Instead use executeBlocking returning a future and chain with coAwait()", replaceWith = ReplaceWith("executeBlocking(blockingCodeHandler).coAwait()"))
 suspend fun <T> WorkerExecutor.executeBlockingAwait(blockingCodeHandler: Callable<T>): T? {
   return awaitResult {
     this.executeBlocking(blockingCodeHandler, it)
@@ -56,7 +56,7 @@ suspend fun <T> WorkerExecutor.executeBlockingAwait(blockingCodeHandler: Callabl
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.WorkerExecutor] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use executeBlocking returning a future and chain with await()", replaceWith = ReplaceWith("executeBlocking(blockingCodeHandler, ordered).await()"))
+@Deprecated(message = "Instead use executeBlocking returning a future and chain with coAwait()", replaceWith = ReplaceWith("executeBlocking(blockingCodeHandler, ordered).coAwait()"))
 suspend fun <T> WorkerExecutor.executeBlockingAwait(blockingCodeHandler: Callable<T>, ordered: Boolean): T? {
   return awaitResult {
     this.executeBlocking(blockingCodeHandler, ordered, it)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/datagram/DatagramSocket.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/datagram/DatagramSocket.kt
@@ -28,7 +28,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.datagram.DatagramSocket] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use pipeTo returning a future and chain with await()", replaceWith = ReplaceWith("pipeTo(dst).await()"))
+@Deprecated(message = "Instead use pipeTo returning a future and chain with coAwait()", replaceWith = ReplaceWith("pipeTo(dst).coAwait()"))
 suspend fun DatagramSocket.pipeToAwait(dst: WriteStream<DatagramPacket>): Unit {
   return awaitResult {
     this.pipeTo(dst, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -44,7 +44,7 @@ suspend fun DatagramSocket.pipeToAwait(dst: WriteStream<DatagramPacket>): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.datagram.DatagramSocket] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use send returning a future and chain with await()", replaceWith = ReplaceWith("send(packet, port, host).await()"))
+@Deprecated(message = "Instead use send returning a future and chain with coAwait()", replaceWith = ReplaceWith("send(packet, port, host).coAwait()"))
 suspend fun DatagramSocket.sendAwait(packet: Buffer, port: Int, host: String): Unit {
   return awaitResult {
     this.send(packet, port, host, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -60,7 +60,7 @@ suspend fun DatagramSocket.sendAwait(packet: Buffer, port: Int, host: String): U
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.datagram.DatagramSocket] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use send returning a future and chain with await()", replaceWith = ReplaceWith("send(str, port, host).await()"))
+@Deprecated(message = "Instead use send returning a future and chain with coAwait()", replaceWith = ReplaceWith("send(str, port, host).coAwait()"))
 suspend fun DatagramSocket.sendAwait(str: String, port: Int, host: String): Unit {
   return awaitResult {
     this.send(str, port, host, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -77,7 +77,7 @@ suspend fun DatagramSocket.sendAwait(str: String, port: Int, host: String): Unit
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.datagram.DatagramSocket] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use send returning a future and chain with await()", replaceWith = ReplaceWith("send(str, enc, port, host).await()"))
+@Deprecated(message = "Instead use send returning a future and chain with coAwait()", replaceWith = ReplaceWith("send(str, enc, port, host).coAwait()"))
 suspend fun DatagramSocket.sendAwait(str: String, enc: String, port: Int, host: String): Unit {
   return awaitResult {
     this.send(str, enc, port, host, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -90,7 +90,7 @@ suspend fun DatagramSocket.sendAwait(str: String, enc: String, port: Int, host: 
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.datagram.DatagramSocket] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use close returning a future and chain with await()", replaceWith = ReplaceWith("close().await()"))
+@Deprecated(message = "Instead use close returning a future and chain with coAwait()", replaceWith = ReplaceWith("close().coAwait()"))
 suspend fun DatagramSocket.closeAwait(): Unit {
   return awaitResult {
     this.close(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -104,7 +104,7 @@ suspend fun DatagramSocket.closeAwait(): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.datagram.DatagramSocket] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use listenMulticastGroup returning a future and chain with await()", replaceWith = ReplaceWith("listenMulticastGroup(multicastAddress).await()"))
+@Deprecated(message = "Instead use listenMulticastGroup returning a future and chain with coAwait()", replaceWith = ReplaceWith("listenMulticastGroup(multicastAddress).coAwait()"))
 suspend fun DatagramSocket.listenMulticastGroupAwait(multicastAddress: String): Unit {
   return awaitResult {
     this.listenMulticastGroup(multicastAddress, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -120,7 +120,7 @@ suspend fun DatagramSocket.listenMulticastGroupAwait(multicastAddress: String): 
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.datagram.DatagramSocket] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use listenMulticastGroup returning a future and chain with await()", replaceWith = ReplaceWith("listenMulticastGroup(multicastAddress, networkInterface, source).await()"))
+@Deprecated(message = "Instead use listenMulticastGroup returning a future and chain with coAwait()", replaceWith = ReplaceWith("listenMulticastGroup(multicastAddress, networkInterface, source).coAwait()"))
 suspend fun DatagramSocket.listenMulticastGroupAwait(multicastAddress: String, networkInterface: String, source: String?): Unit {
   return awaitResult {
     this.listenMulticastGroup(multicastAddress, networkInterface, source, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -134,7 +134,7 @@ suspend fun DatagramSocket.listenMulticastGroupAwait(multicastAddress: String, n
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.datagram.DatagramSocket] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use unlistenMulticastGroup returning a future and chain with await()", replaceWith = ReplaceWith("unlistenMulticastGroup(multicastAddress).await()"))
+@Deprecated(message = "Instead use unlistenMulticastGroup returning a future and chain with coAwait()", replaceWith = ReplaceWith("unlistenMulticastGroup(multicastAddress).coAwait()"))
 suspend fun DatagramSocket.unlistenMulticastGroupAwait(multicastAddress: String): Unit {
   return awaitResult {
     this.unlistenMulticastGroup(multicastAddress, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -150,7 +150,7 @@ suspend fun DatagramSocket.unlistenMulticastGroupAwait(multicastAddress: String)
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.datagram.DatagramSocket] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use unlistenMulticastGroup returning a future and chain with await()", replaceWith = ReplaceWith("unlistenMulticastGroup(multicastAddress, networkInterface, source).await()"))
+@Deprecated(message = "Instead use unlistenMulticastGroup returning a future and chain with coAwait()", replaceWith = ReplaceWith("unlistenMulticastGroup(multicastAddress, networkInterface, source).coAwait()"))
 suspend fun DatagramSocket.unlistenMulticastGroupAwait(multicastAddress: String, networkInterface: String, source: String?): Unit {
   return awaitResult {
     this.unlistenMulticastGroup(multicastAddress, networkInterface, source, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -165,7 +165,7 @@ suspend fun DatagramSocket.unlistenMulticastGroupAwait(multicastAddress: String,
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.datagram.DatagramSocket] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use blockMulticastGroup returning a future and chain with await()", replaceWith = ReplaceWith("blockMulticastGroup(multicastAddress, sourceToBlock).await()"))
+@Deprecated(message = "Instead use blockMulticastGroup returning a future and chain with coAwait()", replaceWith = ReplaceWith("blockMulticastGroup(multicastAddress, sourceToBlock).coAwait()"))
 suspend fun DatagramSocket.blockMulticastGroupAwait(multicastAddress: String, sourceToBlock: String): Unit {
   return awaitResult {
     this.blockMulticastGroup(multicastAddress, sourceToBlock, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -181,7 +181,7 @@ suspend fun DatagramSocket.blockMulticastGroupAwait(multicastAddress: String, so
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.datagram.DatagramSocket] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use blockMulticastGroup returning a future and chain with await()", replaceWith = ReplaceWith("blockMulticastGroup(multicastAddress, networkInterface, sourceToBlock).await()"))
+@Deprecated(message = "Instead use blockMulticastGroup returning a future and chain with coAwait()", replaceWith = ReplaceWith("blockMulticastGroup(multicastAddress, networkInterface, sourceToBlock).coAwait()"))
 suspend fun DatagramSocket.blockMulticastGroupAwait(multicastAddress: String, networkInterface: String, sourceToBlock: String): Unit {
   return awaitResult {
     this.blockMulticastGroup(multicastAddress, networkInterface, sourceToBlock, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -197,7 +197,7 @@ suspend fun DatagramSocket.blockMulticastGroupAwait(multicastAddress: String, ne
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.datagram.DatagramSocket] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use listen returning a future and chain with await()", replaceWith = ReplaceWith("listen(port, host).await()"))
+@Deprecated(message = "Instead use listen returning a future and chain with coAwait()", replaceWith = ReplaceWith("listen(port, host).coAwait()"))
 suspend fun DatagramSocket.listenAwait(port: Int, host: String): DatagramSocket {
   return awaitResult {
     this.listen(port, host, it)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/dns/DnsClient.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/dns/DnsClient.kt
@@ -28,7 +28,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.dns.DnsClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use lookup returning a future and chain with await()", replaceWith = ReplaceWith("lookup(name).await()"))
+@Deprecated(message = "Instead use lookup returning a future and chain with coAwait()", replaceWith = ReplaceWith("lookup(name).coAwait()"))
 suspend fun DnsClient.lookupAwait(name: String): String? {
   return awaitResult {
     this.lookup(name, it)
@@ -43,7 +43,7 @@ suspend fun DnsClient.lookupAwait(name: String): String? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.dns.DnsClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use lookup4 returning a future and chain with await()", replaceWith = ReplaceWith("lookup4(name).await()"))
+@Deprecated(message = "Instead use lookup4 returning a future and chain with coAwait()", replaceWith = ReplaceWith("lookup4(name).coAwait()"))
 suspend fun DnsClient.lookup4Await(name: String): String? {
   return awaitResult {
     this.lookup4(name, it)
@@ -58,7 +58,7 @@ suspend fun DnsClient.lookup4Await(name: String): String? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.dns.DnsClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use lookup6 returning a future and chain with await()", replaceWith = ReplaceWith("lookup6(name).await()"))
+@Deprecated(message = "Instead use lookup6 returning a future and chain with coAwait()", replaceWith = ReplaceWith("lookup6(name).coAwait()"))
 suspend fun DnsClient.lookup6Await(name: String): String? {
   return awaitResult {
     this.lookup6(name, it)
@@ -73,7 +73,7 @@ suspend fun DnsClient.lookup6Await(name: String): String? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.dns.DnsClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use resolveA returning a future and chain with await()", replaceWith = ReplaceWith("resolveA(name).await()"))
+@Deprecated(message = "Instead use resolveA returning a future and chain with coAwait()", replaceWith = ReplaceWith("resolveA(name).coAwait()"))
 suspend fun DnsClient.resolveAAwait(name: String): List<String> {
   return awaitResult {
     this.resolveA(name, it)
@@ -88,7 +88,7 @@ suspend fun DnsClient.resolveAAwait(name: String): List<String> {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.dns.DnsClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use resolveAAAA returning a future and chain with await()", replaceWith = ReplaceWith("resolveAAAA(name).await()"))
+@Deprecated(message = "Instead use resolveAAAA returning a future and chain with coAwait()", replaceWith = ReplaceWith("resolveAAAA(name).coAwait()"))
 suspend fun DnsClient.resolveAAAAAwait(name: String): List<String> {
   return awaitResult {
     this.resolveAAAA(name, it)
@@ -103,7 +103,7 @@ suspend fun DnsClient.resolveAAAAAwait(name: String): List<String> {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.dns.DnsClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use resolveCNAME returning a future and chain with await()", replaceWith = ReplaceWith("resolveCNAME(name).await()"))
+@Deprecated(message = "Instead use resolveCNAME returning a future and chain with coAwait()", replaceWith = ReplaceWith("resolveCNAME(name).coAwait()"))
 suspend fun DnsClient.resolveCNAMEAwait(name: String): List<String> {
   return awaitResult {
     this.resolveCNAME(name, it)
@@ -118,7 +118,7 @@ suspend fun DnsClient.resolveCNAMEAwait(name: String): List<String> {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.dns.DnsClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use resolveMX returning a future and chain with await()", replaceWith = ReplaceWith("resolveMX(name).await()"))
+@Deprecated(message = "Instead use resolveMX returning a future and chain with coAwait()", replaceWith = ReplaceWith("resolveMX(name).coAwait()"))
 suspend fun DnsClient.resolveMXAwait(name: String): List<MxRecord> {
   return awaitResult {
     this.resolveMX(name, it)
@@ -133,7 +133,7 @@ suspend fun DnsClient.resolveMXAwait(name: String): List<MxRecord> {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.dns.DnsClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use resolveTXT returning a future and chain with await()", replaceWith = ReplaceWith("resolveTXT(name).await()"))
+@Deprecated(message = "Instead use resolveTXT returning a future and chain with coAwait()", replaceWith = ReplaceWith("resolveTXT(name).coAwait()"))
 suspend fun DnsClient.resolveTXTAwait(name: String): List<String> {
   return awaitResult {
     this.resolveTXT(name, it)
@@ -148,7 +148,7 @@ suspend fun DnsClient.resolveTXTAwait(name: String): List<String> {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.dns.DnsClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use resolvePTR returning a future and chain with await()", replaceWith = ReplaceWith("resolvePTR(name).await()"))
+@Deprecated(message = "Instead use resolvePTR returning a future and chain with coAwait()", replaceWith = ReplaceWith("resolvePTR(name).coAwait()"))
 suspend fun DnsClient.resolvePTRAwait(name: String): String? {
   return awaitResult {
     this.resolvePTR(name, it)
@@ -163,7 +163,7 @@ suspend fun DnsClient.resolvePTRAwait(name: String): String? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.dns.DnsClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use resolveNS returning a future and chain with await()", replaceWith = ReplaceWith("resolveNS(name).await()"))
+@Deprecated(message = "Instead use resolveNS returning a future and chain with coAwait()", replaceWith = ReplaceWith("resolveNS(name).coAwait()"))
 suspend fun DnsClient.resolveNSAwait(name: String): List<String> {
   return awaitResult {
     this.resolveNS(name, it)
@@ -178,7 +178,7 @@ suspend fun DnsClient.resolveNSAwait(name: String): List<String> {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.dns.DnsClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use resolveSRV returning a future and chain with await()", replaceWith = ReplaceWith("resolveSRV(name).await()"))
+@Deprecated(message = "Instead use resolveSRV returning a future and chain with coAwait()", replaceWith = ReplaceWith("resolveSRV(name).coAwait()"))
 suspend fun DnsClient.resolveSRVAwait(name: String): List<SrvRecord> {
   return awaitResult {
     this.resolveSRV(name, it)
@@ -193,7 +193,7 @@ suspend fun DnsClient.resolveSRVAwait(name: String): List<SrvRecord> {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.dns.DnsClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use reverseLookup returning a future and chain with await()", replaceWith = ReplaceWith("reverseLookup(ipaddress).await()"))
+@Deprecated(message = "Instead use reverseLookup returning a future and chain with coAwait()", replaceWith = ReplaceWith("reverseLookup(ipaddress).coAwait()"))
 suspend fun DnsClient.reverseLookupAwait(ipaddress: String): String? {
   return awaitResult {
     this.reverseLookup(ipaddress, it)
@@ -206,7 +206,7 @@ suspend fun DnsClient.reverseLookupAwait(ipaddress: String): String? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.dns.DnsClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use close returning a future and chain with await()", replaceWith = ReplaceWith("close().await()"))
+@Deprecated(message = "Instead use close returning a future and chain with coAwait()", replaceWith = ReplaceWith("close().coAwait()"))
 suspend fun DnsClient.closeAwait(): Unit {
   return awaitResult {
     this.close(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/eventbus/EventBus.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/eventbus/EventBus.kt
@@ -29,7 +29,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.eventbus.EventBus] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use request returning a future and chain with await()", replaceWith = ReplaceWith("request(address, message).await()"))
+@Deprecated(message = "Instead use request returning a future and chain with coAwait()", replaceWith = ReplaceWith("request(address, message).coAwait()"))
 suspend fun <T> EventBus.requestAwait(address: String, message: Any?): Message<T> {
   return awaitResult {
     this.request(address, message, it)
@@ -46,7 +46,7 @@ suspend fun <T> EventBus.requestAwait(address: String, message: Any?): Message<T
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.eventbus.EventBus] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use request returning a future and chain with await()", replaceWith = ReplaceWith("request(address, message, options).await()"))
+@Deprecated(message = "Instead use request returning a future and chain with coAwait()", replaceWith = ReplaceWith("request(address, message, options).coAwait()"))
 suspend fun <T> EventBus.requestAwait(address: String, message: Any?, options: DeliveryOptions): Message<T> {
   return awaitResult {
     this.request(address, message, options, it)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/eventbus/Message.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/eventbus/Message.kt
@@ -27,7 +27,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.eventbus.Message] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use replyAndRequest returning a future and chain with await()", replaceWith = ReplaceWith("replyAndRequest(message).await()"))
+@Deprecated(message = "Instead use replyAndRequest returning a future and chain with coAwait()", replaceWith = ReplaceWith("replyAndRequest(message).coAwait()"))
 suspend fun <R,T> Message<T>.replyAndRequestAwait(message: Any?): Message<R> {
   return awaitResult {
     this.replyAndRequest(message, it)
@@ -43,7 +43,7 @@ suspend fun <R,T> Message<T>.replyAndRequestAwait(message: Any?): Message<R> {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.eventbus.Message] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use replyAndRequest returning a future and chain with await()", replaceWith = ReplaceWith("replyAndRequest(message, options).await()"))
+@Deprecated(message = "Instead use replyAndRequest returning a future and chain with coAwait()", replaceWith = ReplaceWith("replyAndRequest(message, options).coAwait()"))
 suspend fun <R,T> Message<T>.replyAndRequestAwait(message: Any?, options: DeliveryOptions): Message<R> {
   return awaitResult {
     this.replyAndRequest(message, options, it)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/eventbus/MessageConsumer.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/eventbus/MessageConsumer.kt
@@ -27,7 +27,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.eventbus.MessageConsumer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use pipeTo returning a future and chain with await()", replaceWith = ReplaceWith("pipeTo(dst).await()"))
+@Deprecated(message = "Instead use pipeTo returning a future and chain with coAwait()", replaceWith = ReplaceWith("pipeTo(dst).coAwait()"))
 suspend fun <T> MessageConsumer<T>.pipeToAwait(dst: WriteStream<Message<T>>): Unit {
   return awaitResult {
     this.pipeTo(dst, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -40,7 +40,7 @@ suspend fun <T> MessageConsumer<T>.pipeToAwait(dst: WriteStream<Message<T>>): Un
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.eventbus.MessageConsumer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use completionHandler returning a future and chain with await()", replaceWith = ReplaceWith("completionHandler().await()"))
+@Deprecated(message = "Instead use completionHandler returning a future and chain with coAwait()", replaceWith = ReplaceWith("completionHandler().coAwait()"))
 suspend fun <T> MessageConsumer<T>.completionHandlerAwait(): Unit {
   return awaitResult {
     this.completionHandler(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -53,7 +53,7 @@ suspend fun <T> MessageConsumer<T>.completionHandlerAwait(): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.eventbus.MessageConsumer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use unregister returning a future and chain with await()", replaceWith = ReplaceWith("unregister().await()"))
+@Deprecated(message = "Instead use unregister returning a future and chain with coAwait()", replaceWith = ReplaceWith("unregister().coAwait()"))
 suspend fun <T> MessageConsumer<T>.unregisterAwait(): Unit {
   return awaitResult {
     this.unregister(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/eventbus/MessageProducer.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/eventbus/MessageProducer.kt
@@ -25,7 +25,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.eventbus.MessageProducer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use write returning a future and chain with await()", replaceWith = ReplaceWith("write(body).await()"))
+@Deprecated(message = "Instead use write returning a future and chain with coAwait()", replaceWith = ReplaceWith("write(body).coAwait()"))
 suspend fun <T> MessageProducer<T>.writeAwait(body: T): Unit {
   return awaitResult {
     this.write(body, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -38,7 +38,7 @@ suspend fun <T> MessageProducer<T>.writeAwait(body: T): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.eventbus.MessageProducer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use close returning a future and chain with await()", replaceWith = ReplaceWith("close().await()"))
+@Deprecated(message = "Instead use close returning a future and chain with coAwait()", replaceWith = ReplaceWith("close().coAwait()"))
 suspend fun <T> MessageProducer<T>.closeAwait(): Unit {
   return awaitResult {
     this.close(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/file/AsyncFile.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/file/AsyncFile.kt
@@ -28,7 +28,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.file.AsyncFile] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use write returning a future and chain with await()", replaceWith = ReplaceWith("write(data).await()"))
+@Deprecated(message = "Instead use write returning a future and chain with coAwait()", replaceWith = ReplaceWith("write(data).coAwait()"))
 suspend fun AsyncFile.writeAwait(data: Buffer): Unit {
   return awaitResult {
     this.write(data, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -41,7 +41,7 @@ suspend fun AsyncFile.writeAwait(data: Buffer): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.file.AsyncFile] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use end returning a future and chain with await()", replaceWith = ReplaceWith("end().await()"))
+@Deprecated(message = "Instead use end returning a future and chain with coAwait()", replaceWith = ReplaceWith("end().coAwait()"))
 suspend fun AsyncFile.endAwait(): Unit {
   return awaitResult {
     this.end(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -55,7 +55,7 @@ suspend fun AsyncFile.endAwait(): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.file.AsyncFile] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use end returning a future and chain with await()", replaceWith = ReplaceWith("end(data).await()"))
+@Deprecated(message = "Instead use end returning a future and chain with coAwait()", replaceWith = ReplaceWith("end(data).coAwait()"))
 suspend fun AsyncFile.endAwait(data: Buffer): Unit {
   return awaitResult {
     this.end(data, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -69,7 +69,7 @@ suspend fun AsyncFile.endAwait(data: Buffer): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.file.AsyncFile] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use pipeTo returning a future and chain with await()", replaceWith = ReplaceWith("pipeTo(dst).await()"))
+@Deprecated(message = "Instead use pipeTo returning a future and chain with coAwait()", replaceWith = ReplaceWith("pipeTo(dst).coAwait()"))
 suspend fun AsyncFile.pipeToAwait(dst: WriteStream<Buffer>): Unit {
   return awaitResult {
     this.pipeTo(dst, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -82,7 +82,7 @@ suspend fun AsyncFile.pipeToAwait(dst: WriteStream<Buffer>): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.file.AsyncFile] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use close returning a future and chain with await()", replaceWith = ReplaceWith("close().await()"))
+@Deprecated(message = "Instead use close returning a future and chain with coAwait()", replaceWith = ReplaceWith("close().coAwait()"))
 suspend fun AsyncFile.closeAwait(): Unit {
   return awaitResult {
     this.close(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -97,7 +97,7 @@ suspend fun AsyncFile.closeAwait(): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.file.AsyncFile] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use write returning a future and chain with await()", replaceWith = ReplaceWith("write(buffer, position).await()"))
+@Deprecated(message = "Instead use write returning a future and chain with coAwait()", replaceWith = ReplaceWith("write(buffer, position).coAwait()"))
 suspend fun AsyncFile.writeAwait(buffer: Buffer, position: Long): Unit {
   return awaitResult {
     this.write(buffer, position, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -115,7 +115,7 @@ suspend fun AsyncFile.writeAwait(buffer: Buffer, position: Long): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.file.AsyncFile] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use read returning a future and chain with await()", replaceWith = ReplaceWith("read(buffer, offset, position, length).await()"))
+@Deprecated(message = "Instead use read returning a future and chain with coAwait()", replaceWith = ReplaceWith("read(buffer, offset, position, length).coAwait()"))
 suspend fun AsyncFile.readAwait(buffer: Buffer, offset: Int, position: Long, length: Int): Buffer {
   return awaitResult {
     this.read(buffer, offset, position, length, it)
@@ -128,7 +128,7 @@ suspend fun AsyncFile.readAwait(buffer: Buffer, offset: Int, position: Long, len
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.file.AsyncFile] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use flush returning a future and chain with await()", replaceWith = ReplaceWith("flush().await()"))
+@Deprecated(message = "Instead use flush returning a future and chain with coAwait()", replaceWith = ReplaceWith("flush().coAwait()"))
 suspend fun AsyncFile.flushAwait(): Unit {
   return awaitResult {
     this.flush(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -142,7 +142,7 @@ suspend fun AsyncFile.flushAwait(): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.file.AsyncFile] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use size returning a future and chain with await()", replaceWith = ReplaceWith("size().await()"))
+@Deprecated(message = "Instead use size returning a future and chain with coAwait()", replaceWith = ReplaceWith("size().coAwait()"))
 suspend fun AsyncFile.sizeAwait(): Long {
   return awaitResult {
     this.size(it)
@@ -156,7 +156,7 @@ suspend fun AsyncFile.sizeAwait(): Long {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.file.AsyncFile] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use lock returning a future and chain with await()", replaceWith = ReplaceWith("lock().await()"))
+@Deprecated(message = "Instead use lock returning a future and chain with coAwait()", replaceWith = ReplaceWith("lock().coAwait()"))
 suspend fun AsyncFile.lockAwait(): AsyncFileLock {
   return awaitResult {
     this.lock(it)
@@ -173,7 +173,7 @@ suspend fun AsyncFile.lockAwait(): AsyncFileLock {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.file.AsyncFile] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use lock returning a future and chain with await()", replaceWith = ReplaceWith("lock(position, size, shared).await()"))
+@Deprecated(message = "Instead use lock returning a future and chain with coAwait()", replaceWith = ReplaceWith("lock(position, size, shared).coAwait()"))
 suspend fun AsyncFile.lockAwait(position: Long, size: Long, shared: Boolean): AsyncFileLock {
   return awaitResult {
     this.lock(position, size, shared, it)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/file/AsyncFileLock.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/file/AsyncFileLock.kt
@@ -25,7 +25,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.file.AsyncFileLock] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use isValid returning a future and chain with await()", replaceWith = ReplaceWith("isValid().await()"))
+@Deprecated(message = "Instead use isValid returning a future and chain with coAwait()", replaceWith = ReplaceWith("isValid().coAwait()"))
 suspend fun AsyncFileLock.isValidAwait(): Boolean {
   return awaitResult {
     this.isValid(it)
@@ -38,7 +38,7 @@ suspend fun AsyncFileLock.isValidAwait(): Boolean {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.file.AsyncFileLock] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use release returning a future and chain with await()", replaceWith = ReplaceWith("release().await()"))
+@Deprecated(message = "Instead use release returning a future and chain with coAwait()", replaceWith = ReplaceWith("release().coAwait()"))
 suspend fun AsyncFileLock.releaseAwait(): Unit {
   return awaitResult {
     this.release(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/file/FileSystem.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/file/FileSystem.kt
@@ -32,7 +32,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use copy returning a future and chain with await()", replaceWith = ReplaceWith("copy(from, to).await()"))
+@Deprecated(message = "Instead use copy returning a future and chain with coAwait()", replaceWith = ReplaceWith("copy(from, to).coAwait()"))
 suspend fun FileSystem.copyAwait(from: String, to: String): Unit {
   return awaitResult {
     this.copy(from, to, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -48,7 +48,7 @@ suspend fun FileSystem.copyAwait(from: String, to: String): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use copy returning a future and chain with await()", replaceWith = ReplaceWith("copy(from, to, options).await()"))
+@Deprecated(message = "Instead use copy returning a future and chain with coAwait()", replaceWith = ReplaceWith("copy(from, to, options).coAwait()"))
 suspend fun FileSystem.copyAwait(from: String, to: String, options: CopyOptions): Unit {
   return awaitResult {
     this.copy(from, to, options, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -64,7 +64,7 @@ suspend fun FileSystem.copyAwait(from: String, to: String, options: CopyOptions)
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use copyRecursive returning a future and chain with await()", replaceWith = ReplaceWith("copyRecursive(from, to, recursive).await()"))
+@Deprecated(message = "Instead use copyRecursive returning a future and chain with coAwait()", replaceWith = ReplaceWith("copyRecursive(from, to, recursive).coAwait()"))
 suspend fun FileSystem.copyRecursiveAwait(from: String, to: String, recursive: Boolean): Unit {
   return awaitResult {
     this.copyRecursive(from, to, recursive, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -79,7 +79,7 @@ suspend fun FileSystem.copyRecursiveAwait(from: String, to: String, recursive: B
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use move returning a future and chain with await()", replaceWith = ReplaceWith("move(from, to).await()"))
+@Deprecated(message = "Instead use move returning a future and chain with coAwait()", replaceWith = ReplaceWith("move(from, to).coAwait()"))
 suspend fun FileSystem.moveAwait(from: String, to: String): Unit {
   return awaitResult {
     this.move(from, to, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -95,7 +95,7 @@ suspend fun FileSystem.moveAwait(from: String, to: String): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use move returning a future and chain with await()", replaceWith = ReplaceWith("move(from, to, options).await()"))
+@Deprecated(message = "Instead use move returning a future and chain with coAwait()", replaceWith = ReplaceWith("move(from, to, options).coAwait()"))
 suspend fun FileSystem.moveAwait(from: String, to: String, options: CopyOptions): Unit {
   return awaitResult {
     this.move(from, to, options, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -110,7 +110,7 @@ suspend fun FileSystem.moveAwait(from: String, to: String, options: CopyOptions)
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use truncate returning a future and chain with await()", replaceWith = ReplaceWith("truncate(path, len).await()"))
+@Deprecated(message = "Instead use truncate returning a future and chain with coAwait()", replaceWith = ReplaceWith("truncate(path, len).coAwait()"))
 suspend fun FileSystem.truncateAwait(path: String, len: Long): Unit {
   return awaitResult {
     this.truncate(path, len, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -125,7 +125,7 @@ suspend fun FileSystem.truncateAwait(path: String, len: Long): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use chmod returning a future and chain with await()", replaceWith = ReplaceWith("chmod(path, perms).await()"))
+@Deprecated(message = "Instead use chmod returning a future and chain with coAwait()", replaceWith = ReplaceWith("chmod(path, perms).coAwait()"))
 suspend fun FileSystem.chmodAwait(path: String, perms: String): Unit {
   return awaitResult {
     this.chmod(path, perms, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -141,7 +141,7 @@ suspend fun FileSystem.chmodAwait(path: String, perms: String): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use chmodRecursive returning a future and chain with await()", replaceWith = ReplaceWith("chmodRecursive(path, perms, dirPerms).await()"))
+@Deprecated(message = "Instead use chmodRecursive returning a future and chain with coAwait()", replaceWith = ReplaceWith("chmodRecursive(path, perms, dirPerms).coAwait()"))
 suspend fun FileSystem.chmodRecursiveAwait(path: String, perms: String, dirPerms: String): Unit {
   return awaitResult {
     this.chmodRecursive(path, perms, dirPerms, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -157,7 +157,7 @@ suspend fun FileSystem.chmodRecursiveAwait(path: String, perms: String, dirPerms
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use chown returning a future and chain with await()", replaceWith = ReplaceWith("chown(path, user, group).await()"))
+@Deprecated(message = "Instead use chown returning a future and chain with coAwait()", replaceWith = ReplaceWith("chown(path, user, group).coAwait()"))
 suspend fun FileSystem.chownAwait(path: String, user: String?, group: String?): Unit {
   return awaitResult {
     this.chown(path, user, group, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -172,7 +172,7 @@ suspend fun FileSystem.chownAwait(path: String, user: String?, group: String?): 
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use props returning a future and chain with await()", replaceWith = ReplaceWith("props(path).await()"))
+@Deprecated(message = "Instead use props returning a future and chain with coAwait()", replaceWith = ReplaceWith("props(path).coAwait()"))
 suspend fun FileSystem.propsAwait(path: String): FileProps {
   return awaitResult {
     this.props(path, it)
@@ -187,7 +187,7 @@ suspend fun FileSystem.propsAwait(path: String): FileProps {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use lprops returning a future and chain with await()", replaceWith = ReplaceWith("lprops(path).await()"))
+@Deprecated(message = "Instead use lprops returning a future and chain with coAwait()", replaceWith = ReplaceWith("lprops(path).coAwait()"))
 suspend fun FileSystem.lpropsAwait(path: String): FileProps {
   return awaitResult {
     this.lprops(path, it)
@@ -202,7 +202,7 @@ suspend fun FileSystem.lpropsAwait(path: String): FileProps {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use link returning a future and chain with await()", replaceWith = ReplaceWith("link(link, existing).await()"))
+@Deprecated(message = "Instead use link returning a future and chain with coAwait()", replaceWith = ReplaceWith("link(link, existing).coAwait()"))
 suspend fun FileSystem.linkAwait(link: String, existing: String): Unit {
   return awaitResult {
     this.link(link, existing, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -217,7 +217,7 @@ suspend fun FileSystem.linkAwait(link: String, existing: String): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use symlink returning a future and chain with await()", replaceWith = ReplaceWith("symlink(link, existing).await()"))
+@Deprecated(message = "Instead use symlink returning a future and chain with coAwait()", replaceWith = ReplaceWith("symlink(link, existing).coAwait()"))
 suspend fun FileSystem.symlinkAwait(link: String, existing: String): Unit {
   return awaitResult {
     this.symlink(link, existing, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -231,7 +231,7 @@ suspend fun FileSystem.symlinkAwait(link: String, existing: String): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use unlink returning a future and chain with await()", replaceWith = ReplaceWith("unlink(link).await()"))
+@Deprecated(message = "Instead use unlink returning a future and chain with coAwait()", replaceWith = ReplaceWith("unlink(link).coAwait()"))
 suspend fun FileSystem.unlinkAwait(link: String): Unit {
   return awaitResult {
     this.unlink(link, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -246,7 +246,7 @@ suspend fun FileSystem.unlinkAwait(link: String): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use readSymlink returning a future and chain with await()", replaceWith = ReplaceWith("readSymlink(link).await()"))
+@Deprecated(message = "Instead use readSymlink returning a future and chain with coAwait()", replaceWith = ReplaceWith("readSymlink(link).coAwait()"))
 suspend fun FileSystem.readSymlinkAwait(link: String): String {
   return awaitResult {
     this.readSymlink(link, it)
@@ -260,7 +260,7 @@ suspend fun FileSystem.readSymlinkAwait(link: String): String {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use delete returning a future and chain with await()", replaceWith = ReplaceWith("delete(path).await()"))
+@Deprecated(message = "Instead use delete returning a future and chain with coAwait()", replaceWith = ReplaceWith("delete(path).coAwait()"))
 suspend fun FileSystem.deleteAwait(path: String): Unit {
   return awaitResult {
     this.delete(path, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -275,7 +275,7 @@ suspend fun FileSystem.deleteAwait(path: String): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use deleteRecursive returning a future and chain with await()", replaceWith = ReplaceWith("deleteRecursive(path, recursive).await()"))
+@Deprecated(message = "Instead use deleteRecursive returning a future and chain with coAwait()", replaceWith = ReplaceWith("deleteRecursive(path, recursive).coAwait()"))
 suspend fun FileSystem.deleteRecursiveAwait(path: String, recursive: Boolean): Unit {
   return awaitResult {
     this.deleteRecursive(path, recursive, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -289,7 +289,7 @@ suspend fun FileSystem.deleteRecursiveAwait(path: String, recursive: Boolean): U
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use mkdir returning a future and chain with await()", replaceWith = ReplaceWith("mkdir(path).await()"))
+@Deprecated(message = "Instead use mkdir returning a future and chain with coAwait()", replaceWith = ReplaceWith("mkdir(path).coAwait()"))
 suspend fun FileSystem.mkdirAwait(path: String): Unit {
   return awaitResult {
     this.mkdir(path, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -304,7 +304,7 @@ suspend fun FileSystem.mkdirAwait(path: String): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use mkdir returning a future and chain with await()", replaceWith = ReplaceWith("mkdir(path, perms).await()"))
+@Deprecated(message = "Instead use mkdir returning a future and chain with coAwait()", replaceWith = ReplaceWith("mkdir(path, perms).coAwait()"))
 suspend fun FileSystem.mkdirAwait(path: String, perms: String): Unit {
   return awaitResult {
     this.mkdir(path, perms, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -318,7 +318,7 @@ suspend fun FileSystem.mkdirAwait(path: String, perms: String): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use mkdirs returning a future and chain with await()", replaceWith = ReplaceWith("mkdirs(path).await()"))
+@Deprecated(message = "Instead use mkdirs returning a future and chain with coAwait()", replaceWith = ReplaceWith("mkdirs(path).coAwait()"))
 suspend fun FileSystem.mkdirsAwait(path: String): Unit {
   return awaitResult {
     this.mkdirs(path, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -333,7 +333,7 @@ suspend fun FileSystem.mkdirsAwait(path: String): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use mkdirs returning a future and chain with await()", replaceWith = ReplaceWith("mkdirs(path, perms).await()"))
+@Deprecated(message = "Instead use mkdirs returning a future and chain with coAwait()", replaceWith = ReplaceWith("mkdirs(path, perms).coAwait()"))
 suspend fun FileSystem.mkdirsAwait(path: String, perms: String): Unit {
   return awaitResult {
     this.mkdirs(path, perms, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -348,7 +348,7 @@ suspend fun FileSystem.mkdirsAwait(path: String, perms: String): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use readDir returning a future and chain with await()", replaceWith = ReplaceWith("readDir(path).await()"))
+@Deprecated(message = "Instead use readDir returning a future and chain with coAwait()", replaceWith = ReplaceWith("readDir(path).coAwait()"))
 suspend fun FileSystem.readDirAwait(path: String): List<String> {
   return awaitResult {
     this.readDir(path, it)
@@ -364,7 +364,7 @@ suspend fun FileSystem.readDirAwait(path: String): List<String> {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use readDir returning a future and chain with await()", replaceWith = ReplaceWith("readDir(path, filter).await()"))
+@Deprecated(message = "Instead use readDir returning a future and chain with coAwait()", replaceWith = ReplaceWith("readDir(path, filter).coAwait()"))
 suspend fun FileSystem.readDirAwait(path: String, filter: String): List<String> {
   return awaitResult {
     this.readDir(path, filter, it)
@@ -379,7 +379,7 @@ suspend fun FileSystem.readDirAwait(path: String, filter: String): List<String> 
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use readFile returning a future and chain with await()", replaceWith = ReplaceWith("readFile(path).await()"))
+@Deprecated(message = "Instead use readFile returning a future and chain with coAwait()", replaceWith = ReplaceWith("readFile(path).coAwait()"))
 suspend fun FileSystem.readFileAwait(path: String): Buffer {
   return awaitResult {
     this.readFile(path, it)
@@ -394,7 +394,7 @@ suspend fun FileSystem.readFileAwait(path: String): Buffer {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use writeFile returning a future and chain with await()", replaceWith = ReplaceWith("writeFile(path, data).await()"))
+@Deprecated(message = "Instead use writeFile returning a future and chain with coAwait()", replaceWith = ReplaceWith("writeFile(path, data).coAwait()"))
 suspend fun FileSystem.writeFileAwait(path: String, data: Buffer): Unit {
   return awaitResult {
     this.writeFile(path, data, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -410,7 +410,7 @@ suspend fun FileSystem.writeFileAwait(path: String, data: Buffer): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use open returning a future and chain with await()", replaceWith = ReplaceWith("open(path, options).await()"))
+@Deprecated(message = "Instead use open returning a future and chain with coAwait()", replaceWith = ReplaceWith("open(path, options).coAwait()"))
 suspend fun FileSystem.openAwait(path: String, options: OpenOptions): AsyncFile {
   return awaitResult {
     this.open(path, options, it)
@@ -424,7 +424,7 @@ suspend fun FileSystem.openAwait(path: String, options: OpenOptions): AsyncFile 
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use createFile returning a future and chain with await()", replaceWith = ReplaceWith("createFile(path).await()"))
+@Deprecated(message = "Instead use createFile returning a future and chain with coAwait()", replaceWith = ReplaceWith("createFile(path).coAwait()"))
 suspend fun FileSystem.createFileAwait(path: String): Unit {
   return awaitResult {
     this.createFile(path, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -439,7 +439,7 @@ suspend fun FileSystem.createFileAwait(path: String): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use createFile returning a future and chain with await()", replaceWith = ReplaceWith("createFile(path, perms).await()"))
+@Deprecated(message = "Instead use createFile returning a future and chain with coAwait()", replaceWith = ReplaceWith("createFile(path, perms).coAwait()"))
 suspend fun FileSystem.createFileAwait(path: String, perms: String): Unit {
   return awaitResult {
     this.createFile(path, perms, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -454,7 +454,7 @@ suspend fun FileSystem.createFileAwait(path: String, perms: String): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use exists returning a future and chain with await()", replaceWith = ReplaceWith("exists(path).await()"))
+@Deprecated(message = "Instead use exists returning a future and chain with coAwait()", replaceWith = ReplaceWith("exists(path).coAwait()"))
 suspend fun FileSystem.existsAwait(path: String): Boolean {
   return awaitResult {
     this.exists(path, it)
@@ -469,7 +469,7 @@ suspend fun FileSystem.existsAwait(path: String): Boolean {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use fsProps returning a future and chain with await()", replaceWith = ReplaceWith("fsProps(path).await()"))
+@Deprecated(message = "Instead use fsProps returning a future and chain with coAwait()", replaceWith = ReplaceWith("fsProps(path).coAwait()"))
 suspend fun FileSystem.fsPropsAwait(path: String): FileSystemProps {
   return awaitResult {
     this.fsProps(path, it)
@@ -484,7 +484,7 @@ suspend fun FileSystem.fsPropsAwait(path: String): FileSystemProps {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use createTempDirectory returning a future and chain with await()", replaceWith = ReplaceWith("createTempDirectory(prefix).await()"))
+@Deprecated(message = "Instead use createTempDirectory returning a future and chain with coAwait()", replaceWith = ReplaceWith("createTempDirectory(prefix).coAwait()"))
 suspend fun FileSystem.createTempDirectoryAwait(prefix: String): String {
   return awaitResult {
     this.createTempDirectory(prefix, it)
@@ -500,7 +500,7 @@ suspend fun FileSystem.createTempDirectoryAwait(prefix: String): String {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use createTempDirectory returning a future and chain with await()", replaceWith = ReplaceWith("createTempDirectory(prefix, perms).await()"))
+@Deprecated(message = "Instead use createTempDirectory returning a future and chain with coAwait()", replaceWith = ReplaceWith("createTempDirectory(prefix, perms).coAwait()"))
 suspend fun FileSystem.createTempDirectoryAwait(prefix: String, perms: String): String {
   return awaitResult {
     this.createTempDirectory(prefix, perms, it)
@@ -517,7 +517,7 @@ suspend fun FileSystem.createTempDirectoryAwait(prefix: String, perms: String): 
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use createTempDirectory returning a future and chain with await()", replaceWith = ReplaceWith("createTempDirectory(dir, prefix, perms).await()"))
+@Deprecated(message = "Instead use createTempDirectory returning a future and chain with coAwait()", replaceWith = ReplaceWith("createTempDirectory(dir, prefix, perms).coAwait()"))
 suspend fun FileSystem.createTempDirectoryAwait(dir: String, prefix: String, perms: String): String {
   return awaitResult {
     this.createTempDirectory(dir, prefix, perms, it)
@@ -533,7 +533,7 @@ suspend fun FileSystem.createTempDirectoryAwait(dir: String, prefix: String, per
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use createTempFile returning a future and chain with await()", replaceWith = ReplaceWith("createTempFile(prefix, suffix).await()"))
+@Deprecated(message = "Instead use createTempFile returning a future and chain with coAwait()", replaceWith = ReplaceWith("createTempFile(prefix, suffix).coAwait()"))
 suspend fun FileSystem.createTempFileAwait(prefix: String, suffix: String): String {
   return awaitResult {
     this.createTempFile(prefix, suffix, it)
@@ -550,7 +550,7 @@ suspend fun FileSystem.createTempFileAwait(prefix: String, suffix: String): Stri
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use createTempFile returning a future and chain with await()", replaceWith = ReplaceWith("createTempFile(prefix, suffix, perms).await()"))
+@Deprecated(message = "Instead use createTempFile returning a future and chain with coAwait()", replaceWith = ReplaceWith("createTempFile(prefix, suffix, perms).coAwait()"))
 suspend fun FileSystem.createTempFileAwait(prefix: String, suffix: String, perms: String): String {
   return awaitResult {
     this.createTempFile(prefix, suffix, perms, it)
@@ -568,7 +568,7 @@ suspend fun FileSystem.createTempFileAwait(prefix: String, suffix: String, perms
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.file.FileSystem] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use createTempFile returning a future and chain with await()", replaceWith = ReplaceWith("createTempFile(dir, prefix, suffix, perms).await()"))
+@Deprecated(message = "Instead use createTempFile returning a future and chain with coAwait()", replaceWith = ReplaceWith("createTempFile(dir, prefix, suffix, perms).coAwait()"))
 suspend fun FileSystem.createTempFileAwait(dir: String, prefix: String, suffix: String, perms: String): String {
   return awaitResult {
     this.createTempFile(dir, prefix, suffix, perms, it)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/http/ClientWebSocket.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/http/ClientWebSocket.kt
@@ -30,7 +30,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.ClientWebSocket] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use write returning a future and chain with await()", replaceWith = ReplaceWith("write(data).await()"))
+@Deprecated(message = "Instead use write returning a future and chain with coAwait()", replaceWith = ReplaceWith("write(data).coAwait()"))
 suspend fun ClientWebSocket.writeAwait(data: Buffer): Unit {
   return awaitResult {
     this.write(data, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -44,7 +44,7 @@ suspend fun ClientWebSocket.writeAwait(data: Buffer): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.ClientWebSocket] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use end returning a future and chain with await()", replaceWith = ReplaceWith("end(data).await()"))
+@Deprecated(message = "Instead use end returning a future and chain with coAwait()", replaceWith = ReplaceWith("end(data).coAwait()"))
 suspend fun ClientWebSocket.endAwait(data: Buffer): Unit {
   return awaitResult {
     this.end(data, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -58,7 +58,7 @@ suspend fun ClientWebSocket.endAwait(data: Buffer): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.ClientWebSocket] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use pipeTo returning a future and chain with await()", replaceWith = ReplaceWith("pipeTo(dst).await()"))
+@Deprecated(message = "Instead use pipeTo returning a future and chain with coAwait()", replaceWith = ReplaceWith("pipeTo(dst).coAwait()"))
 suspend fun ClientWebSocket.pipeToAwait(dst: WriteStream<Buffer>): Unit {
   return awaitResult {
     this.pipeTo(dst, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -71,7 +71,7 @@ suspend fun ClientWebSocket.pipeToAwait(dst: WriteStream<Buffer>): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.ClientWebSocket] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use end returning a future and chain with await()", replaceWith = ReplaceWith("end().await()"))
+@Deprecated(message = "Instead use end returning a future and chain with coAwait()", replaceWith = ReplaceWith("end().coAwait()"))
 suspend fun ClientWebSocket.endAwait(): Unit {
   return awaitResult {
     this.end(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -84,7 +84,7 @@ suspend fun ClientWebSocket.endAwait(): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.ClientWebSocket] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use close returning a future and chain with await()", replaceWith = ReplaceWith("close().await()"))
+@Deprecated(message = "Instead use close returning a future and chain with coAwait()", replaceWith = ReplaceWith("close().coAwait()"))
 suspend fun ClientWebSocket.closeAwait(): Unit {
   return awaitResult {
     this.close(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -98,7 +98,7 @@ suspend fun ClientWebSocket.closeAwait(): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.ClientWebSocket] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use close returning a future and chain with await()", replaceWith = ReplaceWith("close(statusCode).await()"))
+@Deprecated(message = "Instead use close returning a future and chain with coAwait()", replaceWith = ReplaceWith("close(statusCode).coAwait()"))
 suspend fun ClientWebSocket.closeAwait(statusCode: Short): Unit {
   return awaitResult {
     this.close(statusCode, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -113,7 +113,7 @@ suspend fun ClientWebSocket.closeAwait(statusCode: Short): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.ClientWebSocket] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use close returning a future and chain with await()", replaceWith = ReplaceWith("close(statusCode, reason).await()"))
+@Deprecated(message = "Instead use close returning a future and chain with coAwait()", replaceWith = ReplaceWith("close(statusCode, reason).coAwait()"))
 suspend fun ClientWebSocket.closeAwait(statusCode: Short, reason: String?): Unit {
   return awaitResult {
     this.close(statusCode, reason, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -130,7 +130,7 @@ suspend fun ClientWebSocket.closeAwait(statusCode: Short, reason: String?): Unit
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.ClientWebSocket] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use connect returning a future and chain with await()", replaceWith = ReplaceWith("connect(port, host, requestURI).await()"))
+@Deprecated(message = "Instead use connect returning a future and chain with coAwait()", replaceWith = ReplaceWith("connect(port, host, requestURI).coAwait()"))
 suspend fun ClientWebSocket.connectAwait(port: Int, host: String, requestURI: String): WebSocket {
   return awaitResult {
     this.connect(port, host, requestURI, it)
@@ -145,7 +145,7 @@ suspend fun ClientWebSocket.connectAwait(port: Int, host: String, requestURI: St
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.ClientWebSocket] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use connect returning a future and chain with await()", replaceWith = ReplaceWith("connect(options).await()"))
+@Deprecated(message = "Instead use connect returning a future and chain with coAwait()", replaceWith = ReplaceWith("connect(options).coAwait()"))
 suspend fun ClientWebSocket.connectAwait(options: WebSocketConnectOptions): WebSocket {
   return awaitResult {
     this.connect(options, it)
@@ -161,7 +161,7 @@ suspend fun ClientWebSocket.connectAwait(options: WebSocketConnectOptions): WebS
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.ClientWebSocket] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use connect returning a future and chain with await()", replaceWith = ReplaceWith("connect(host, requestURI).await()"))
+@Deprecated(message = "Instead use connect returning a future and chain with coAwait()", replaceWith = ReplaceWith("connect(host, requestURI).coAwait()"))
 suspend fun ClientWebSocket.connectAwait(host: String, requestURI: String): WebSocket {
   return awaitResult {
     this.connect(host, requestURI, it)
@@ -176,56 +176,56 @@ suspend fun ClientWebSocket.connectAwait(host: String, requestURI: String): WebS
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.ClientWebSocket] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use connect returning a future and chain with await()", replaceWith = ReplaceWith("connect(requestURI).await()"))
+@Deprecated(message = "Instead use connect returning a future and chain with coAwait()", replaceWith = ReplaceWith("connect(requestURI).coAwait()"))
 suspend fun ClientWebSocket.connectAwait(requestURI: String): WebSocket {
   return awaitResult {
     this.connect(requestURI, it)
   }
 }
 
-@Deprecated(message = "Instead use writeFrame returning a future and chain with await()", replaceWith = ReplaceWith("writeFrame(frame).await()"))
+@Deprecated(message = "Instead use writeFrame returning a future and chain with coAwait()", replaceWith = ReplaceWith("writeFrame(frame).coAwait()"))
 suspend fun ClientWebSocket.writeFrameAwait(frame: WebSocketFrame): Unit {
   return awaitResult {
     this.writeFrame(frame, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
   }
 }
 
-@Deprecated(message = "Instead use writeFinalTextFrame returning a future and chain with await()", replaceWith = ReplaceWith("writeFinalTextFrame(text).await()"))
+@Deprecated(message = "Instead use writeFinalTextFrame returning a future and chain with coAwait()", replaceWith = ReplaceWith("writeFinalTextFrame(text).coAwait()"))
 suspend fun ClientWebSocket.writeFinalTextFrameAwait(text: String): Unit {
   return awaitResult {
     this.writeFinalTextFrame(text, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
   }
 }
 
-@Deprecated(message = "Instead use writeFinalBinaryFrame returning a future and chain with await()", replaceWith = ReplaceWith("writeFinalBinaryFrame(data).await()"))
+@Deprecated(message = "Instead use writeFinalBinaryFrame returning a future and chain with coAwait()", replaceWith = ReplaceWith("writeFinalBinaryFrame(data).coAwait()"))
 suspend fun ClientWebSocket.writeFinalBinaryFrameAwait(data: Buffer): Unit {
   return awaitResult {
     this.writeFinalBinaryFrame(data, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
   }
 }
 
-@Deprecated(message = "Instead use writeBinaryMessage returning a future and chain with await()", replaceWith = ReplaceWith("writeBinaryMessage(data).await()"))
+@Deprecated(message = "Instead use writeBinaryMessage returning a future and chain with coAwait()", replaceWith = ReplaceWith("writeBinaryMessage(data).coAwait()"))
 suspend fun ClientWebSocket.writeBinaryMessageAwait(data: Buffer): Unit {
   return awaitResult {
     this.writeBinaryMessage(data, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
   }
 }
 
-@Deprecated(message = "Instead use writeTextMessage returning a future and chain with await()", replaceWith = ReplaceWith("writeTextMessage(text).await()"))
+@Deprecated(message = "Instead use writeTextMessage returning a future and chain with coAwait()", replaceWith = ReplaceWith("writeTextMessage(text).coAwait()"))
 suspend fun ClientWebSocket.writeTextMessageAwait(text: String): Unit {
   return awaitResult {
     this.writeTextMessage(text, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
   }
 }
 
-@Deprecated(message = "Instead use writePing returning a future and chain with await()", replaceWith = ReplaceWith("writePing(data).await()"))
+@Deprecated(message = "Instead use writePing returning a future and chain with coAwait()", replaceWith = ReplaceWith("writePing(data).coAwait()"))
 suspend fun ClientWebSocket.writePingAwait(data: Buffer): Unit {
   return awaitResult {
     this.writePing(data, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
   }
 }
 
-@Deprecated(message = "Instead use writePong returning a future and chain with await()", replaceWith = ReplaceWith("writePong(data).await()"))
+@Deprecated(message = "Instead use writePong returning a future and chain with coAwait()", replaceWith = ReplaceWith("writePong(data).coAwait()"))
 suspend fun ClientWebSocket.writePongAwait(data: Buffer): Unit {
   return awaitResult {
     this.writePong(data, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/http/HttpClient.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/http/HttpClient.kt
@@ -30,7 +30,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use request returning a future and chain with await()", replaceWith = ReplaceWith("request(options).await()"))
+@Deprecated(message = "Instead use request returning a future and chain with coAwait()", replaceWith = ReplaceWith("request(options).coAwait()"))
 suspend fun HttpClient.requestAwait(options: RequestOptions): HttpClientRequest {
   return awaitResult {
     this.request(options, it)
@@ -48,7 +48,7 @@ suspend fun HttpClient.requestAwait(options: RequestOptions): HttpClientRequest 
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use request returning a future and chain with await()", replaceWith = ReplaceWith("request(method, port, host, requestURI).await()"))
+@Deprecated(message = "Instead use request returning a future and chain with coAwait()", replaceWith = ReplaceWith("request(method, port, host, requestURI).coAwait()"))
 suspend fun HttpClient.requestAwait(method: HttpMethod, port: Int, host: String, requestURI: String): HttpClientRequest {
   return awaitResult {
     this.request(method, port, host, requestURI, it)
@@ -65,7 +65,7 @@ suspend fun HttpClient.requestAwait(method: HttpMethod, port: Int, host: String,
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use request returning a future and chain with await()", replaceWith = ReplaceWith("request(method, host, requestURI).await()"))
+@Deprecated(message = "Instead use request returning a future and chain with coAwait()", replaceWith = ReplaceWith("request(method, host, requestURI).coAwait()"))
 suspend fun HttpClient.requestAwait(method: HttpMethod, host: String, requestURI: String): HttpClientRequest {
   return awaitResult {
     this.request(method, host, requestURI, it)
@@ -81,7 +81,7 @@ suspend fun HttpClient.requestAwait(method: HttpMethod, host: String, requestURI
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use request returning a future and chain with await()", replaceWith = ReplaceWith("request(method, requestURI).await()"))
+@Deprecated(message = "Instead use request returning a future and chain with coAwait()", replaceWith = ReplaceWith("request(method, requestURI).coAwait()"))
 suspend fun HttpClient.requestAwait(method: HttpMethod, requestURI: String): HttpClientRequest {
   return awaitResult {
     this.request(method, requestURI, it)
@@ -96,7 +96,7 @@ suspend fun HttpClient.requestAwait(method: HttpMethod, requestURI: String): Htt
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use updateSSLOptions returning a future and chain with await()", replaceWith = ReplaceWith("updateSSLOptions(options).await()"))
+@Deprecated(message = "Instead use updateSSLOptions returning a future and chain with coAwait()", replaceWith = ReplaceWith("updateSSLOptions(options).coAwait()"))
 suspend fun HttpClient.updateSSLOptionsAwait(options: SSLOptions): Boolean {
   return awaitResult {
     this.updateSSLOptions(options, it)
@@ -112,7 +112,7 @@ suspend fun HttpClient.updateSSLOptionsAwait(options: SSLOptions): Boolean {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use updateSSLOptions returning a future and chain with await()", replaceWith = ReplaceWith("updateSSLOptions(options, force).await()"))
+@Deprecated(message = "Instead use updateSSLOptions returning a future and chain with coAwait()", replaceWith = ReplaceWith("updateSSLOptions(options, force).coAwait()"))
 suspend fun HttpClient.updateSSLOptionsAwait(options: SSLOptions, force: Boolean): Boolean {
   return awaitResult {
     this.updateSSLOptions(options, force, it)
@@ -125,7 +125,7 @@ suspend fun HttpClient.updateSSLOptionsAwait(options: SSLOptions, force: Boolean
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use close returning a future and chain with await()", replaceWith = ReplaceWith("close().await()"))
+@Deprecated(message = "Instead use close returning a future and chain with coAwait()", replaceWith = ReplaceWith("close().coAwait()"))
 suspend fun HttpClient.closeAwait(): Unit {
   return awaitResult {
     this.close(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/http/HttpClientRequest.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/http/HttpClientRequest.kt
@@ -28,7 +28,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpClientRequest] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use write returning a future and chain with await()", replaceWith = ReplaceWith("write(data).await()"))
+@Deprecated(message = "Instead use write returning a future and chain with coAwait()", replaceWith = ReplaceWith("write(data).coAwait()"))
 suspend fun HttpClientRequest.writeAwait(data: Buffer): Unit {
   return awaitResult {
     this.write(data, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -42,7 +42,7 @@ suspend fun HttpClientRequest.writeAwait(data: Buffer): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpClientRequest] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use write returning a future and chain with await()", replaceWith = ReplaceWith("write(chunk).await()"))
+@Deprecated(message = "Instead use write returning a future and chain with coAwait()", replaceWith = ReplaceWith("write(chunk).coAwait()"))
 suspend fun HttpClientRequest.writeAwait(chunk: String): Unit {
   return awaitResult {
     this.write(chunk, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -57,7 +57,7 @@ suspend fun HttpClientRequest.writeAwait(chunk: String): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpClientRequest] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use write returning a future and chain with await()", replaceWith = ReplaceWith("write(chunk, enc).await()"))
+@Deprecated(message = "Instead use write returning a future and chain with coAwait()", replaceWith = ReplaceWith("write(chunk, enc).coAwait()"))
 suspend fun HttpClientRequest.writeAwait(chunk: String, enc: String): Unit {
   return awaitResult {
     this.write(chunk, enc, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -70,7 +70,7 @@ suspend fun HttpClientRequest.writeAwait(chunk: String, enc: String): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpClientRequest] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use sendHead returning a future and chain with await()", replaceWith = ReplaceWith("sendHead().await()"))
+@Deprecated(message = "Instead use sendHead returning a future and chain with coAwait()", replaceWith = ReplaceWith("sendHead().coAwait()"))
 suspend fun HttpClientRequest.sendHeadAwait(): Unit {
   return awaitResult {
     this.sendHead(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -84,7 +84,7 @@ suspend fun HttpClientRequest.sendHeadAwait(): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpClientRequest] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use connect returning a future and chain with await()", replaceWith = ReplaceWith("connect().await()"))
+@Deprecated(message = "Instead use connect returning a future and chain with coAwait()", replaceWith = ReplaceWith("connect().coAwait()"))
 suspend fun HttpClientRequest.connectAwait(): HttpClientResponse {
   return awaitResult {
     this.connect(it)
@@ -98,7 +98,7 @@ suspend fun HttpClientRequest.connectAwait(): HttpClientResponse {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpClientRequest] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use response returning a future and chain with await()", replaceWith = ReplaceWith("response().await()"))
+@Deprecated(message = "Instead use response returning a future and chain with coAwait()", replaceWith = ReplaceWith("response().coAwait()"))
 suspend fun HttpClientRequest.responseAwait(): HttpClientResponse {
   return awaitResult {
     this.response(it)
@@ -112,7 +112,7 @@ suspend fun HttpClientRequest.responseAwait(): HttpClientResponse {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpClientRequest] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use send returning a future and chain with await()", replaceWith = ReplaceWith("send().await()"))
+@Deprecated(message = "Instead use send returning a future and chain with coAwait()", replaceWith = ReplaceWith("send().coAwait()"))
 suspend fun HttpClientRequest.sendAwait(): HttpClientResponse {
   return awaitResult {
     this.send(it)
@@ -127,7 +127,7 @@ suspend fun HttpClientRequest.sendAwait(): HttpClientResponse {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpClientRequest] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use send returning a future and chain with await()", replaceWith = ReplaceWith("send(body).await()"))
+@Deprecated(message = "Instead use send returning a future and chain with coAwait()", replaceWith = ReplaceWith("send(body).coAwait()"))
 suspend fun HttpClientRequest.sendAwait(body: String): HttpClientResponse {
   return awaitResult {
     this.send(body, it)
@@ -142,7 +142,7 @@ suspend fun HttpClientRequest.sendAwait(body: String): HttpClientResponse {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpClientRequest] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use send returning a future and chain with await()", replaceWith = ReplaceWith("send(body).await()"))
+@Deprecated(message = "Instead use send returning a future and chain with coAwait()", replaceWith = ReplaceWith("send(body).coAwait()"))
 suspend fun HttpClientRequest.sendAwait(body: Buffer): HttpClientResponse {
   return awaitResult {
     this.send(body, it)
@@ -157,7 +157,7 @@ suspend fun HttpClientRequest.sendAwait(body: Buffer): HttpClientResponse {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpClientRequest] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use send returning a future and chain with await()", replaceWith = ReplaceWith("send(body).await()"))
+@Deprecated(message = "Instead use send returning a future and chain with coAwait()", replaceWith = ReplaceWith("send(body).coAwait()"))
 suspend fun HttpClientRequest.sendAwait(body: ReadStream<Buffer>): HttpClientResponse {
   return awaitResult {
     this.send(body, it)
@@ -171,7 +171,7 @@ suspend fun HttpClientRequest.sendAwait(body: ReadStream<Buffer>): HttpClientRes
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpClientRequest] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use end returning a future and chain with await()", replaceWith = ReplaceWith("end(chunk).await()"))
+@Deprecated(message = "Instead use end returning a future and chain with coAwait()", replaceWith = ReplaceWith("end(chunk).coAwait()"))
 suspend fun HttpClientRequest.endAwait(chunk: String): Unit {
   return awaitResult {
     this.end(chunk, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -186,7 +186,7 @@ suspend fun HttpClientRequest.endAwait(chunk: String): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpClientRequest] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use end returning a future and chain with await()", replaceWith = ReplaceWith("end(chunk, enc).await()"))
+@Deprecated(message = "Instead use end returning a future and chain with coAwait()", replaceWith = ReplaceWith("end(chunk, enc).coAwait()"))
 suspend fun HttpClientRequest.endAwait(chunk: String, enc: String): Unit {
   return awaitResult {
     this.end(chunk, enc, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -200,7 +200,7 @@ suspend fun HttpClientRequest.endAwait(chunk: String, enc: String): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpClientRequest] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use end returning a future and chain with await()", replaceWith = ReplaceWith("end(chunk).await()"))
+@Deprecated(message = "Instead use end returning a future and chain with coAwait()", replaceWith = ReplaceWith("end(chunk).coAwait()"))
 suspend fun HttpClientRequest.endAwait(chunk: Buffer): Unit {
   return awaitResult {
     this.end(chunk, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -213,7 +213,7 @@ suspend fun HttpClientRequest.endAwait(chunk: Buffer): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpClientRequest] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use end returning a future and chain with await()", replaceWith = ReplaceWith("end().await()"))
+@Deprecated(message = "Instead use end returning a future and chain with coAwait()", replaceWith = ReplaceWith("end().coAwait()"))
 suspend fun HttpClientRequest.endAwait(): Unit {
   return awaitResult {
     this.end(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/http/HttpClientResponse.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/http/HttpClientResponse.kt
@@ -27,7 +27,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpClientResponse] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use pipeTo returning a future and chain with await()", replaceWith = ReplaceWith("pipeTo(dst).await()"))
+@Deprecated(message = "Instead use pipeTo returning a future and chain with coAwait()", replaceWith = ReplaceWith("pipeTo(dst).coAwait()"))
 suspend fun HttpClientResponse.pipeToAwait(dst: WriteStream<Buffer>): Unit {
   return awaitResult {
     this.pipeTo(dst, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -41,7 +41,7 @@ suspend fun HttpClientResponse.pipeToAwait(dst: WriteStream<Buffer>): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpClientResponse] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use body returning a future and chain with await()", replaceWith = ReplaceWith("body().await()"))
+@Deprecated(message = "Instead use body returning a future and chain with coAwait()", replaceWith = ReplaceWith("body().coAwait()"))
 suspend fun HttpClientResponse.bodyAwait(): Buffer {
   return awaitResult {
     this.body(it)
@@ -54,7 +54,7 @@ suspend fun HttpClientResponse.bodyAwait(): Buffer {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpClientResponse] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use end returning a future and chain with await()", replaceWith = ReplaceWith("end().await()"))
+@Deprecated(message = "Instead use end returning a future and chain with coAwait()", replaceWith = ReplaceWith("end().coAwait()"))
 suspend fun HttpClientResponse.endAwait(): Unit {
   return awaitResult {
     this.end(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/http/HttpConnection.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/http/HttpConnection.kt
@@ -27,7 +27,7 @@ import java.util.concurrent.TimeUnit
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use shutdown returning a future and chain with await()", replaceWith = ReplaceWith("shutdown().await()"))
+@Deprecated(message = "Instead use shutdown returning a future and chain with coAwait()", replaceWith = ReplaceWith("shutdown().coAwait()"))
 suspend fun HttpConnection.shutdownAwait(): Unit {
   return awaitResult {
     this.shutdown(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -42,7 +42,7 @@ suspend fun HttpConnection.shutdownAwait(): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use shutdown returning a future and chain with await()", replaceWith = ReplaceWith("shutdown(timeout, unit).await()"))
+@Deprecated(message = "Instead use shutdown returning a future and chain with coAwait()", replaceWith = ReplaceWith("shutdown(timeout, unit).coAwait()"))
 suspend fun HttpConnection.shutdownAwait(timeout: Long, unit: TimeUnit): Unit {
   return awaitResult {
     this.shutdown(timeout, unit, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -55,7 +55,7 @@ suspend fun HttpConnection.shutdownAwait(timeout: Long, unit: TimeUnit): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use close returning a future and chain with await()", replaceWith = ReplaceWith("close().await()"))
+@Deprecated(message = "Instead use close returning a future and chain with coAwait()", replaceWith = ReplaceWith("close().coAwait()"))
 suspend fun HttpConnection.closeAwait(): Unit {
   return awaitResult {
     this.close(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -69,7 +69,7 @@ suspend fun HttpConnection.closeAwait(): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use updateSettings returning a future and chain with await()", replaceWith = ReplaceWith("updateSettings(settings).await()"))
+@Deprecated(message = "Instead use updateSettings returning a future and chain with coAwait()", replaceWith = ReplaceWith("updateSettings(settings).coAwait()"))
 suspend fun HttpConnection.updateSettingsAwait(settings: Http2Settings): Unit {
   return awaitResult {
     this.updateSettings(settings, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -84,7 +84,7 @@ suspend fun HttpConnection.updateSettingsAwait(settings: Http2Settings): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use ping returning a future and chain with await()", replaceWith = ReplaceWith("ping(data).await()"))
+@Deprecated(message = "Instead use ping returning a future and chain with coAwait()", replaceWith = ReplaceWith("ping(data).coAwait()"))
 suspend fun HttpConnection.pingAwait(data: Buffer): Buffer {
   return awaitResult {
     this.ping(data, it)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/http/HttpServer.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/http/HttpServer.kt
@@ -28,7 +28,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpServer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use updateSSLOptions returning a future and chain with await()", replaceWith = ReplaceWith("updateSSLOptions(options).await()"))
+@Deprecated(message = "Instead use updateSSLOptions returning a future and chain with coAwait()", replaceWith = ReplaceWith("updateSSLOptions(options).coAwait()"))
 suspend fun HttpServer.updateSSLOptionsAwait(options: SSLOptions): Boolean {
   return awaitResult {
     this.updateSSLOptions(options, it)
@@ -44,7 +44,7 @@ suspend fun HttpServer.updateSSLOptionsAwait(options: SSLOptions): Boolean {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpServer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use updateSSLOptions returning a future and chain with await()", replaceWith = ReplaceWith("updateSSLOptions(options, force).await()"))
+@Deprecated(message = "Instead use updateSSLOptions returning a future and chain with coAwait()", replaceWith = ReplaceWith("updateSSLOptions(options, force).coAwait()"))
 suspend fun HttpServer.updateSSLOptionsAwait(options: SSLOptions, force: Boolean): Boolean {
   return awaitResult {
     this.updateSSLOptions(options, force, it)
@@ -60,7 +60,7 @@ suspend fun HttpServer.updateSSLOptionsAwait(options: SSLOptions, force: Boolean
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpServer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use listen returning a future and chain with await()", replaceWith = ReplaceWith("listen(port, host).await()"))
+@Deprecated(message = "Instead use listen returning a future and chain with coAwait()", replaceWith = ReplaceWith("listen(port, host).coAwait()"))
 suspend fun HttpServer.listenAwait(port: Int, host: String): HttpServer {
   return awaitResult {
     this.listen(port, host, it)
@@ -75,7 +75,7 @@ suspend fun HttpServer.listenAwait(port: Int, host: String): HttpServer {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpServer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use listen returning a future and chain with await()", replaceWith = ReplaceWith("listen(address).await()"))
+@Deprecated(message = "Instead use listen returning a future and chain with coAwait()", replaceWith = ReplaceWith("listen(address).coAwait()"))
 suspend fun HttpServer.listenAwait(address: SocketAddress): HttpServer {
   return awaitResult {
     this.listen(address, it)
@@ -90,7 +90,7 @@ suspend fun HttpServer.listenAwait(address: SocketAddress): HttpServer {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpServer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use listen returning a future and chain with await()", replaceWith = ReplaceWith("listen(port).await()"))
+@Deprecated(message = "Instead use listen returning a future and chain with coAwait()", replaceWith = ReplaceWith("listen(port).coAwait()"))
 suspend fun HttpServer.listenAwait(port: Int): HttpServer {
   return awaitResult {
     this.listen(port, it)
@@ -104,7 +104,7 @@ suspend fun HttpServer.listenAwait(port: Int): HttpServer {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpServer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use listen returning a future and chain with await()", replaceWith = ReplaceWith("listen().await()"))
+@Deprecated(message = "Instead use listen returning a future and chain with coAwait()", replaceWith = ReplaceWith("listen().coAwait()"))
 suspend fun HttpServer.listenAwait(): HttpServer {
   return awaitResult {
     this.listen(it)
@@ -117,7 +117,7 @@ suspend fun HttpServer.listenAwait(): HttpServer {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpServer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use close returning a future and chain with await()", replaceWith = ReplaceWith("close().await()"))
+@Deprecated(message = "Instead use close returning a future and chain with coAwait()", replaceWith = ReplaceWith("close().coAwait()"))
 suspend fun HttpServer.closeAwait(): Unit {
   return awaitResult {
     this.close(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/http/HttpServerFileUpload.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/http/HttpServerFileUpload.kt
@@ -27,7 +27,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpServerFileUpload] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use pipeTo returning a future and chain with await()", replaceWith = ReplaceWith("pipeTo(dst).await()"))
+@Deprecated(message = "Instead use pipeTo returning a future and chain with coAwait()", replaceWith = ReplaceWith("pipeTo(dst).coAwait()"))
 suspend fun HttpServerFileUpload.pipeToAwait(dst: WriteStream<Buffer>): Unit {
   return awaitResult {
     this.pipeTo(dst, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -41,7 +41,7 @@ suspend fun HttpServerFileUpload.pipeToAwait(dst: WriteStream<Buffer>): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpServerFileUpload] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use streamToFileSystem returning a future and chain with await()", replaceWith = ReplaceWith("streamToFileSystem(filename).await()"))
+@Deprecated(message = "Instead use streamToFileSystem returning a future and chain with coAwait()", replaceWith = ReplaceWith("streamToFileSystem(filename).coAwait()"))
 suspend fun HttpServerFileUpload.streamToFileSystemAwait(filename: String): Unit {
   return awaitResult {
     this.streamToFileSystem(filename, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/http/HttpServerRequest.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/http/HttpServerRequest.kt
@@ -29,7 +29,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpServerRequest] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use pipeTo returning a future and chain with await()", replaceWith = ReplaceWith("pipeTo(dst).await()"))
+@Deprecated(message = "Instead use pipeTo returning a future and chain with coAwait()", replaceWith = ReplaceWith("pipeTo(dst).coAwait()"))
 suspend fun HttpServerRequest.pipeToAwait(dst: WriteStream<Buffer>): Unit {
   return awaitResult {
     this.pipeTo(dst, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -42,7 +42,7 @@ suspend fun HttpServerRequest.pipeToAwait(dst: WriteStream<Buffer>): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpServerRequest] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use end returning a future and chain with await()", replaceWith = ReplaceWith("end().await()"))
+@Deprecated(message = "Instead use end returning a future and chain with coAwait()", replaceWith = ReplaceWith("end().coAwait()"))
 suspend fun HttpServerRequest.endAwait(): Unit {
   return awaitResult {
     this.end(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -56,7 +56,7 @@ suspend fun HttpServerRequest.endAwait(): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpServerRequest] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use toNetSocket returning a future and chain with await()", replaceWith = ReplaceWith("toNetSocket().await()"))
+@Deprecated(message = "Instead use toNetSocket returning a future and chain with coAwait()", replaceWith = ReplaceWith("toNetSocket().coAwait()"))
 suspend fun HttpServerRequest.toNetSocketAwait(): NetSocket {
   return awaitResult {
     this.toNetSocket(it)
@@ -70,7 +70,7 @@ suspend fun HttpServerRequest.toNetSocketAwait(): NetSocket {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpServerRequest] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use toWebSocket returning a future and chain with await()", replaceWith = ReplaceWith("toWebSocket().await()"))
+@Deprecated(message = "Instead use toWebSocket returning a future and chain with coAwait()", replaceWith = ReplaceWith("toWebSocket().coAwait()"))
 suspend fun HttpServerRequest.toWebSocketAwait(): ServerWebSocket {
   return awaitResult {
     this.toWebSocket(it)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/http/HttpServerResponse.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/http/HttpServerResponse.kt
@@ -29,7 +29,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpServerResponse] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use write returning a future and chain with await()", replaceWith = ReplaceWith("write(data).await()"))
+@Deprecated(message = "Instead use write returning a future and chain with coAwait()", replaceWith = ReplaceWith("write(data).coAwait()"))
 suspend fun HttpServerResponse.writeAwait(data: Buffer): Unit {
   return awaitResult {
     this.write(data, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -42,7 +42,7 @@ suspend fun HttpServerResponse.writeAwait(data: Buffer): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpServerResponse] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use end returning a future and chain with await()", replaceWith = ReplaceWith("end().await()"))
+@Deprecated(message = "Instead use end returning a future and chain with coAwait()", replaceWith = ReplaceWith("end().coAwait()"))
 suspend fun HttpServerResponse.endAwait(): Unit {
   return awaitResult {
     this.end(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -57,7 +57,7 @@ suspend fun HttpServerResponse.endAwait(): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpServerResponse] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use write returning a future and chain with await()", replaceWith = ReplaceWith("write(chunk, enc).await()"))
+@Deprecated(message = "Instead use write returning a future and chain with coAwait()", replaceWith = ReplaceWith("write(chunk, enc).coAwait()"))
 suspend fun HttpServerResponse.writeAwait(chunk: String, enc: String): Unit {
   return awaitResult {
     this.write(chunk, enc, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -71,7 +71,7 @@ suspend fun HttpServerResponse.writeAwait(chunk: String, enc: String): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpServerResponse] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use write returning a future and chain with await()", replaceWith = ReplaceWith("write(chunk).await()"))
+@Deprecated(message = "Instead use write returning a future and chain with coAwait()", replaceWith = ReplaceWith("write(chunk).coAwait()"))
 suspend fun HttpServerResponse.writeAwait(chunk: String): Unit {
   return awaitResult {
     this.write(chunk, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -85,7 +85,7 @@ suspend fun HttpServerResponse.writeAwait(chunk: String): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpServerResponse] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use writeEarlyHints returning a future and chain with await()", replaceWith = ReplaceWith("writeEarlyHints(headers).await()"))
+@Deprecated(message = "Instead use writeEarlyHints returning a future and chain with coAwait()", replaceWith = ReplaceWith("writeEarlyHints(headers).coAwait()"))
 suspend fun HttpServerResponse.writeEarlyHintsAwait(headers: MultiMap): Unit {
   return awaitResult {
     this.writeEarlyHints(headers, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -99,7 +99,7 @@ suspend fun HttpServerResponse.writeEarlyHintsAwait(headers: MultiMap): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpServerResponse] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use end returning a future and chain with await()", replaceWith = ReplaceWith("end(chunk).await()"))
+@Deprecated(message = "Instead use end returning a future and chain with coAwait()", replaceWith = ReplaceWith("end(chunk).coAwait()"))
 suspend fun HttpServerResponse.endAwait(chunk: String): Unit {
   return awaitResult {
     this.end(chunk, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -114,7 +114,7 @@ suspend fun HttpServerResponse.endAwait(chunk: String): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpServerResponse] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use end returning a future and chain with await()", replaceWith = ReplaceWith("end(chunk, enc).await()"))
+@Deprecated(message = "Instead use end returning a future and chain with coAwait()", replaceWith = ReplaceWith("end(chunk, enc).coAwait()"))
 suspend fun HttpServerResponse.endAwait(chunk: String, enc: String): Unit {
   return awaitResult {
     this.end(chunk, enc, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -128,7 +128,7 @@ suspend fun HttpServerResponse.endAwait(chunk: String, enc: String): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpServerResponse] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use end returning a future and chain with await()", replaceWith = ReplaceWith("end(chunk).await()"))
+@Deprecated(message = "Instead use end returning a future and chain with coAwait()", replaceWith = ReplaceWith("end(chunk).coAwait()"))
 suspend fun HttpServerResponse.endAwait(chunk: Buffer): Unit {
   return awaitResult {
     this.end(chunk, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -141,7 +141,7 @@ suspend fun HttpServerResponse.endAwait(chunk: Buffer): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpServerResponse] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use send returning a future and chain with await()", replaceWith = ReplaceWith("send().await()"))
+@Deprecated(message = "Instead use send returning a future and chain with coAwait()", replaceWith = ReplaceWith("send().coAwait()"))
 suspend fun HttpServerResponse.sendAwait(): Unit {
   return awaitResult {
     this.send(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -155,7 +155,7 @@ suspend fun HttpServerResponse.sendAwait(): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpServerResponse] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use send returning a future and chain with await()", replaceWith = ReplaceWith("send(body).await()"))
+@Deprecated(message = "Instead use send returning a future and chain with coAwait()", replaceWith = ReplaceWith("send(body).coAwait()"))
 suspend fun HttpServerResponse.sendAwait(body: String): Unit {
   return awaitResult {
     this.send(body, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -169,7 +169,7 @@ suspend fun HttpServerResponse.sendAwait(body: String): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpServerResponse] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use send returning a future and chain with await()", replaceWith = ReplaceWith("send(body).await()"))
+@Deprecated(message = "Instead use send returning a future and chain with coAwait()", replaceWith = ReplaceWith("send(body).coAwait()"))
 suspend fun HttpServerResponse.sendAwait(body: Buffer): Unit {
   return awaitResult {
     this.send(body, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -183,7 +183,7 @@ suspend fun HttpServerResponse.sendAwait(body: Buffer): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpServerResponse] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use send returning a future and chain with await()", replaceWith = ReplaceWith("send(body).await()"))
+@Deprecated(message = "Instead use send returning a future and chain with coAwait()", replaceWith = ReplaceWith("send(body).coAwait()"))
 suspend fun HttpServerResponse.sendAwait(body: ReadStream<Buffer>): Unit {
   return awaitResult {
     this.send(body, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -197,7 +197,7 @@ suspend fun HttpServerResponse.sendAwait(body: ReadStream<Buffer>): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpServerResponse] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use sendFile returning a future and chain with await()", replaceWith = ReplaceWith("sendFile(filename).await()"))
+@Deprecated(message = "Instead use sendFile returning a future and chain with coAwait()", replaceWith = ReplaceWith("sendFile(filename).coAwait()"))
 suspend fun HttpServerResponse.sendFileAwait(filename: String): Unit {
   return awaitResult {
     this.sendFile(filename, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -212,7 +212,7 @@ suspend fun HttpServerResponse.sendFileAwait(filename: String): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpServerResponse] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use sendFile returning a future and chain with await()", replaceWith = ReplaceWith("sendFile(filename, offset).await()"))
+@Deprecated(message = "Instead use sendFile returning a future and chain with coAwait()", replaceWith = ReplaceWith("sendFile(filename, offset).coAwait()"))
 suspend fun HttpServerResponse.sendFileAwait(filename: String, offset: Long): Unit {
   return awaitResult {
     this.sendFile(filename, offset, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -228,7 +228,7 @@ suspend fun HttpServerResponse.sendFileAwait(filename: String, offset: Long): Un
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpServerResponse] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use sendFile returning a future and chain with await()", replaceWith = ReplaceWith("sendFile(filename, offset, length).await()"))
+@Deprecated(message = "Instead use sendFile returning a future and chain with coAwait()", replaceWith = ReplaceWith("sendFile(filename, offset, length).coAwait()"))
 suspend fun HttpServerResponse.sendFileAwait(filename: String, offset: Long, length: Long): Unit {
   return awaitResult {
     this.sendFile(filename, offset, length, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -245,7 +245,7 @@ suspend fun HttpServerResponse.sendFileAwait(filename: String, offset: Long, len
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpServerResponse] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use push returning a future and chain with await()", replaceWith = ReplaceWith("push(method, host, path).await()"))
+@Deprecated(message = "Instead use push returning a future and chain with coAwait()", replaceWith = ReplaceWith("push(method, host, path).coAwait()"))
 suspend fun HttpServerResponse.pushAwait(method: HttpMethod, host: String, path: String): HttpServerResponse {
   return awaitResult {
     this.push(method, host, path, it)
@@ -262,7 +262,7 @@ suspend fun HttpServerResponse.pushAwait(method: HttpMethod, host: String, path:
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpServerResponse] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use push returning a future and chain with await()", replaceWith = ReplaceWith("push(method, path, headers).await()"))
+@Deprecated(message = "Instead use push returning a future and chain with coAwait()", replaceWith = ReplaceWith("push(method, path, headers).coAwait()"))
 suspend fun HttpServerResponse.pushAwait(method: HttpMethod, path: String, headers: MultiMap): HttpServerResponse {
   return awaitResult {
     this.push(method, path, headers, it)
@@ -278,7 +278,7 @@ suspend fun HttpServerResponse.pushAwait(method: HttpMethod, path: String, heade
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpServerResponse] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use push returning a future and chain with await()", replaceWith = ReplaceWith("push(method, path).await()"))
+@Deprecated(message = "Instead use push returning a future and chain with coAwait()", replaceWith = ReplaceWith("push(method, path).coAwait()"))
 suspend fun HttpServerResponse.pushAwait(method: HttpMethod, path: String): HttpServerResponse {
   return awaitResult {
     this.push(method, path, it)
@@ -296,7 +296,7 @@ suspend fun HttpServerResponse.pushAwait(method: HttpMethod, path: String): Http
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.HttpServerResponse] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use push returning a future and chain with await()", replaceWith = ReplaceWith("push(method, host, path, headers).await()"))
+@Deprecated(message = "Instead use push returning a future and chain with coAwait()", replaceWith = ReplaceWith("push(method, host, path, headers).coAwait()"))
 suspend fun HttpServerResponse.pushAwait(method: HttpMethod, host: String, path: String, headers: MultiMap): HttpServerResponse {
   return awaitResult {
     this.push(method, host, path, headers, it)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/http/ServerWebSocket.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/http/ServerWebSocket.kt
@@ -28,7 +28,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.ServerWebSocket] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use write returning a future and chain with await()", replaceWith = ReplaceWith("write(data).await()"))
+@Deprecated(message = "Instead use write returning a future and chain with coAwait()", replaceWith = ReplaceWith("write(data).coAwait()"))
 suspend fun ServerWebSocket.writeAwait(data: Buffer): Unit {
   return awaitResult {
     this.write(data, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -42,7 +42,7 @@ suspend fun ServerWebSocket.writeAwait(data: Buffer): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.ServerWebSocket] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use end returning a future and chain with await()", replaceWith = ReplaceWith("end(data).await()"))
+@Deprecated(message = "Instead use end returning a future and chain with coAwait()", replaceWith = ReplaceWith("end(data).coAwait()"))
 suspend fun ServerWebSocket.endAwait(data: Buffer): Unit {
   return awaitResult {
     this.end(data, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -56,7 +56,7 @@ suspend fun ServerWebSocket.endAwait(data: Buffer): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.ServerWebSocket] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use pipeTo returning a future and chain with await()", replaceWith = ReplaceWith("pipeTo(dst).await()"))
+@Deprecated(message = "Instead use pipeTo returning a future and chain with coAwait()", replaceWith = ReplaceWith("pipeTo(dst).coAwait()"))
 suspend fun ServerWebSocket.pipeToAwait(dst: WriteStream<Buffer>): Unit {
   return awaitResult {
     this.pipeTo(dst, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -69,7 +69,7 @@ suspend fun ServerWebSocket.pipeToAwait(dst: WriteStream<Buffer>): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.ServerWebSocket] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use end returning a future and chain with await()", replaceWith = ReplaceWith("end().await()"))
+@Deprecated(message = "Instead use end returning a future and chain with coAwait()", replaceWith = ReplaceWith("end().coAwait()"))
 suspend fun ServerWebSocket.endAwait(): Unit {
   return awaitResult {
     this.end(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -82,7 +82,7 @@ suspend fun ServerWebSocket.endAwait(): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.ServerWebSocket] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use close returning a future and chain with await()", replaceWith = ReplaceWith("close().await()"))
+@Deprecated(message = "Instead use close returning a future and chain with coAwait()", replaceWith = ReplaceWith("close().coAwait()"))
 suspend fun ServerWebSocket.closeAwait(): Unit {
   return awaitResult {
     this.close(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -96,7 +96,7 @@ suspend fun ServerWebSocket.closeAwait(): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.ServerWebSocket] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use close returning a future and chain with await()", replaceWith = ReplaceWith("close(statusCode).await()"))
+@Deprecated(message = "Instead use close returning a future and chain with coAwait()", replaceWith = ReplaceWith("close(statusCode).coAwait()"))
 suspend fun ServerWebSocket.closeAwait(statusCode: Short): Unit {
   return awaitResult {
     this.close(statusCode, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -111,56 +111,56 @@ suspend fun ServerWebSocket.closeAwait(statusCode: Short): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.ServerWebSocket] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use close returning a future and chain with await()", replaceWith = ReplaceWith("close(statusCode, reason).await()"))
+@Deprecated(message = "Instead use close returning a future and chain with coAwait()", replaceWith = ReplaceWith("close(statusCode, reason).coAwait()"))
 suspend fun ServerWebSocket.closeAwait(statusCode: Short, reason: String?): Unit {
   return awaitResult {
     this.close(statusCode, reason, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
   }
 }
 
-@Deprecated(message = "Instead use writeFrame returning a future and chain with await()", replaceWith = ReplaceWith("writeFrame(frame).await()"))
+@Deprecated(message = "Instead use writeFrame returning a future and chain with coAwait()", replaceWith = ReplaceWith("writeFrame(frame).coAwait()"))
 suspend fun ServerWebSocket.writeFrameAwait(frame: WebSocketFrame): Unit {
   return awaitResult {
     this.writeFrame(frame, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
   }
 }
 
-@Deprecated(message = "Instead use writeFinalTextFrame returning a future and chain with await()", replaceWith = ReplaceWith("writeFinalTextFrame(text).await()"))
+@Deprecated(message = "Instead use writeFinalTextFrame returning a future and chain with coAwait()", replaceWith = ReplaceWith("writeFinalTextFrame(text).coAwait()"))
 suspend fun ServerWebSocket.writeFinalTextFrameAwait(text: String): Unit {
   return awaitResult {
     this.writeFinalTextFrame(text, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
   }
 }
 
-@Deprecated(message = "Instead use writeFinalBinaryFrame returning a future and chain with await()", replaceWith = ReplaceWith("writeFinalBinaryFrame(data).await()"))
+@Deprecated(message = "Instead use writeFinalBinaryFrame returning a future and chain with coAwait()", replaceWith = ReplaceWith("writeFinalBinaryFrame(data).coAwait()"))
 suspend fun ServerWebSocket.writeFinalBinaryFrameAwait(data: Buffer): Unit {
   return awaitResult {
     this.writeFinalBinaryFrame(data, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
   }
 }
 
-@Deprecated(message = "Instead use writeBinaryMessage returning a future and chain with await()", replaceWith = ReplaceWith("writeBinaryMessage(data).await()"))
+@Deprecated(message = "Instead use writeBinaryMessage returning a future and chain with coAwait()", replaceWith = ReplaceWith("writeBinaryMessage(data).coAwait()"))
 suspend fun ServerWebSocket.writeBinaryMessageAwait(data: Buffer): Unit {
   return awaitResult {
     this.writeBinaryMessage(data, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
   }
 }
 
-@Deprecated(message = "Instead use writeTextMessage returning a future and chain with await()", replaceWith = ReplaceWith("writeTextMessage(text).await()"))
+@Deprecated(message = "Instead use writeTextMessage returning a future and chain with coAwait()", replaceWith = ReplaceWith("writeTextMessage(text).coAwait()"))
 suspend fun ServerWebSocket.writeTextMessageAwait(text: String): Unit {
   return awaitResult {
     this.writeTextMessage(text, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
   }
 }
 
-@Deprecated(message = "Instead use writePing returning a future and chain with await()", replaceWith = ReplaceWith("writePing(data).await()"))
+@Deprecated(message = "Instead use writePing returning a future and chain with coAwait()", replaceWith = ReplaceWith("writePing(data).coAwait()"))
 suspend fun ServerWebSocket.writePingAwait(data: Buffer): Unit {
   return awaitResult {
     this.writePing(data, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
   }
 }
 
-@Deprecated(message = "Instead use writePong returning a future and chain with await()", replaceWith = ReplaceWith("writePong(data).await()"))
+@Deprecated(message = "Instead use writePong returning a future and chain with coAwait()", replaceWith = ReplaceWith("writePong(data).coAwait()"))
 suspend fun ServerWebSocket.writePongAwait(data: Buffer): Unit {
   return awaitResult {
     this.writePong(data, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/http/WebSocket.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/http/WebSocket.kt
@@ -28,7 +28,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.WebSocket] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use write returning a future and chain with await()", replaceWith = ReplaceWith("write(data).await()"))
+@Deprecated(message = "Instead use write returning a future and chain with coAwait()", replaceWith = ReplaceWith("write(data).coAwait()"))
 suspend fun WebSocket.writeAwait(data: Buffer): Unit {
   return awaitResult {
     this.write(data, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -42,7 +42,7 @@ suspend fun WebSocket.writeAwait(data: Buffer): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.WebSocket] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use end returning a future and chain with await()", replaceWith = ReplaceWith("end(data).await()"))
+@Deprecated(message = "Instead use end returning a future and chain with coAwait()", replaceWith = ReplaceWith("end(data).coAwait()"))
 suspend fun WebSocket.endAwait(data: Buffer): Unit {
   return awaitResult {
     this.end(data, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -56,7 +56,7 @@ suspend fun WebSocket.endAwait(data: Buffer): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.WebSocket] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use pipeTo returning a future and chain with await()", replaceWith = ReplaceWith("pipeTo(dst).await()"))
+@Deprecated(message = "Instead use pipeTo returning a future and chain with coAwait()", replaceWith = ReplaceWith("pipeTo(dst).coAwait()"))
 suspend fun WebSocket.pipeToAwait(dst: WriteStream<Buffer>): Unit {
   return awaitResult {
     this.pipeTo(dst, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -69,7 +69,7 @@ suspend fun WebSocket.pipeToAwait(dst: WriteStream<Buffer>): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.WebSocket] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use end returning a future and chain with await()", replaceWith = ReplaceWith("end().await()"))
+@Deprecated(message = "Instead use end returning a future and chain with coAwait()", replaceWith = ReplaceWith("end().coAwait()"))
 suspend fun WebSocket.endAwait(): Unit {
   return awaitResult {
     this.end(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -82,7 +82,7 @@ suspend fun WebSocket.endAwait(): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.WebSocket] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use close returning a future and chain with await()", replaceWith = ReplaceWith("close().await()"))
+@Deprecated(message = "Instead use close returning a future and chain with coAwait()", replaceWith = ReplaceWith("close().coAwait()"))
 suspend fun WebSocket.closeAwait(): Unit {
   return awaitResult {
     this.close(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -96,7 +96,7 @@ suspend fun WebSocket.closeAwait(): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.WebSocket] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use close returning a future and chain with await()", replaceWith = ReplaceWith("close(statusCode).await()"))
+@Deprecated(message = "Instead use close returning a future and chain with coAwait()", replaceWith = ReplaceWith("close(statusCode).coAwait()"))
 suspend fun WebSocket.closeAwait(statusCode: Short): Unit {
   return awaitResult {
     this.close(statusCode, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -111,56 +111,56 @@ suspend fun WebSocket.closeAwait(statusCode: Short): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.WebSocket] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use close returning a future and chain with await()", replaceWith = ReplaceWith("close(statusCode, reason).await()"))
+@Deprecated(message = "Instead use close returning a future and chain with coAwait()", replaceWith = ReplaceWith("close(statusCode, reason).coAwait()"))
 suspend fun WebSocket.closeAwait(statusCode: Short, reason: String?): Unit {
   return awaitResult {
     this.close(statusCode, reason, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
   }
 }
 
-@Deprecated(message = "Instead use writeFrame returning a future and chain with await()", replaceWith = ReplaceWith("writeFrame(frame).await()"))
+@Deprecated(message = "Instead use writeFrame returning a future and chain with coAwait()", replaceWith = ReplaceWith("writeFrame(frame).coAwait()"))
 suspend fun WebSocket.writeFrameAwait(frame: WebSocketFrame): Unit {
   return awaitResult {
     this.writeFrame(frame, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
   }
 }
 
-@Deprecated(message = "Instead use writeFinalTextFrame returning a future and chain with await()", replaceWith = ReplaceWith("writeFinalTextFrame(text).await()"))
+@Deprecated(message = "Instead use writeFinalTextFrame returning a future and chain with coAwait()", replaceWith = ReplaceWith("writeFinalTextFrame(text).coAwait()"))
 suspend fun WebSocket.writeFinalTextFrameAwait(text: String): Unit {
   return awaitResult {
     this.writeFinalTextFrame(text, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
   }
 }
 
-@Deprecated(message = "Instead use writeFinalBinaryFrame returning a future and chain with await()", replaceWith = ReplaceWith("writeFinalBinaryFrame(data).await()"))
+@Deprecated(message = "Instead use writeFinalBinaryFrame returning a future and chain with coAwait()", replaceWith = ReplaceWith("writeFinalBinaryFrame(data).coAwait()"))
 suspend fun WebSocket.writeFinalBinaryFrameAwait(data: Buffer): Unit {
   return awaitResult {
     this.writeFinalBinaryFrame(data, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
   }
 }
 
-@Deprecated(message = "Instead use writeBinaryMessage returning a future and chain with await()", replaceWith = ReplaceWith("writeBinaryMessage(data).await()"))
+@Deprecated(message = "Instead use writeBinaryMessage returning a future and chain with coAwait()", replaceWith = ReplaceWith("writeBinaryMessage(data).coAwait()"))
 suspend fun WebSocket.writeBinaryMessageAwait(data: Buffer): Unit {
   return awaitResult {
     this.writeBinaryMessage(data, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
   }
 }
 
-@Deprecated(message = "Instead use writeTextMessage returning a future and chain with await()", replaceWith = ReplaceWith("writeTextMessage(text).await()"))
+@Deprecated(message = "Instead use writeTextMessage returning a future and chain with coAwait()", replaceWith = ReplaceWith("writeTextMessage(text).coAwait()"))
 suspend fun WebSocket.writeTextMessageAwait(text: String): Unit {
   return awaitResult {
     this.writeTextMessage(text, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
   }
 }
 
-@Deprecated(message = "Instead use writePing returning a future and chain with await()", replaceWith = ReplaceWith("writePing(data).await()"))
+@Deprecated(message = "Instead use writePing returning a future and chain with coAwait()", replaceWith = ReplaceWith("writePing(data).coAwait()"))
 suspend fun WebSocket.writePingAwait(data: Buffer): Unit {
   return awaitResult {
     this.writePing(data, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
   }
 }
 
-@Deprecated(message = "Instead use writePong returning a future and chain with await()", replaceWith = ReplaceWith("writePong(data).await()"))
+@Deprecated(message = "Instead use writePong returning a future and chain with coAwait()", replaceWith = ReplaceWith("writePong(data).coAwait()"))
 suspend fun WebSocket.writePongAwait(data: Buffer): Unit {
   return awaitResult {
     this.writePong(data, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/http/WebSocketBase.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/http/WebSocketBase.kt
@@ -28,7 +28,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.WebSocketBase] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use write returning a future and chain with await()", replaceWith = ReplaceWith("write(data).await()"))
+@Deprecated(message = "Instead use write returning a future and chain with coAwait()", replaceWith = ReplaceWith("write(data).coAwait()"))
 suspend fun WebSocketBase.writeAwait(data: Buffer): Unit {
   return awaitResult {
     this.write(data, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -42,7 +42,7 @@ suspend fun WebSocketBase.writeAwait(data: Buffer): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.WebSocketBase] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use end returning a future and chain with await()", replaceWith = ReplaceWith("end(data).await()"))
+@Deprecated(message = "Instead use end returning a future and chain with coAwait()", replaceWith = ReplaceWith("end(data).coAwait()"))
 suspend fun WebSocketBase.endAwait(data: Buffer): Unit {
   return awaitResult {
     this.end(data, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -56,7 +56,7 @@ suspend fun WebSocketBase.endAwait(data: Buffer): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.WebSocketBase] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use pipeTo returning a future and chain with await()", replaceWith = ReplaceWith("pipeTo(dst).await()"))
+@Deprecated(message = "Instead use pipeTo returning a future and chain with coAwait()", replaceWith = ReplaceWith("pipeTo(dst).coAwait()"))
 suspend fun WebSocketBase.pipeToAwait(dst: WriteStream<Buffer>): Unit {
   return awaitResult {
     this.pipeTo(dst, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -70,7 +70,7 @@ suspend fun WebSocketBase.pipeToAwait(dst: WriteStream<Buffer>): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.WebSocketBase] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use writeFrame returning a future and chain with await()", replaceWith = ReplaceWith("writeFrame(frame).await()"))
+@Deprecated(message = "Instead use writeFrame returning a future and chain with coAwait()", replaceWith = ReplaceWith("writeFrame(frame).coAwait()"))
 suspend fun WebSocketBase.writeFrameAwait(frame: WebSocketFrame): Unit {
   return awaitResult {
     this.writeFrame(frame, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -84,7 +84,7 @@ suspend fun WebSocketBase.writeFrameAwait(frame: WebSocketFrame): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.WebSocketBase] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use writeFinalTextFrame returning a future and chain with await()", replaceWith = ReplaceWith("writeFinalTextFrame(text).await()"))
+@Deprecated(message = "Instead use writeFinalTextFrame returning a future and chain with coAwait()", replaceWith = ReplaceWith("writeFinalTextFrame(text).coAwait()"))
 suspend fun WebSocketBase.writeFinalTextFrameAwait(text: String): Unit {
   return awaitResult {
     this.writeFinalTextFrame(text, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -98,7 +98,7 @@ suspend fun WebSocketBase.writeFinalTextFrameAwait(text: String): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.WebSocketBase] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use writeFinalBinaryFrame returning a future and chain with await()", replaceWith = ReplaceWith("writeFinalBinaryFrame(data).await()"))
+@Deprecated(message = "Instead use writeFinalBinaryFrame returning a future and chain with coAwait()", replaceWith = ReplaceWith("writeFinalBinaryFrame(data).coAwait()"))
 suspend fun WebSocketBase.writeFinalBinaryFrameAwait(data: Buffer): Unit {
   return awaitResult {
     this.writeFinalBinaryFrame(data, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -112,7 +112,7 @@ suspend fun WebSocketBase.writeFinalBinaryFrameAwait(data: Buffer): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.WebSocketBase] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use writeBinaryMessage returning a future and chain with await()", replaceWith = ReplaceWith("writeBinaryMessage(data).await()"))
+@Deprecated(message = "Instead use writeBinaryMessage returning a future and chain with coAwait()", replaceWith = ReplaceWith("writeBinaryMessage(data).coAwait()"))
 suspend fun WebSocketBase.writeBinaryMessageAwait(data: Buffer): Unit {
   return awaitResult {
     this.writeBinaryMessage(data, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -126,7 +126,7 @@ suspend fun WebSocketBase.writeBinaryMessageAwait(data: Buffer): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.WebSocketBase] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use writeTextMessage returning a future and chain with await()", replaceWith = ReplaceWith("writeTextMessage(text).await()"))
+@Deprecated(message = "Instead use writeTextMessage returning a future and chain with coAwait()", replaceWith = ReplaceWith("writeTextMessage(text).coAwait()"))
 suspend fun WebSocketBase.writeTextMessageAwait(text: String): Unit {
   return awaitResult {
     this.writeTextMessage(text, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -140,7 +140,7 @@ suspend fun WebSocketBase.writeTextMessageAwait(text: String): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.WebSocketBase] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use writePing returning a future and chain with await()", replaceWith = ReplaceWith("writePing(data).await()"))
+@Deprecated(message = "Instead use writePing returning a future and chain with coAwait()", replaceWith = ReplaceWith("writePing(data).coAwait()"))
 suspend fun WebSocketBase.writePingAwait(data: Buffer): Unit {
   return awaitResult {
     this.writePing(data, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -154,7 +154,7 @@ suspend fun WebSocketBase.writePingAwait(data: Buffer): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.WebSocketBase] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use writePong returning a future and chain with await()", replaceWith = ReplaceWith("writePong(data).await()"))
+@Deprecated(message = "Instead use writePong returning a future and chain with coAwait()", replaceWith = ReplaceWith("writePong(data).coAwait()"))
 suspend fun WebSocketBase.writePongAwait(data: Buffer): Unit {
   return awaitResult {
     this.writePong(data, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -167,7 +167,7 @@ suspend fun WebSocketBase.writePongAwait(data: Buffer): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.WebSocketBase] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use end returning a future and chain with await()", replaceWith = ReplaceWith("end().await()"))
+@Deprecated(message = "Instead use end returning a future and chain with coAwait()", replaceWith = ReplaceWith("end().coAwait()"))
 suspend fun WebSocketBase.endAwait(): Unit {
   return awaitResult {
     this.end(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -180,7 +180,7 @@ suspend fun WebSocketBase.endAwait(): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.WebSocketBase] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use close returning a future and chain with await()", replaceWith = ReplaceWith("close().await()"))
+@Deprecated(message = "Instead use close returning a future and chain with coAwait()", replaceWith = ReplaceWith("close().coAwait()"))
 suspend fun WebSocketBase.closeAwait(): Unit {
   return awaitResult {
     this.close(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -194,7 +194,7 @@ suspend fun WebSocketBase.closeAwait(): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.WebSocketBase] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use close returning a future and chain with await()", replaceWith = ReplaceWith("close(statusCode).await()"))
+@Deprecated(message = "Instead use close returning a future and chain with coAwait()", replaceWith = ReplaceWith("close(statusCode).coAwait()"))
 suspend fun WebSocketBase.closeAwait(statusCode: Short): Unit {
   return awaitResult {
     this.close(statusCode, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -209,7 +209,7 @@ suspend fun WebSocketBase.closeAwait(statusCode: Short): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.WebSocketBase] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use close returning a future and chain with await()", replaceWith = ReplaceWith("close(statusCode, reason).await()"))
+@Deprecated(message = "Instead use close returning a future and chain with coAwait()", replaceWith = ReplaceWith("close(statusCode, reason).coAwait()"))
 suspend fun WebSocketBase.closeAwait(statusCode: Short, reason: String?): Unit {
   return awaitResult {
     this.close(statusCode, reason, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/http/WebSocketClient.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/http/WebSocketClient.kt
@@ -31,7 +31,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.WebSocketClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use connect returning a future and chain with await()", replaceWith = ReplaceWith("connect(port, host, requestURI).await()"))
+@Deprecated(message = "Instead use connect returning a future and chain with coAwait()", replaceWith = ReplaceWith("connect(port, host, requestURI).coAwait()"))
 suspend fun WebSocketClient.connectAwait(port: Int, host: String, requestURI: String): WebSocket {
   return awaitResult {
     this.connect(port, host, requestURI, it)
@@ -47,7 +47,7 @@ suspend fun WebSocketClient.connectAwait(port: Int, host: String, requestURI: St
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.WebSocketClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use connect returning a future and chain with await()", replaceWith = ReplaceWith("connect(host, requestURI).await()"))
+@Deprecated(message = "Instead use connect returning a future and chain with coAwait()", replaceWith = ReplaceWith("connect(host, requestURI).coAwait()"))
 suspend fun WebSocketClient.connectAwait(host: String, requestURI: String): WebSocket {
   return awaitResult {
     this.connect(host, requestURI, it)
@@ -62,7 +62,7 @@ suspend fun WebSocketClient.connectAwait(host: String, requestURI: String): WebS
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.WebSocketClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use connect returning a future and chain with await()", replaceWith = ReplaceWith("connect(requestURI).await()"))
+@Deprecated(message = "Instead use connect returning a future and chain with coAwait()", replaceWith = ReplaceWith("connect(requestURI).coAwait()"))
 suspend fun WebSocketClient.connectAwait(requestURI: String): WebSocket {
   return awaitResult {
     this.connect(requestURI, it)
@@ -77,7 +77,7 @@ suspend fun WebSocketClient.connectAwait(requestURI: String): WebSocket {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.WebSocketClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use connect returning a future and chain with await()", replaceWith = ReplaceWith("connect(options).await()"))
+@Deprecated(message = "Instead use connect returning a future and chain with coAwait()", replaceWith = ReplaceWith("connect(options).coAwait()"))
 suspend fun WebSocketClient.connectAwait(options: WebSocketConnectOptions): WebSocket {
   return awaitResult {
     this.connect(options, it)
@@ -92,7 +92,7 @@ suspend fun WebSocketClient.connectAwait(options: WebSocketConnectOptions): WebS
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.WebSocketClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use updateSSLOptions returning a future and chain with await()", replaceWith = ReplaceWith("updateSSLOptions(options).await()"))
+@Deprecated(message = "Instead use updateSSLOptions returning a future and chain with coAwait()", replaceWith = ReplaceWith("updateSSLOptions(options).coAwait()"))
 suspend fun WebSocketClient.updateSSLOptionsAwait(options: SSLOptions): Boolean {
   return awaitResult {
     this.updateSSLOptions(options, it)
@@ -108,7 +108,7 @@ suspend fun WebSocketClient.updateSSLOptionsAwait(options: SSLOptions): Boolean 
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.WebSocketClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use updateSSLOptions returning a future and chain with await()", replaceWith = ReplaceWith("updateSSLOptions(options, force).await()"))
+@Deprecated(message = "Instead use updateSSLOptions returning a future and chain with coAwait()", replaceWith = ReplaceWith("updateSSLOptions(options, force).coAwait()"))
 suspend fun WebSocketClient.updateSSLOptionsAwait(options: SSLOptions, force: Boolean): Boolean {
   return awaitResult {
     this.updateSSLOptions(options, force, it)
@@ -121,7 +121,7 @@ suspend fun WebSocketClient.updateSSLOptionsAwait(options: SSLOptions, force: Bo
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.http.WebSocketClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use close returning a future and chain with await()", replaceWith = ReplaceWith("close().await()"))
+@Deprecated(message = "Instead use close returning a future and chain with coAwait()", replaceWith = ReplaceWith("close().coAwait()"))
 suspend fun WebSocketClient.closeAwait(): Unit {
   return awaitResult {
     this.close(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/net/NetClient.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/net/NetClient.kt
@@ -30,7 +30,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.net.NetClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use connect returning a future and chain with await()", replaceWith = ReplaceWith("connect(port, host).await()"))
+@Deprecated(message = "Instead use connect returning a future and chain with coAwait()", replaceWith = ReplaceWith("connect(port, host).coAwait()"))
 suspend fun NetClient.connectAwait(port: Int, host: String): NetSocket {
   return awaitResult {
     this.connect(port, host, it)
@@ -47,7 +47,7 @@ suspend fun NetClient.connectAwait(port: Int, host: String): NetSocket {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.net.NetClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use connect returning a future and chain with await()", replaceWith = ReplaceWith("connect(port, host, serverName).await()"))
+@Deprecated(message = "Instead use connect returning a future and chain with coAwait()", replaceWith = ReplaceWith("connect(port, host, serverName).coAwait()"))
 suspend fun NetClient.connectAwait(port: Int, host: String, serverName: String): NetSocket {
   return awaitResult {
     this.connect(port, host, serverName, it)
@@ -62,7 +62,7 @@ suspend fun NetClient.connectAwait(port: Int, host: String, serverName: String):
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.net.NetClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use connect returning a future and chain with await()", replaceWith = ReplaceWith("connect(remoteAddress).await()"))
+@Deprecated(message = "Instead use connect returning a future and chain with coAwait()", replaceWith = ReplaceWith("connect(remoteAddress).coAwait()"))
 suspend fun NetClient.connectAwait(remoteAddress: SocketAddress): NetSocket {
   return awaitResult {
     this.connect(remoteAddress, it)
@@ -78,7 +78,7 @@ suspend fun NetClient.connectAwait(remoteAddress: SocketAddress): NetSocket {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.net.NetClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use connect returning a future and chain with await()", replaceWith = ReplaceWith("connect(remoteAddress, serverName).await()"))
+@Deprecated(message = "Instead use connect returning a future and chain with coAwait()", replaceWith = ReplaceWith("connect(remoteAddress, serverName).coAwait()"))
 suspend fun NetClient.connectAwait(remoteAddress: SocketAddress, serverName: String): NetSocket {
   return awaitResult {
     this.connect(remoteAddress, serverName, it)
@@ -91,7 +91,7 @@ suspend fun NetClient.connectAwait(remoteAddress: SocketAddress, serverName: Str
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.net.NetClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use close returning a future and chain with await()", replaceWith = ReplaceWith("close().await()"))
+@Deprecated(message = "Instead use close returning a future and chain with coAwait()", replaceWith = ReplaceWith("close().coAwait()"))
 suspend fun NetClient.closeAwait(): Unit {
   return awaitResult {
     this.close(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -106,7 +106,7 @@ suspend fun NetClient.closeAwait(): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.net.NetClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use updateSSLOptions returning a future and chain with await()", replaceWith = ReplaceWith("updateSSLOptions(options).await()"))
+@Deprecated(message = "Instead use updateSSLOptions returning a future and chain with coAwait()", replaceWith = ReplaceWith("updateSSLOptions(options).coAwait()"))
 suspend fun NetClient.updateSSLOptionsAwait(options: SSLOptions): Boolean {
   return awaitResult {
     this.updateSSLOptions(options, it)
@@ -122,7 +122,7 @@ suspend fun NetClient.updateSSLOptionsAwait(options: SSLOptions): Boolean {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.net.NetClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use updateSSLOptions returning a future and chain with await()", replaceWith = ReplaceWith("updateSSLOptions(options, force).await()"))
+@Deprecated(message = "Instead use updateSSLOptions returning a future and chain with coAwait()", replaceWith = ReplaceWith("updateSSLOptions(options, force).coAwait()"))
 suspend fun NetClient.updateSSLOptionsAwait(options: SSLOptions, force: Boolean): Boolean {
   return awaitResult {
     this.updateSSLOptions(options, force, it)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/net/NetServer.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/net/NetServer.kt
@@ -27,7 +27,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.net.NetServer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use listen returning a future and chain with await()", replaceWith = ReplaceWith("listen().await()"))
+@Deprecated(message = "Instead use listen returning a future and chain with coAwait()", replaceWith = ReplaceWith("listen().coAwait()"))
 suspend fun NetServer.listenAwait(): NetServer {
   return awaitResult {
     this.listen(it)
@@ -43,7 +43,7 @@ suspend fun NetServer.listenAwait(): NetServer {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.net.NetServer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use listen returning a future and chain with await()", replaceWith = ReplaceWith("listen(port, host).await()"))
+@Deprecated(message = "Instead use listen returning a future and chain with coAwait()", replaceWith = ReplaceWith("listen(port, host).coAwait()"))
 suspend fun NetServer.listenAwait(port: Int, host: String): NetServer {
   return awaitResult {
     this.listen(port, host, it)
@@ -58,7 +58,7 @@ suspend fun NetServer.listenAwait(port: Int, host: String): NetServer {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.net.NetServer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use listen returning a future and chain with await()", replaceWith = ReplaceWith("listen(port).await()"))
+@Deprecated(message = "Instead use listen returning a future and chain with coAwait()", replaceWith = ReplaceWith("listen(port).coAwait()"))
 suspend fun NetServer.listenAwait(port: Int): NetServer {
   return awaitResult {
     this.listen(port, it)
@@ -73,7 +73,7 @@ suspend fun NetServer.listenAwait(port: Int): NetServer {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.net.NetServer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use listen returning a future and chain with await()", replaceWith = ReplaceWith("listen(localAddress).await()"))
+@Deprecated(message = "Instead use listen returning a future and chain with coAwait()", replaceWith = ReplaceWith("listen(localAddress).coAwait()"))
 suspend fun NetServer.listenAwait(localAddress: SocketAddress): NetServer {
   return awaitResult {
     this.listen(localAddress, it)
@@ -86,7 +86,7 @@ suspend fun NetServer.listenAwait(localAddress: SocketAddress): NetServer {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.net.NetServer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use close returning a future and chain with await()", replaceWith = ReplaceWith("close().await()"))
+@Deprecated(message = "Instead use close returning a future and chain with coAwait()", replaceWith = ReplaceWith("close().coAwait()"))
 suspend fun NetServer.closeAwait(): Unit {
   return awaitResult {
     this.close(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -101,7 +101,7 @@ suspend fun NetServer.closeAwait(): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.net.NetServer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use updateSSLOptions returning a future and chain with await()", replaceWith = ReplaceWith("updateSSLOptions(options).await()"))
+@Deprecated(message = "Instead use updateSSLOptions returning a future and chain with coAwait()", replaceWith = ReplaceWith("updateSSLOptions(options).coAwait()"))
 suspend fun NetServer.updateSSLOptionsAwait(options: SSLOptions): Boolean {
   return awaitResult {
     this.updateSSLOptions(options, it)
@@ -117,7 +117,7 @@ suspend fun NetServer.updateSSLOptionsAwait(options: SSLOptions): Boolean {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.net.NetServer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use updateSSLOptions returning a future and chain with await()", replaceWith = ReplaceWith("updateSSLOptions(options, force).await()"))
+@Deprecated(message = "Instead use updateSSLOptions returning a future and chain with coAwait()", replaceWith = ReplaceWith("updateSSLOptions(options, force).coAwait()"))
 suspend fun NetServer.updateSSLOptionsAwait(options: SSLOptions, force: Boolean): Boolean {
   return awaitResult {
     this.updateSSLOptions(options, force, it)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/net/NetSocket.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/net/NetSocket.kt
@@ -27,7 +27,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.net.NetSocket] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use end returning a future and chain with await()", replaceWith = ReplaceWith("end(data).await()"))
+@Deprecated(message = "Instead use end returning a future and chain with coAwait()", replaceWith = ReplaceWith("end(data).coAwait()"))
 suspend fun NetSocket.endAwait(data: Buffer): Unit {
   return awaitResult {
     this.end(data, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -41,7 +41,7 @@ suspend fun NetSocket.endAwait(data: Buffer): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.net.NetSocket] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use pipeTo returning a future and chain with await()", replaceWith = ReplaceWith("pipeTo(dst).await()"))
+@Deprecated(message = "Instead use pipeTo returning a future and chain with coAwait()", replaceWith = ReplaceWith("pipeTo(dst).coAwait()"))
 suspend fun NetSocket.pipeToAwait(dst: WriteStream<Buffer>): Unit {
   return awaitResult {
     this.pipeTo(dst, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -55,7 +55,7 @@ suspend fun NetSocket.pipeToAwait(dst: WriteStream<Buffer>): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.net.NetSocket] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use write returning a future and chain with await()", replaceWith = ReplaceWith("write(str).await()"))
+@Deprecated(message = "Instead use write returning a future and chain with coAwait()", replaceWith = ReplaceWith("write(str).coAwait()"))
 suspend fun NetSocket.writeAwait(str: String): Unit {
   return awaitResult {
     this.write(str, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -70,7 +70,7 @@ suspend fun NetSocket.writeAwait(str: String): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.net.NetSocket] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use write returning a future and chain with await()", replaceWith = ReplaceWith("write(str, enc).await()"))
+@Deprecated(message = "Instead use write returning a future and chain with coAwait()", replaceWith = ReplaceWith("write(str, enc).coAwait()"))
 suspend fun NetSocket.writeAwait(str: String, enc: String): Unit {
   return awaitResult {
     this.write(str, enc, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -84,7 +84,7 @@ suspend fun NetSocket.writeAwait(str: String, enc: String): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.net.NetSocket] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use write returning a future and chain with await()", replaceWith = ReplaceWith("write(message).await()"))
+@Deprecated(message = "Instead use write returning a future and chain with coAwait()", replaceWith = ReplaceWith("write(message).coAwait()"))
 suspend fun NetSocket.writeAwait(message: Buffer): Unit {
   return awaitResult {
     this.write(message, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -98,7 +98,7 @@ suspend fun NetSocket.writeAwait(message: Buffer): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.net.NetSocket] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use sendFile returning a future and chain with await()", replaceWith = ReplaceWith("sendFile(filename).await()"))
+@Deprecated(message = "Instead use sendFile returning a future and chain with coAwait()", replaceWith = ReplaceWith("sendFile(filename).coAwait()"))
 suspend fun NetSocket.sendFileAwait(filename: String): Unit {
   return awaitResult {
     this.sendFile(filename, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -113,7 +113,7 @@ suspend fun NetSocket.sendFileAwait(filename: String): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.net.NetSocket] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use sendFile returning a future and chain with await()", replaceWith = ReplaceWith("sendFile(filename, offset).await()"))
+@Deprecated(message = "Instead use sendFile returning a future and chain with coAwait()", replaceWith = ReplaceWith("sendFile(filename, offset).coAwait()"))
 suspend fun NetSocket.sendFileAwait(filename: String, offset: Long): Unit {
   return awaitResult {
     this.sendFile(filename, offset, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -129,7 +129,7 @@ suspend fun NetSocket.sendFileAwait(filename: String, offset: Long): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.net.NetSocket] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use sendFile returning a future and chain with await()", replaceWith = ReplaceWith("sendFile(filename, offset, length).await()"))
+@Deprecated(message = "Instead use sendFile returning a future and chain with coAwait()", replaceWith = ReplaceWith("sendFile(filename, offset, length).coAwait()"))
 suspend fun NetSocket.sendFileAwait(filename: String, offset: Long, length: Long): Unit {
   return awaitResult {
     this.sendFile(filename, offset, length, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -142,7 +142,7 @@ suspend fun NetSocket.sendFileAwait(filename: String, offset: Long, length: Long
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.net.NetSocket] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use end returning a future and chain with await()", replaceWith = ReplaceWith("end().await()"))
+@Deprecated(message = "Instead use end returning a future and chain with coAwait()", replaceWith = ReplaceWith("end().coAwait()"))
 suspend fun NetSocket.endAwait(): Unit {
   return awaitResult {
     this.end(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -155,7 +155,7 @@ suspend fun NetSocket.endAwait(): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.net.NetSocket] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use close returning a future and chain with await()", replaceWith = ReplaceWith("close().await()"))
+@Deprecated(message = "Instead use close returning a future and chain with coAwait()", replaceWith = ReplaceWith("close().coAwait()"))
 suspend fun NetSocket.closeAwait(): Unit {
   return awaitResult {
     this.close(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -168,7 +168,7 @@ suspend fun NetSocket.closeAwait(): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.net.NetSocket] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use upgradeToSsl returning a future and chain with await()", replaceWith = ReplaceWith("upgradeToSsl().await()"))
+@Deprecated(message = "Instead use upgradeToSsl returning a future and chain with coAwait()", replaceWith = ReplaceWith("upgradeToSsl().coAwait()"))
 suspend fun NetSocket.upgradeToSslAwait(): Unit {
   return awaitResult {
     this.upgradeToSsl(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -182,7 +182,7 @@ suspend fun NetSocket.upgradeToSslAwait(): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.net.NetSocket] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use upgradeToSsl returning a future and chain with await()", replaceWith = ReplaceWith("upgradeToSsl(serverName).await()"))
+@Deprecated(message = "Instead use upgradeToSsl returning a future and chain with coAwait()", replaceWith = ReplaceWith("upgradeToSsl(serverName).coAwait()"))
 suspend fun NetSocket.upgradeToSslAwait(serverName: String): Unit {
   return awaitResult {
     this.upgradeToSsl(serverName, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/parsetools/JsonParser.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/parsetools/JsonParser.kt
@@ -27,7 +27,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.parsetools.JsonParser] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use pipeTo returning a future and chain with await()", replaceWith = ReplaceWith("pipeTo(dst).await()"))
+@Deprecated(message = "Instead use pipeTo returning a future and chain with coAwait()", replaceWith = ReplaceWith("pipeTo(dst).coAwait()"))
 suspend fun JsonParser.pipeToAwait(dst: WriteStream<JsonEvent>): Unit {
   return awaitResult {
     this.pipeTo(dst, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/parsetools/RecordParser.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/parsetools/RecordParser.kt
@@ -27,7 +27,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.parsetools.RecordParser] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use pipeTo returning a future and chain with await()", replaceWith = ReplaceWith("pipeTo(dst).await()"))
+@Deprecated(message = "Instead use pipeTo returning a future and chain with coAwait()", replaceWith = ReplaceWith("pipeTo(dst).coAwait()"))
 suspend fun RecordParser.pipeToAwait(dst: WriteStream<Buffer>): Unit {
   return awaitResult {
     this.pipeTo(dst, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/shareddata/AsyncMap.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/shareddata/AsyncMap.kt
@@ -26,7 +26,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.shareddata.AsyncMap] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use get returning a future and chain with await()", replaceWith = ReplaceWith("get(k).await()"))
+@Deprecated(message = "Instead use get returning a future and chain with coAwait()", replaceWith = ReplaceWith("get(k).coAwait()"))
 suspend fun <K,V> AsyncMap<K,V>.getAwait(k: K): V? {
   return awaitResult {
     this.get(k, it)
@@ -41,7 +41,7 @@ suspend fun <K,V> AsyncMap<K,V>.getAwait(k: K): V? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.shareddata.AsyncMap] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use put returning a future and chain with await()", replaceWith = ReplaceWith("put(k, v).await()"))
+@Deprecated(message = "Instead use put returning a future and chain with coAwait()", replaceWith = ReplaceWith("put(k, v).coAwait()"))
 suspend fun <K,V> AsyncMap<K,V>.putAwait(k: K, v: V): Unit {
   return awaitResult {
     this.put(k, v, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -57,7 +57,7 @@ suspend fun <K,V> AsyncMap<K,V>.putAwait(k: K, v: V): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.shareddata.AsyncMap] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use put returning a future and chain with await()", replaceWith = ReplaceWith("put(k, v, ttl).await()"))
+@Deprecated(message = "Instead use put returning a future and chain with coAwait()", replaceWith = ReplaceWith("put(k, v, ttl).coAwait()"))
 suspend fun <K,V> AsyncMap<K,V>.putAwait(k: K, v: V, ttl: Long): Unit {
   return awaitResult {
     this.put(k, v, ttl, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -73,7 +73,7 @@ suspend fun <K,V> AsyncMap<K,V>.putAwait(k: K, v: V, ttl: Long): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.shareddata.AsyncMap] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use putIfAbsent returning a future and chain with await()", replaceWith = ReplaceWith("putIfAbsent(k, v).await()"))
+@Deprecated(message = "Instead use putIfAbsent returning a future and chain with coAwait()", replaceWith = ReplaceWith("putIfAbsent(k, v).coAwait()"))
 suspend fun <K,V> AsyncMap<K,V>.putIfAbsentAwait(k: K, v: V): V? {
   return awaitResult {
     this.putIfAbsent(k, v, it)
@@ -90,7 +90,7 @@ suspend fun <K,V> AsyncMap<K,V>.putIfAbsentAwait(k: K, v: V): V? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.shareddata.AsyncMap] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use putIfAbsent returning a future and chain with await()", replaceWith = ReplaceWith("putIfAbsent(k, v, ttl).await()"))
+@Deprecated(message = "Instead use putIfAbsent returning a future and chain with coAwait()", replaceWith = ReplaceWith("putIfAbsent(k, v, ttl).coAwait()"))
 suspend fun <K,V> AsyncMap<K,V>.putIfAbsentAwait(k: K, v: V, ttl: Long): V? {
   return awaitResult {
     this.putIfAbsent(k, v, ttl, it)
@@ -105,7 +105,7 @@ suspend fun <K,V> AsyncMap<K,V>.putIfAbsentAwait(k: K, v: V, ttl: Long): V? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.shareddata.AsyncMap] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use remove returning a future and chain with await()", replaceWith = ReplaceWith("remove(k).await()"))
+@Deprecated(message = "Instead use remove returning a future and chain with coAwait()", replaceWith = ReplaceWith("remove(k).coAwait()"))
 suspend fun <K,V> AsyncMap<K,V>.removeAwait(k: K): V? {
   return awaitResult {
     this.remove(k, it)
@@ -121,7 +121,7 @@ suspend fun <K,V> AsyncMap<K,V>.removeAwait(k: K): V? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.shareddata.AsyncMap] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use removeIfPresent returning a future and chain with await()", replaceWith = ReplaceWith("removeIfPresent(k, v).await()"))
+@Deprecated(message = "Instead use removeIfPresent returning a future and chain with coAwait()", replaceWith = ReplaceWith("removeIfPresent(k, v).coAwait()"))
 suspend fun <K,V> AsyncMap<K,V>.removeIfPresentAwait(k: K, v: V): Boolean {
   return awaitResult {
     this.removeIfPresent(k, v, it)
@@ -137,7 +137,7 @@ suspend fun <K,V> AsyncMap<K,V>.removeIfPresentAwait(k: K, v: V): Boolean {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.shareddata.AsyncMap] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use replace returning a future and chain with await()", replaceWith = ReplaceWith("replace(k, v).await()"))
+@Deprecated(message = "Instead use replace returning a future and chain with coAwait()", replaceWith = ReplaceWith("replace(k, v).coAwait()"))
 suspend fun <K,V> AsyncMap<K,V>.replaceAwait(k: K, v: V): V? {
   return awaitResult {
     this.replace(k, v, it)
@@ -154,7 +154,7 @@ suspend fun <K,V> AsyncMap<K,V>.replaceAwait(k: K, v: V): V? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.shareddata.AsyncMap] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use replace returning a future and chain with await()", replaceWith = ReplaceWith("replace(k, v, ttl).await()"))
+@Deprecated(message = "Instead use replace returning a future and chain with coAwait()", replaceWith = ReplaceWith("replace(k, v, ttl).coAwait()"))
 suspend fun <K,V> AsyncMap<K,V>.replaceAwait(k: K, v: V, ttl: Long): V? {
   return awaitResult {
     this.replace(k, v, ttl, it)
@@ -171,7 +171,7 @@ suspend fun <K,V> AsyncMap<K,V>.replaceAwait(k: K, v: V, ttl: Long): V? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.shareddata.AsyncMap] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use replaceIfPresent returning a future and chain with await()", replaceWith = ReplaceWith("replaceIfPresent(k, oldValue, newValue).await()"))
+@Deprecated(message = "Instead use replaceIfPresent returning a future and chain with coAwait()", replaceWith = ReplaceWith("replaceIfPresent(k, oldValue, newValue).coAwait()"))
 suspend fun <K,V> AsyncMap<K,V>.replaceIfPresentAwait(k: K, oldValue: V, newValue: V): Boolean {
   return awaitResult {
     this.replaceIfPresent(k, oldValue, newValue, it)
@@ -189,7 +189,7 @@ suspend fun <K,V> AsyncMap<K,V>.replaceIfPresentAwait(k: K, oldValue: V, newValu
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.shareddata.AsyncMap] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use replaceIfPresent returning a future and chain with await()", replaceWith = ReplaceWith("replaceIfPresent(k, oldValue, newValue, ttl).await()"))
+@Deprecated(message = "Instead use replaceIfPresent returning a future and chain with coAwait()", replaceWith = ReplaceWith("replaceIfPresent(k, oldValue, newValue, ttl).coAwait()"))
 suspend fun <K,V> AsyncMap<K,V>.replaceIfPresentAwait(k: K, oldValue: V, newValue: V, ttl: Long): Boolean {
   return awaitResult {
     this.replaceIfPresent(k, oldValue, newValue, ttl, it)
@@ -202,7 +202,7 @@ suspend fun <K,V> AsyncMap<K,V>.replaceIfPresentAwait(k: K, oldValue: V, newValu
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.shareddata.AsyncMap] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use clear returning a future and chain with await()", replaceWith = ReplaceWith("clear().await()"))
+@Deprecated(message = "Instead use clear returning a future and chain with coAwait()", replaceWith = ReplaceWith("clear().coAwait()"))
 suspend fun <K,V> AsyncMap<K,V>.clearAwait(): Unit {
   return awaitResult {
     this.clear(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -216,7 +216,7 @@ suspend fun <K,V> AsyncMap<K,V>.clearAwait(): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.shareddata.AsyncMap] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use size returning a future and chain with await()", replaceWith = ReplaceWith("size().await()"))
+@Deprecated(message = "Instead use size returning a future and chain with coAwait()", replaceWith = ReplaceWith("size().coAwait()"))
 suspend fun <K,V> AsyncMap<K,V>.sizeAwait(): Int {
   return awaitResult {
     this.size(it)
@@ -230,7 +230,7 @@ suspend fun <K,V> AsyncMap<K,V>.sizeAwait(): Int {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.shareddata.AsyncMap] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use keys returning a future and chain with await()", replaceWith = ReplaceWith("keys().await()"))
+@Deprecated(message = "Instead use keys returning a future and chain with coAwait()", replaceWith = ReplaceWith("keys().coAwait()"))
 suspend fun <K,V> AsyncMap<K,V>.keysAwait(): Set<K> {
   return awaitResult {
     this.keys(it)
@@ -244,7 +244,7 @@ suspend fun <K,V> AsyncMap<K,V>.keysAwait(): Set<K> {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.shareddata.AsyncMap] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use values returning a future and chain with await()", replaceWith = ReplaceWith("values().await()"))
+@Deprecated(message = "Instead use values returning a future and chain with coAwait()", replaceWith = ReplaceWith("values().coAwait()"))
 suspend fun <K,V> AsyncMap<K,V>.valuesAwait(): List<V> {
   return awaitResult {
     this.values(it)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/shareddata/Counter.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/shareddata/Counter.kt
@@ -25,7 +25,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.shareddata.Counter] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use get returning a future and chain with await()", replaceWith = ReplaceWith("get().await()"))
+@Deprecated(message = "Instead use get returning a future and chain with coAwait()", replaceWith = ReplaceWith("get().coAwait()"))
 suspend fun Counter.getAwait(): Long {
   return awaitResult {
     this.get(it)
@@ -39,7 +39,7 @@ suspend fun Counter.getAwait(): Long {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.shareddata.Counter] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use incrementAndGet returning a future and chain with await()", replaceWith = ReplaceWith("incrementAndGet().await()"))
+@Deprecated(message = "Instead use incrementAndGet returning a future and chain with coAwait()", replaceWith = ReplaceWith("incrementAndGet().coAwait()"))
 suspend fun Counter.incrementAndGetAwait(): Long {
   return awaitResult {
     this.incrementAndGet(it)
@@ -53,7 +53,7 @@ suspend fun Counter.incrementAndGetAwait(): Long {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.shareddata.Counter] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use getAndIncrement returning a future and chain with await()", replaceWith = ReplaceWith("getAndIncrement().await()"))
+@Deprecated(message = "Instead use getAndIncrement returning a future and chain with coAwait()", replaceWith = ReplaceWith("getAndIncrement().coAwait()"))
 suspend fun Counter.getAndIncrementAwait(): Long {
   return awaitResult {
     this.getAndIncrement(it)
@@ -67,7 +67,7 @@ suspend fun Counter.getAndIncrementAwait(): Long {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.shareddata.Counter] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use decrementAndGet returning a future and chain with await()", replaceWith = ReplaceWith("decrementAndGet().await()"))
+@Deprecated(message = "Instead use decrementAndGet returning a future and chain with coAwait()", replaceWith = ReplaceWith("decrementAndGet().coAwait()"))
 suspend fun Counter.decrementAndGetAwait(): Long {
   return awaitResult {
     this.decrementAndGet(it)
@@ -82,7 +82,7 @@ suspend fun Counter.decrementAndGetAwait(): Long {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.shareddata.Counter] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use addAndGet returning a future and chain with await()", replaceWith = ReplaceWith("addAndGet(value).await()"))
+@Deprecated(message = "Instead use addAndGet returning a future and chain with coAwait()", replaceWith = ReplaceWith("addAndGet(value).coAwait()"))
 suspend fun Counter.addAndGetAwait(value: Long): Long {
   return awaitResult {
     this.addAndGet(value, it)
@@ -97,7 +97,7 @@ suspend fun Counter.addAndGetAwait(value: Long): Long {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.shareddata.Counter] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use getAndAdd returning a future and chain with await()", replaceWith = ReplaceWith("getAndAdd(value).await()"))
+@Deprecated(message = "Instead use getAndAdd returning a future and chain with coAwait()", replaceWith = ReplaceWith("getAndAdd(value).coAwait()"))
 suspend fun Counter.getAndAddAwait(value: Long): Long {
   return awaitResult {
     this.getAndAdd(value, it)
@@ -113,7 +113,7 @@ suspend fun Counter.getAndAddAwait(value: Long): Long {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.shareddata.Counter] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use compareAndSet returning a future and chain with await()", replaceWith = ReplaceWith("compareAndSet(expected, value).await()"))
+@Deprecated(message = "Instead use compareAndSet returning a future and chain with coAwait()", replaceWith = ReplaceWith("compareAndSet(expected, value).coAwait()"))
 suspend fun Counter.compareAndSetAwait(expected: Long, value: Long): Boolean {
   return awaitResult {
     this.compareAndSet(expected, value, it)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/shareddata/SharedData.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/shareddata/SharedData.kt
@@ -29,7 +29,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.shareddata.SharedData] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use getClusterWideMap returning a future and chain with await()", replaceWith = ReplaceWith("getClusterWideMap(name).await()"))
+@Deprecated(message = "Instead use getClusterWideMap returning a future and chain with coAwait()", replaceWith = ReplaceWith("getClusterWideMap(name).coAwait()"))
 suspend fun <K,V> SharedData.getClusterWideMapAwait(name: String): AsyncMap<K,V> {
   return awaitResult {
     this.getClusterWideMap(name, it)
@@ -44,7 +44,7 @@ suspend fun <K,V> SharedData.getClusterWideMapAwait(name: String): AsyncMap<K,V>
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.shareddata.SharedData] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use getAsyncMap returning a future and chain with await()", replaceWith = ReplaceWith("getAsyncMap(name).await()"))
+@Deprecated(message = "Instead use getAsyncMap returning a future and chain with coAwait()", replaceWith = ReplaceWith("getAsyncMap(name).coAwait()"))
 suspend fun <K,V> SharedData.getAsyncMapAwait(name: String): AsyncMap<K,V> {
   return awaitResult {
     this.getAsyncMap(name, it)
@@ -59,7 +59,7 @@ suspend fun <K,V> SharedData.getAsyncMapAwait(name: String): AsyncMap<K,V> {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.shareddata.SharedData] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use getLocalAsyncMap returning a future and chain with await()", replaceWith = ReplaceWith("getLocalAsyncMap(name).await()"))
+@Deprecated(message = "Instead use getLocalAsyncMap returning a future and chain with coAwait()", replaceWith = ReplaceWith("getLocalAsyncMap(name).coAwait()"))
 suspend fun <K,V> SharedData.getLocalAsyncMapAwait(name: String): AsyncMap<K,V> {
   return awaitResult {
     this.getLocalAsyncMap(name, it)
@@ -74,7 +74,7 @@ suspend fun <K,V> SharedData.getLocalAsyncMapAwait(name: String): AsyncMap<K,V> 
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.shareddata.SharedData] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use getLock returning a future and chain with await()", replaceWith = ReplaceWith("getLock(name).await()"))
+@Deprecated(message = "Instead use getLock returning a future and chain with coAwait()", replaceWith = ReplaceWith("getLock(name).coAwait()"))
 suspend fun SharedData.getLockAwait(name: String): Lock {
   return awaitResult {
     this.getLock(name, it)
@@ -90,7 +90,7 @@ suspend fun SharedData.getLockAwait(name: String): Lock {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.shareddata.SharedData] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use getLockWithTimeout returning a future and chain with await()", replaceWith = ReplaceWith("getLockWithTimeout(name, timeout).await()"))
+@Deprecated(message = "Instead use getLockWithTimeout returning a future and chain with coAwait()", replaceWith = ReplaceWith("getLockWithTimeout(name, timeout).coAwait()"))
 suspend fun SharedData.getLockWithTimeoutAwait(name: String, timeout: Long): Lock {
   return awaitResult {
     this.getLockWithTimeout(name, timeout, it)
@@ -105,7 +105,7 @@ suspend fun SharedData.getLockWithTimeoutAwait(name: String, timeout: Long): Loc
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.shareddata.SharedData] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use getLocalLock returning a future and chain with await()", replaceWith = ReplaceWith("getLocalLock(name).await()"))
+@Deprecated(message = "Instead use getLocalLock returning a future and chain with coAwait()", replaceWith = ReplaceWith("getLocalLock(name).coAwait()"))
 suspend fun SharedData.getLocalLockAwait(name: String): Lock {
   return awaitResult {
     this.getLocalLock(name, it)
@@ -121,7 +121,7 @@ suspend fun SharedData.getLocalLockAwait(name: String): Lock {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.shareddata.SharedData] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use getLocalLockWithTimeout returning a future and chain with await()", replaceWith = ReplaceWith("getLocalLockWithTimeout(name, timeout).await()"))
+@Deprecated(message = "Instead use getLocalLockWithTimeout returning a future and chain with coAwait()", replaceWith = ReplaceWith("getLocalLockWithTimeout(name, timeout).coAwait()"))
 suspend fun SharedData.getLocalLockWithTimeoutAwait(name: String, timeout: Long): Lock {
   return awaitResult {
     this.getLocalLockWithTimeout(name, timeout, it)
@@ -136,7 +136,7 @@ suspend fun SharedData.getLocalLockWithTimeoutAwait(name: String, timeout: Long)
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.shareddata.SharedData] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use getCounter returning a future and chain with await()", replaceWith = ReplaceWith("getCounter(name).await()"))
+@Deprecated(message = "Instead use getCounter returning a future and chain with coAwait()", replaceWith = ReplaceWith("getCounter(name).coAwait()"))
 suspend fun SharedData.getCounterAwait(name: String): Counter {
   return awaitResult {
     this.getCounter(name, it)
@@ -151,7 +151,7 @@ suspend fun SharedData.getCounterAwait(name: String): Counter {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.shareddata.SharedData] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use getLocalCounter returning a future and chain with await()", replaceWith = ReplaceWith("getLocalCounter(name).await()"))
+@Deprecated(message = "Instead use getLocalCounter returning a future and chain with coAwait()", replaceWith = ReplaceWith("getLocalCounter(name).coAwait()"))
 suspend fun SharedData.getLocalCounterAwait(name: String): Counter {
   return awaitResult {
     this.getLocalCounter(name, it)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/streams/Pipe.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/streams/Pipe.kt
@@ -26,7 +26,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.streams.Pipe] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use to returning a future and chain with await()", replaceWith = ReplaceWith("to(dst).await()"))
+@Deprecated(message = "Instead use to returning a future and chain with coAwait()", replaceWith = ReplaceWith("to(dst).coAwait()"))
 suspend fun <T> Pipe<T>.toAwait(dst: WriteStream<T>): Unit {
   return awaitResult {
     this.to(dst, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/streams/ReadStream.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/streams/ReadStream.kt
@@ -26,7 +26,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.streams.ReadStream] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use pipeTo returning a future and chain with await()", replaceWith = ReplaceWith("pipeTo(dst).await()"))
+@Deprecated(message = "Instead use pipeTo returning a future and chain with coAwait()", replaceWith = ReplaceWith("pipeTo(dst).coAwait()"))
 suspend fun <T> ReadStream<T>.pipeToAwait(dst: WriteStream<T>): Unit {
   return awaitResult {
     this.pipeTo(dst, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/streams/WriteStream.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/core/streams/WriteStream.kt
@@ -25,7 +25,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.streams.WriteStream] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use write returning a future and chain with await()", replaceWith = ReplaceWith("write(data).await()"))
+@Deprecated(message = "Instead use write returning a future and chain with coAwait()", replaceWith = ReplaceWith("write(data).coAwait()"))
 suspend fun <T> WriteStream<T>.writeAwait(data: T): Unit {
   return awaitResult {
     this.write(data, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -38,7 +38,7 @@ suspend fun <T> WriteStream<T>.writeAwait(data: T): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.streams.WriteStream] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use end returning a future and chain with await()", replaceWith = ReplaceWith("end().await()"))
+@Deprecated(message = "Instead use end returning a future and chain with coAwait()", replaceWith = ReplaceWith("end().coAwait()"))
 suspend fun <T> WriteStream<T>.endAwait(): Unit {
   return awaitResult {
     this.end(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -52,7 +52,7 @@ suspend fun <T> WriteStream<T>.endAwait(): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.core.streams.WriteStream] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use end returning a future and chain with await()", replaceWith = ReplaceWith("end(data).await()"))
+@Deprecated(message = "Instead use end returning a future and chain with coAwait()", replaceWith = ReplaceWith("end(data).coAwait()"))
 suspend fun <T> WriteStream<T>.endAwait(data: T): Unit {
   return awaitResult {
     this.end(data, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/db2client/DB2Connection.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/db2client/DB2Connection.kt
@@ -21,7 +21,7 @@ import io.vertx.db2client.DB2Connection as DB2ConnectionVertxAlias
 import io.vertx.kotlin.coroutines.awaitResult
 import io.vertx.sqlclient.PreparedStatement
 
-@Deprecated(message = "Instead use prepare returning a future and chain with await()", replaceWith = ReplaceWith("prepare(sql).await()"))
+@Deprecated(message = "Instead use prepare returning a future and chain with coAwait()", replaceWith = ReplaceWith("prepare(sql).coAwait()"))
 suspend fun DB2ConnectionVertxAlias.prepareAwait(sql: String): PreparedStatement {
   return awaitResult {
     this.prepare(sql, it)
@@ -34,7 +34,7 @@ suspend fun DB2ConnectionVertxAlias.prepareAwait(sql: String): PreparedStatement
  *
  * NOTE: This function has been automatically generated from [io.vertx.db2client.DB2Connection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use ping returning a future and chain with await()", replaceWith = ReplaceWith("ping().await()"))
+@Deprecated(message = "Instead use ping returning a future and chain with coAwait()", replaceWith = ReplaceWith("ping().coAwait()"))
 suspend fun DB2ConnectionVertxAlias.pingAwait(): Unit {
   return awaitResult {
     this.ping(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -47,7 +47,7 @@ suspend fun DB2ConnectionVertxAlias.pingAwait(): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.db2client.DB2Connection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use debug returning a future and chain with await()", replaceWith = ReplaceWith("debug().await()"))
+@Deprecated(message = "Instead use debug returning a future and chain with coAwait()", replaceWith = ReplaceWith("debug().coAwait()"))
 suspend fun DB2ConnectionVertxAlias.debugAwait(): Unit {
   return awaitResult {
     this.debug(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -64,7 +64,7 @@ object DB2Connection {
    *
    * NOTE: This function has been automatically generated from [io.vertx.db2client.DB2Connection] using Vert.x codegen.
    */
-  @Deprecated(message = "Instead use connect returning a future and chain with await()", replaceWith = ReplaceWith("connect(vertx, connectOptions).await()"))
+  @Deprecated(message = "Instead use connect returning a future and chain with coAwait()", replaceWith = ReplaceWith("connect(vertx, connectOptions).coAwait()"))
   suspend fun connectAwait(vertx: Vertx, connectOptions: DB2ConnectOptions): DB2ConnectionVertxAlias {
     return awaitResult {
       DB2ConnectionVertxAlias.connect(vertx, connectOptions, it)
@@ -80,7 +80,7 @@ object DB2Connection {
    *
    * NOTE: This function has been automatically generated from [io.vertx.db2client.DB2Connection] using Vert.x codegen.
    */
-  @Deprecated(message = "Instead use connect returning a future and chain with await()", replaceWith = ReplaceWith("connect(vertx, connectionUri).await()"))
+  @Deprecated(message = "Instead use connect returning a future and chain with coAwait()", replaceWith = ReplaceWith("connect(vertx, connectionUri).coAwait()"))
   suspend fun connectAwait(vertx: Vertx, connectionUri: String): DB2ConnectionVertxAlias {
     return awaitResult {
       DB2ConnectionVertxAlias.connect(vertx, connectionUri, it)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/auth/authorization/AuthorizationProvider.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/auth/authorization/AuthorizationProvider.kt
@@ -26,7 +26,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.auth.authorization.AuthorizationProvider] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use getAuthorizations returning a future and chain with await()", replaceWith = ReplaceWith("getAuthorizations(user).await()"))
+@Deprecated(message = "Instead use getAuthorizations returning a future and chain with coAwait()", replaceWith = ReplaceWith("getAuthorizations(user).coAwait()"))
 suspend fun AuthorizationProvider.getAuthorizationsAwait(user: User): Unit {
   return awaitResult {
     this.getAuthorizations(user, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/auth/mongo/MongoUserUtil.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/auth/mongo/MongoUserUtil.kt
@@ -27,7 +27,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.auth.mongo.MongoUserUtil] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use createUser returning a future and chain with await()", replaceWith = ReplaceWith("createUser(username, password).await()"))
+@Deprecated(message = "Instead use createUser returning a future and chain with coAwait()", replaceWith = ReplaceWith("createUser(username, password).coAwait()"))
 suspend fun MongoUserUtil.createUserAwait(username: String, password: String): String {
   return awaitResult {
     this.createUser(username, password, it)
@@ -43,7 +43,7 @@ suspend fun MongoUserUtil.createUserAwait(username: String, password: String): S
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.auth.mongo.MongoUserUtil] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use createHashedUser returning a future and chain with await()", replaceWith = ReplaceWith("createHashedUser(username, hash).await()"))
+@Deprecated(message = "Instead use createHashedUser returning a future and chain with coAwait()", replaceWith = ReplaceWith("createHashedUser(username, hash).coAwait()"))
 suspend fun MongoUserUtil.createHashedUserAwait(username: String, hash: String): String {
   return awaitResult {
     this.createHashedUser(username, hash, it)
@@ -60,7 +60,7 @@ suspend fun MongoUserUtil.createHashedUserAwait(username: String, hash: String):
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.auth.mongo.MongoUserUtil] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use createUserRolesAndPermissions returning a future and chain with await()", replaceWith = ReplaceWith("createUserRolesAndPermissions(username, roles, permissions).await()"))
+@Deprecated(message = "Instead use createUserRolesAndPermissions returning a future and chain with coAwait()", replaceWith = ReplaceWith("createUserRolesAndPermissions(username, roles, permissions).coAwait()"))
 suspend fun MongoUserUtil.createUserRolesAndPermissionsAwait(username: String, roles: List<String>, permissions: List<String>): String {
   return awaitResult {
     this.createUserRolesAndPermissions(username, roles, permissions, it)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/auth/oauth2/OAuth2Auth.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/auth/oauth2/OAuth2Auth.kt
@@ -26,7 +26,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.auth.oauth2.OAuth2Auth] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use jWKSet returning a future and chain with await()", replaceWith = ReplaceWith("jWKSet().await()"))
+@Deprecated(message = "Instead use jWKSet returning a future and chain with coAwait()", replaceWith = ReplaceWith("jWKSet().coAwait()"))
 suspend fun OAuth2Auth.jWKSetAwait(): Unit {
   return awaitResult {
     this.jWKSet(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -41,7 +41,7 @@ suspend fun OAuth2Auth.jWKSetAwait(): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.auth.oauth2.OAuth2Auth] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use refresh returning a future and chain with await()", replaceWith = ReplaceWith("refresh(user).await()"))
+@Deprecated(message = "Instead use refresh returning a future and chain with coAwait()", replaceWith = ReplaceWith("refresh(user).coAwait()"))
 suspend fun OAuth2Auth.refreshAwait(user: User): User {
   return awaitResult {
     this.refresh(user, it)
@@ -56,7 +56,7 @@ suspend fun OAuth2Auth.refreshAwait(user: User): User {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.auth.oauth2.OAuth2Auth] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use revoke returning a future and chain with await()", replaceWith = ReplaceWith("revoke(user, tokenType).await()"))
+@Deprecated(message = "Instead use revoke returning a future and chain with coAwait()", replaceWith = ReplaceWith("revoke(user, tokenType).coAwait()"))
 suspend fun OAuth2Auth.revokeAwait(user: User, tokenType: String): Unit {
   return awaitResult {
     this.revoke(user, tokenType, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -70,7 +70,7 @@ suspend fun OAuth2Auth.revokeAwait(user: User, tokenType: String): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.auth.oauth2.OAuth2Auth] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use revoke returning a future and chain with await()", replaceWith = ReplaceWith("revoke(user).await()"))
+@Deprecated(message = "Instead use revoke returning a future and chain with coAwait()", replaceWith = ReplaceWith("revoke(user).coAwait()"))
 suspend fun OAuth2Auth.revokeAwait(user: User): Unit {
   return awaitResult {
     this.revoke(user, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -85,7 +85,7 @@ suspend fun OAuth2Auth.revokeAwait(user: User): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.auth.oauth2.OAuth2Auth] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use userInfo returning a future and chain with await()", replaceWith = ReplaceWith("userInfo(user).await()"))
+@Deprecated(message = "Instead use userInfo returning a future and chain with coAwait()", replaceWith = ReplaceWith("userInfo(user).coAwait()"))
 suspend fun OAuth2Auth.userInfoAwait(user: User): JsonObject {
   return awaitResult {
     this.userInfo(user, it)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/auth/oauth2/providers/AmazonCognitoAuth.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/auth/oauth2/providers/AmazonCognitoAuth.kt
@@ -31,7 +31,7 @@ object AmazonCognitoAuth {
    *
    * NOTE: This function has been automatically generated from [io.vertx.ext.auth.oauth2.providers.AmazonCognitoAuth] using Vert.x codegen.
    */
-  @Deprecated(message = "Instead use discover returning a future and chain with await()", replaceWith = ReplaceWith("discover(vertx, config).await()"))
+  @Deprecated(message = "Instead use discover returning a future and chain with coAwait()", replaceWith = ReplaceWith("discover(vertx, config).coAwait()"))
   suspend fun discoverAwait(vertx: Vertx, config: OAuth2Options): OAuth2Auth {
     return awaitResult {
       AmazonCognitoAuthVertxAlias.discover(vertx, config, it)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/auth/oauth2/providers/AzureADAuth.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/auth/oauth2/providers/AzureADAuth.kt
@@ -31,7 +31,7 @@ object AzureADAuth {
    *
    * NOTE: This function has been automatically generated from [io.vertx.ext.auth.oauth2.providers.AzureADAuth] using Vert.x codegen.
    */
-  @Deprecated(message = "Instead use discover returning a future and chain with await()", replaceWith = ReplaceWith("discover(vertx, config).await()"))
+  @Deprecated(message = "Instead use discover returning a future and chain with coAwait()", replaceWith = ReplaceWith("discover(vertx, config).coAwait()"))
   suspend fun discoverAwait(vertx: Vertx, config: OAuth2Options): OAuth2Auth {
     return awaitResult {
       AzureADAuthVertxAlias.discover(vertx, config, it)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/auth/oauth2/providers/GoogleAuth.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/auth/oauth2/providers/GoogleAuth.kt
@@ -31,7 +31,7 @@ object GoogleAuth {
    *
    * NOTE: This function has been automatically generated from [io.vertx.ext.auth.oauth2.providers.GoogleAuth] using Vert.x codegen.
    */
-  @Deprecated(message = "Instead use discover returning a future and chain with await()", replaceWith = ReplaceWith("discover(vertx, config).await()"))
+  @Deprecated(message = "Instead use discover returning a future and chain with coAwait()", replaceWith = ReplaceWith("discover(vertx, config).coAwait()"))
   suspend fun discoverAwait(vertx: Vertx, config: OAuth2Options): OAuth2Auth {
     return awaitResult {
       GoogleAuthVertxAlias.discover(vertx, config, it)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/auth/oauth2/providers/IBMCloudAuth.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/auth/oauth2/providers/IBMCloudAuth.kt
@@ -31,7 +31,7 @@ object IBMCloudAuth {
    *
    * NOTE: This function has been automatically generated from [io.vertx.ext.auth.oauth2.providers.IBMCloudAuth] using Vert.x codegen.
    */
-  @Deprecated(message = "Instead use discover returning a future and chain with await()", replaceWith = ReplaceWith("discover(vertx, config).await()"))
+  @Deprecated(message = "Instead use discover returning a future and chain with coAwait()", replaceWith = ReplaceWith("discover(vertx, config).coAwait()"))
   suspend fun discoverAwait(vertx: Vertx, config: OAuth2Options): OAuth2Auth {
     return awaitResult {
       IBMCloudAuthVertxAlias.discover(vertx, config, it)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/auth/oauth2/providers/KeycloakAuth.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/auth/oauth2/providers/KeycloakAuth.kt
@@ -31,7 +31,7 @@ object KeycloakAuth {
    *
    * NOTE: This function has been automatically generated from [io.vertx.ext.auth.oauth2.providers.KeycloakAuth] using Vert.x codegen.
    */
-  @Deprecated(message = "Instead use discover returning a future and chain with await()", replaceWith = ReplaceWith("discover(vertx, config).await()"))
+  @Deprecated(message = "Instead use discover returning a future and chain with coAwait()", replaceWith = ReplaceWith("discover(vertx, config).coAwait()"))
   suspend fun discoverAwait(vertx: Vertx, config: OAuth2Options): OAuth2Auth {
     return awaitResult {
       KeycloakAuthVertxAlias.discover(vertx, config, it)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/auth/oauth2/providers/OpenIDConnectAuth.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/auth/oauth2/providers/OpenIDConnectAuth.kt
@@ -31,7 +31,7 @@ object OpenIDConnectAuth {
    *
    * NOTE: This function has been automatically generated from [io.vertx.ext.auth.oauth2.providers.OpenIDConnectAuth] using Vert.x codegen.
    */
-  @Deprecated(message = "Instead use discover returning a future and chain with await()", replaceWith = ReplaceWith("discover(vertx, config).await()"))
+  @Deprecated(message = "Instead use discover returning a future and chain with coAwait()", replaceWith = ReplaceWith("discover(vertx, config).coAwait()"))
   suspend fun discoverAwait(vertx: Vertx, config: OAuth2Options): OAuth2Auth {
     return awaitResult {
       OpenIDConnectAuthVertxAlias.discover(vertx, config, it)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/auth/oauth2/providers/SalesforceAuth.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/auth/oauth2/providers/SalesforceAuth.kt
@@ -31,7 +31,7 @@ object SalesforceAuth {
    *
    * NOTE: This function has been automatically generated from [io.vertx.ext.auth.oauth2.providers.SalesforceAuth] using Vert.x codegen.
    */
-  @Deprecated(message = "Instead use discover returning a future and chain with await()", replaceWith = ReplaceWith("discover(vertx, config).await()"))
+  @Deprecated(message = "Instead use discover returning a future and chain with coAwait()", replaceWith = ReplaceWith("discover(vertx, config).coAwait()"))
   suspend fun discoverAwait(vertx: Vertx, config: OAuth2Options): OAuth2Auth {
     return awaitResult {
       SalesforceAuthVertxAlias.discover(vertx, config, it)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/auth/sqlclient/SqlUserUtil.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/auth/sqlclient/SqlUserUtil.kt
@@ -26,7 +26,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.auth.sqlclient.SqlUserUtil] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use createUser returning a future and chain with await()", replaceWith = ReplaceWith("createUser(username, password).await()"))
+@Deprecated(message = "Instead use createUser returning a future and chain with coAwait()", replaceWith = ReplaceWith("createUser(username, password).coAwait()"))
 suspend fun SqlUserUtil.createUserAwait(username: String, password: String): Unit {
   return awaitResult {
     this.createUser(username, password, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -41,7 +41,7 @@ suspend fun SqlUserUtil.createUserAwait(username: String, password: String): Uni
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.auth.sqlclient.SqlUserUtil] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use createHashedUser returning a future and chain with await()", replaceWith = ReplaceWith("createHashedUser(username, hash).await()"))
+@Deprecated(message = "Instead use createHashedUser returning a future and chain with coAwait()", replaceWith = ReplaceWith("createHashedUser(username, hash).coAwait()"))
 suspend fun SqlUserUtil.createHashedUserAwait(username: String, hash: String): Unit {
   return awaitResult {
     this.createHashedUser(username, hash, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -56,7 +56,7 @@ suspend fun SqlUserUtil.createHashedUserAwait(username: String, hash: String): U
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.auth.sqlclient.SqlUserUtil] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use createUserRole returning a future and chain with await()", replaceWith = ReplaceWith("createUserRole(username, role).await()"))
+@Deprecated(message = "Instead use createUserRole returning a future and chain with coAwait()", replaceWith = ReplaceWith("createUserRole(username, role).coAwait()"))
 suspend fun SqlUserUtil.createUserRoleAwait(username: String, role: String): Unit {
   return awaitResult {
     this.createUserRole(username, role, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -71,7 +71,7 @@ suspend fun SqlUserUtil.createUserRoleAwait(username: String, role: String): Uni
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.auth.sqlclient.SqlUserUtil] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use createRolePermission returning a future and chain with await()", replaceWith = ReplaceWith("createRolePermission(role, permission).await()"))
+@Deprecated(message = "Instead use createRolePermission returning a future and chain with coAwait()", replaceWith = ReplaceWith("createRolePermission(role, permission).coAwait()"))
 suspend fun SqlUserUtil.createRolePermissionAwait(role: String, permission: String): Unit {
   return awaitResult {
     this.createRolePermission(role, permission, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/auth/webauthn/MetaDataService.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/auth/webauthn/MetaDataService.kt
@@ -26,7 +26,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.auth.webauthn.MetaDataService] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use fetchTOC returning a future and chain with await()", replaceWith = ReplaceWith("fetchTOC(url).await()"))
+@Deprecated(message = "Instead use fetchTOC returning a future and chain with coAwait()", replaceWith = ReplaceWith("fetchTOC(url).coAwait()"))
 suspend fun MetaDataService.fetchTOCAwait(url: String): Boolean {
   return awaitResult {
     this.fetchTOC(url, it)
@@ -40,7 +40,7 @@ suspend fun MetaDataService.fetchTOCAwait(url: String): Boolean {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.auth.webauthn.MetaDataService] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use fetchTOC returning a future and chain with await()", replaceWith = ReplaceWith("fetchTOC().await()"))
+@Deprecated(message = "Instead use fetchTOC returning a future and chain with coAwait()", replaceWith = ReplaceWith("fetchTOC().coAwait()"))
 suspend fun MetaDataService.fetchTOCAwait(): Boolean {
   return awaitResult {
     this.fetchTOC(it)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/auth/webauthn/WebAuthn.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/auth/webauthn/WebAuthn.kt
@@ -27,7 +27,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.auth.webauthn.WebAuthn] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use createCredentialsOptions returning a future and chain with await()", replaceWith = ReplaceWith("createCredentialsOptions(user).await()"))
+@Deprecated(message = "Instead use createCredentialsOptions returning a future and chain with coAwait()", replaceWith = ReplaceWith("createCredentialsOptions(user).coAwait()"))
 suspend fun WebAuthn.createCredentialsOptionsAwait(user: JsonObject): JsonObject {
   return awaitResult {
     this.createCredentialsOptions(user, it)
@@ -42,7 +42,7 @@ suspend fun WebAuthn.createCredentialsOptionsAwait(user: JsonObject): JsonObject
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.auth.webauthn.WebAuthn] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use getCredentialsOptions returning a future and chain with await()", replaceWith = ReplaceWith("getCredentialsOptions(name).await()"))
+@Deprecated(message = "Instead use getCredentialsOptions returning a future and chain with coAwait()", replaceWith = ReplaceWith("getCredentialsOptions(name).coAwait()"))
 suspend fun WebAuthn.getCredentialsOptionsAwait(name: String?): JsonObject {
   return awaitResult {
     this.getCredentialsOptions(name, it)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/consul/ConsulClient.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/consul/ConsulClient.kt
@@ -62,7 +62,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use agentInfo returning a future and chain with await()", replaceWith = ReplaceWith("agentInfo().await()"))
+@Deprecated(message = "Instead use agentInfo returning a future and chain with coAwait()", replaceWith = ReplaceWith("agentInfo().coAwait()"))
 suspend fun ConsulClient.agentInfoAwait(): JsonObject {
   return awaitResult {
     this.agentInfo(it)
@@ -76,7 +76,7 @@ suspend fun ConsulClient.agentInfoAwait(): JsonObject {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use coordinateNodes returning a future and chain with await()", replaceWith = ReplaceWith("coordinateNodes().await()"))
+@Deprecated(message = "Instead use coordinateNodes returning a future and chain with coAwait()", replaceWith = ReplaceWith("coordinateNodes().coAwait()"))
 suspend fun ConsulClient.coordinateNodesAwait(): CoordinateList {
   return awaitResult {
     this.coordinateNodes(it)
@@ -91,7 +91,7 @@ suspend fun ConsulClient.coordinateNodesAwait(): CoordinateList {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use coordinateNodesWithOptions returning a future and chain with await()", replaceWith = ReplaceWith("coordinateNodesWithOptions(options).await()"))
+@Deprecated(message = "Instead use coordinateNodesWithOptions returning a future and chain with coAwait()", replaceWith = ReplaceWith("coordinateNodesWithOptions(options).coAwait()"))
 suspend fun ConsulClient.coordinateNodesWithOptionsAwait(options: BlockingQueryOptions): CoordinateList {
   return awaitResult {
     this.coordinateNodesWithOptions(options, it)
@@ -105,7 +105,7 @@ suspend fun ConsulClient.coordinateNodesWithOptionsAwait(options: BlockingQueryO
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use coordinateDatacenters returning a future and chain with await()", replaceWith = ReplaceWith("coordinateDatacenters().await()"))
+@Deprecated(message = "Instead use coordinateDatacenters returning a future and chain with coAwait()", replaceWith = ReplaceWith("coordinateDatacenters().coAwait()"))
 suspend fun ConsulClient.coordinateDatacentersAwait(): List<DcCoordinates> {
   return awaitResult {
     this.coordinateDatacenters(it)
@@ -120,7 +120,7 @@ suspend fun ConsulClient.coordinateDatacentersAwait(): List<DcCoordinates> {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use getKeys returning a future and chain with await()", replaceWith = ReplaceWith("getKeys(keyPrefix).await()"))
+@Deprecated(message = "Instead use getKeys returning a future and chain with coAwait()", replaceWith = ReplaceWith("getKeys(keyPrefix).coAwait()"))
 suspend fun ConsulClient.getKeysAwait(keyPrefix: String): List<String> {
   return awaitResult {
     this.getKeys(keyPrefix, it)
@@ -136,7 +136,7 @@ suspend fun ConsulClient.getKeysAwait(keyPrefix: String): List<String> {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use getKeysWithOptions returning a future and chain with await()", replaceWith = ReplaceWith("getKeysWithOptions(keyPrefix, options).await()"))
+@Deprecated(message = "Instead use getKeysWithOptions returning a future and chain with coAwait()", replaceWith = ReplaceWith("getKeysWithOptions(keyPrefix, options).coAwait()"))
 suspend fun ConsulClient.getKeysWithOptionsAwait(keyPrefix: String, options: BlockingQueryOptions): List<String> {
   return awaitResult {
     this.getKeysWithOptions(keyPrefix, options, it)
@@ -151,7 +151,7 @@ suspend fun ConsulClient.getKeysWithOptionsAwait(keyPrefix: String, options: Blo
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use getValue returning a future and chain with await()", replaceWith = ReplaceWith("getValue(key).await()"))
+@Deprecated(message = "Instead use getValue returning a future and chain with coAwait()", replaceWith = ReplaceWith("getValue(key).coAwait()"))
 suspend fun ConsulClient.getValueAwait(key: String): KeyValue {
   return awaitResult {
     this.getValue(key, it)
@@ -167,7 +167,7 @@ suspend fun ConsulClient.getValueAwait(key: String): KeyValue {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use getValueWithOptions returning a future and chain with await()", replaceWith = ReplaceWith("getValueWithOptions(key, options).await()"))
+@Deprecated(message = "Instead use getValueWithOptions returning a future and chain with coAwait()", replaceWith = ReplaceWith("getValueWithOptions(key, options).coAwait()"))
 suspend fun ConsulClient.getValueWithOptionsAwait(key: String, options: BlockingQueryOptions): KeyValue {
   return awaitResult {
     this.getValueWithOptions(key, options, it)
@@ -181,7 +181,7 @@ suspend fun ConsulClient.getValueWithOptionsAwait(key: String, options: Blocking
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use deleteValue returning a future and chain with await()", replaceWith = ReplaceWith("deleteValue(key).await()"))
+@Deprecated(message = "Instead use deleteValue returning a future and chain with coAwait()", replaceWith = ReplaceWith("deleteValue(key).coAwait()"))
 suspend fun ConsulClient.deleteValueAwait(key: String): Unit {
   return awaitResult {
     this.deleteValue(key, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -196,7 +196,7 @@ suspend fun ConsulClient.deleteValueAwait(key: String): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use getValues returning a future and chain with await()", replaceWith = ReplaceWith("getValues(keyPrefix).await()"))
+@Deprecated(message = "Instead use getValues returning a future and chain with coAwait()", replaceWith = ReplaceWith("getValues(keyPrefix).coAwait()"))
 suspend fun ConsulClient.getValuesAwait(keyPrefix: String): KeyValueList {
   return awaitResult {
     this.getValues(keyPrefix, it)
@@ -212,7 +212,7 @@ suspend fun ConsulClient.getValuesAwait(keyPrefix: String): KeyValueList {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use getValuesWithOptions returning a future and chain with await()", replaceWith = ReplaceWith("getValuesWithOptions(keyPrefix, options).await()"))
+@Deprecated(message = "Instead use getValuesWithOptions returning a future and chain with coAwait()", replaceWith = ReplaceWith("getValuesWithOptions(keyPrefix, options).coAwait()"))
 suspend fun ConsulClient.getValuesWithOptionsAwait(keyPrefix: String, options: BlockingQueryOptions): KeyValueList {
   return awaitResult {
     this.getValuesWithOptions(keyPrefix, options, it)
@@ -226,7 +226,7 @@ suspend fun ConsulClient.getValuesWithOptionsAwait(keyPrefix: String, options: B
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use deleteValues returning a future and chain with await()", replaceWith = ReplaceWith("deleteValues(keyPrefix).await()"))
+@Deprecated(message = "Instead use deleteValues returning a future and chain with coAwait()", replaceWith = ReplaceWith("deleteValues(keyPrefix).coAwait()"))
 suspend fun ConsulClient.deleteValuesAwait(keyPrefix: String): Unit {
   return awaitResult {
     this.deleteValues(keyPrefix, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -242,7 +242,7 @@ suspend fun ConsulClient.deleteValuesAwait(keyPrefix: String): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use putValue returning a future and chain with await()", replaceWith = ReplaceWith("putValue(key, value).await()"))
+@Deprecated(message = "Instead use putValue returning a future and chain with coAwait()", replaceWith = ReplaceWith("putValue(key, value).coAwait()"))
 suspend fun ConsulClient.putValueAwait(key: String, value: String): Boolean {
   return awaitResult {
     this.putValue(key, value, it)
@@ -259,7 +259,7 @@ suspend fun ConsulClient.putValueAwait(key: String, value: String): Boolean {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use putValueWithOptions returning a future and chain with await()", replaceWith = ReplaceWith("putValueWithOptions(key, value, options).await()"))
+@Deprecated(message = "Instead use putValueWithOptions returning a future and chain with coAwait()", replaceWith = ReplaceWith("putValueWithOptions(key, value, options).coAwait()"))
 suspend fun ConsulClient.putValueWithOptionsAwait(key: String, value: String, options: KeyValueOptions): Boolean {
   return awaitResult {
     this.putValueWithOptions(key, value, options, it)
@@ -274,7 +274,7 @@ suspend fun ConsulClient.putValueWithOptionsAwait(key: String, value: String, op
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use transaction returning a future and chain with await()", replaceWith = ReplaceWith("transaction(request).await()"))
+@Deprecated(message = "Instead use transaction returning a future and chain with coAwait()", replaceWith = ReplaceWith("transaction(request).coAwait()"))
 suspend fun ConsulClient.transactionAwait(request: TxnRequest): TxnResponse {
   return awaitResult {
     this.transaction(request, it)
@@ -289,7 +289,7 @@ suspend fun ConsulClient.transactionAwait(request: TxnRequest): TxnResponse {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use createAclPolicy returning a future and chain with await()", replaceWith = ReplaceWith("createAclPolicy(policy).await()"))
+@Deprecated(message = "Instead use createAclPolicy returning a future and chain with coAwait()", replaceWith = ReplaceWith("createAclPolicy(policy).coAwait()"))
 suspend fun ConsulClient.createAclPolicyAwait(policy: AclPolicy): String {
   return awaitResult {
     this.createAclPolicy(policy, it)
@@ -304,7 +304,7 @@ suspend fun ConsulClient.createAclPolicyAwait(policy: AclPolicy): String {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use readPolicy returning a future and chain with await()", replaceWith = ReplaceWith("readPolicy(id).await()"))
+@Deprecated(message = "Instead use readPolicy returning a future and chain with coAwait()", replaceWith = ReplaceWith("readPolicy(id).coAwait()"))
 suspend fun ConsulClient.readPolicyAwait(id: String): AclPolicy {
   return awaitResult {
     this.readPolicy(id, it)
@@ -319,7 +319,7 @@ suspend fun ConsulClient.readPolicyAwait(id: String): AclPolicy {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use readPolicyByName returning a future and chain with await()", replaceWith = ReplaceWith("readPolicyByName(name).await()"))
+@Deprecated(message = "Instead use readPolicyByName returning a future and chain with coAwait()", replaceWith = ReplaceWith("readPolicyByName(name).coAwait()"))
 suspend fun ConsulClient.readPolicyByNameAwait(name: String): AclPolicy {
   return awaitResult {
     this.readPolicyByName(name, it)
@@ -335,7 +335,7 @@ suspend fun ConsulClient.readPolicyByNameAwait(name: String): AclPolicy {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use updatePolicy returning a future and chain with await()", replaceWith = ReplaceWith("updatePolicy(id, policy).await()"))
+@Deprecated(message = "Instead use updatePolicy returning a future and chain with coAwait()", replaceWith = ReplaceWith("updatePolicy(id, policy).coAwait()"))
 suspend fun ConsulClient.updatePolicyAwait(id: String, policy: AclPolicy): AclPolicy {
   return awaitResult {
     this.updatePolicy(id, policy, it)
@@ -350,7 +350,7 @@ suspend fun ConsulClient.updatePolicyAwait(id: String, policy: AclPolicy): AclPo
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use createAclToken returning a future and chain with await()", replaceWith = ReplaceWith("createAclToken(token).await()"))
+@Deprecated(message = "Instead use createAclToken returning a future and chain with coAwait()", replaceWith = ReplaceWith("createAclToken(token).coAwait()"))
 suspend fun ConsulClient.createAclTokenAwait(token: AclToken): AclToken {
   return awaitResult {
     this.createAclToken(token, it)
@@ -366,7 +366,7 @@ suspend fun ConsulClient.createAclTokenAwait(token: AclToken): AclToken {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use updateAclToken returning a future and chain with await()", replaceWith = ReplaceWith("updateAclToken(accessorId, token).await()"))
+@Deprecated(message = "Instead use updateAclToken returning a future and chain with coAwait()", replaceWith = ReplaceWith("updateAclToken(accessorId, token).coAwait()"))
 suspend fun ConsulClient.updateAclTokenAwait(accessorId: String, token: AclToken): AclToken {
   return awaitResult {
     this.updateAclToken(accessorId, token, it)
@@ -382,7 +382,7 @@ suspend fun ConsulClient.updateAclTokenAwait(accessorId: String, token: AclToken
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use cloneAclToken returning a future and chain with await()", replaceWith = ReplaceWith("cloneAclToken(accessorId, cloneAclToken).await()"))
+@Deprecated(message = "Instead use cloneAclToken returning a future and chain with coAwait()", replaceWith = ReplaceWith("cloneAclToken(accessorId, cloneAclToken).coAwait()"))
 suspend fun ConsulClient.cloneAclTokenAwait(accessorId: String, cloneAclToken: CloneAclTokenOptions): AclToken {
   return awaitResult {
     this.cloneAclToken(accessorId, cloneAclToken, it)
@@ -396,7 +396,7 @@ suspend fun ConsulClient.cloneAclTokenAwait(accessorId: String, cloneAclToken: C
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use getAclTokens returning a future and chain with await()", replaceWith = ReplaceWith("getAclTokens().await()"))
+@Deprecated(message = "Instead use getAclTokens returning a future and chain with coAwait()", replaceWith = ReplaceWith("getAclTokens().coAwait()"))
 suspend fun ConsulClient.getAclTokensAwait(): List<AclToken> {
   return awaitResult {
     this.getAclTokens(it)
@@ -411,7 +411,7 @@ suspend fun ConsulClient.getAclTokensAwait(): List<AclToken> {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use readAclToken returning a future and chain with await()", replaceWith = ReplaceWith("readAclToken(accessorId).await()"))
+@Deprecated(message = "Instead use readAclToken returning a future and chain with coAwait()", replaceWith = ReplaceWith("readAclToken(accessorId).coAwait()"))
 suspend fun ConsulClient.readAclTokenAwait(accessorId: String): AclToken {
   return awaitResult {
     this.readAclToken(accessorId, it)
@@ -426,7 +426,7 @@ suspend fun ConsulClient.readAclTokenAwait(accessorId: String): AclToken {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use deleteAclToken returning a future and chain with await()", replaceWith = ReplaceWith("deleteAclToken(accessorId).await()"))
+@Deprecated(message = "Instead use deleteAclToken returning a future and chain with coAwait()", replaceWith = ReplaceWith("deleteAclToken(accessorId).coAwait()"))
 suspend fun ConsulClient.deleteAclTokenAwait(accessorId: String): Boolean {
   return awaitResult {
     this.deleteAclToken(accessorId, it)
@@ -441,7 +441,7 @@ suspend fun ConsulClient.deleteAclTokenAwait(accessorId: String): Boolean {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use fireEvent returning a future and chain with await()", replaceWith = ReplaceWith("fireEvent(name).await()"))
+@Deprecated(message = "Instead use fireEvent returning a future and chain with coAwait()", replaceWith = ReplaceWith("fireEvent(name).coAwait()"))
 suspend fun ConsulClient.fireEventAwait(name: String): Event {
   return awaitResult {
     this.fireEvent(name, it)
@@ -457,7 +457,7 @@ suspend fun ConsulClient.fireEventAwait(name: String): Event {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use fireEventWithOptions returning a future and chain with await()", replaceWith = ReplaceWith("fireEventWithOptions(name, options).await()"))
+@Deprecated(message = "Instead use fireEventWithOptions returning a future and chain with coAwait()", replaceWith = ReplaceWith("fireEventWithOptions(name, options).coAwait()"))
 suspend fun ConsulClient.fireEventWithOptionsAwait(name: String, options: EventOptions): Event {
   return awaitResult {
     this.fireEventWithOptions(name, options, it)
@@ -471,7 +471,7 @@ suspend fun ConsulClient.fireEventWithOptionsAwait(name: String, options: EventO
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use listEvents returning a future and chain with await()", replaceWith = ReplaceWith("listEvents().await()"))
+@Deprecated(message = "Instead use listEvents returning a future and chain with coAwait()", replaceWith = ReplaceWith("listEvents().coAwait()"))
 suspend fun ConsulClient.listEventsAwait(): EventList {
   return awaitResult {
     this.listEvents(it)
@@ -486,7 +486,7 @@ suspend fun ConsulClient.listEventsAwait(): EventList {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use listEventsWithOptions returning a future and chain with await()", replaceWith = ReplaceWith("listEventsWithOptions(options).await()"))
+@Deprecated(message = "Instead use listEventsWithOptions returning a future and chain with coAwait()", replaceWith = ReplaceWith("listEventsWithOptions(options).coAwait()"))
 suspend fun ConsulClient.listEventsWithOptionsAwait(options: EventListOptions): EventList {
   return awaitResult {
     this.listEventsWithOptions(options, it)
@@ -500,7 +500,7 @@ suspend fun ConsulClient.listEventsWithOptionsAwait(options: EventListOptions): 
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use registerService returning a future and chain with await()", replaceWith = ReplaceWith("registerService(serviceOptions).await()"))
+@Deprecated(message = "Instead use registerService returning a future and chain with coAwait()", replaceWith = ReplaceWith("registerService(serviceOptions).coAwait()"))
 suspend fun ConsulClient.registerServiceAwait(serviceOptions: ServiceOptions): Unit {
   return awaitResult {
     this.registerService(serviceOptions, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -514,7 +514,7 @@ suspend fun ConsulClient.registerServiceAwait(serviceOptions: ServiceOptions): U
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use maintenanceService returning a future and chain with await()", replaceWith = ReplaceWith("maintenanceService(maintenanceOptions).await()"))
+@Deprecated(message = "Instead use maintenanceService returning a future and chain with coAwait()", replaceWith = ReplaceWith("maintenanceService(maintenanceOptions).coAwait()"))
 suspend fun ConsulClient.maintenanceServiceAwait(maintenanceOptions: MaintenanceOptions): Unit {
   return awaitResult {
     this.maintenanceService(maintenanceOptions, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -528,7 +528,7 @@ suspend fun ConsulClient.maintenanceServiceAwait(maintenanceOptions: Maintenance
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use deregisterService returning a future and chain with await()", replaceWith = ReplaceWith("deregisterService(id).await()"))
+@Deprecated(message = "Instead use deregisterService returning a future and chain with coAwait()", replaceWith = ReplaceWith("deregisterService(id).coAwait()"))
 suspend fun ConsulClient.deregisterServiceAwait(id: String): Unit {
   return awaitResult {
     this.deregisterService(id, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -543,7 +543,7 @@ suspend fun ConsulClient.deregisterServiceAwait(id: String): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use catalogServiceNodes returning a future and chain with await()", replaceWith = ReplaceWith("catalogServiceNodes(service).await()"))
+@Deprecated(message = "Instead use catalogServiceNodes returning a future and chain with coAwait()", replaceWith = ReplaceWith("catalogServiceNodes(service).coAwait()"))
 suspend fun ConsulClient.catalogServiceNodesAwait(service: String): ServiceList {
   return awaitResult {
     this.catalogServiceNodes(service, it)
@@ -559,7 +559,7 @@ suspend fun ConsulClient.catalogServiceNodesAwait(service: String): ServiceList 
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use catalogServiceNodesWithOptions returning a future and chain with await()", replaceWith = ReplaceWith("catalogServiceNodesWithOptions(service, options).await()"))
+@Deprecated(message = "Instead use catalogServiceNodesWithOptions returning a future and chain with coAwait()", replaceWith = ReplaceWith("catalogServiceNodesWithOptions(service, options).coAwait()"))
 suspend fun ConsulClient.catalogServiceNodesWithOptionsAwait(service: String, options: ServiceQueryOptions): ServiceList {
   return awaitResult {
     this.catalogServiceNodesWithOptions(service, options, it)
@@ -573,7 +573,7 @@ suspend fun ConsulClient.catalogServiceNodesWithOptionsAwait(service: String, op
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use catalogDatacenters returning a future and chain with await()", replaceWith = ReplaceWith("catalogDatacenters().await()"))
+@Deprecated(message = "Instead use catalogDatacenters returning a future and chain with coAwait()", replaceWith = ReplaceWith("catalogDatacenters().coAwait()"))
 suspend fun ConsulClient.catalogDatacentersAwait(): List<String> {
   return awaitResult {
     this.catalogDatacenters(it)
@@ -587,7 +587,7 @@ suspend fun ConsulClient.catalogDatacentersAwait(): List<String> {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use catalogNodes returning a future and chain with await()", replaceWith = ReplaceWith("catalogNodes().await()"))
+@Deprecated(message = "Instead use catalogNodes returning a future and chain with coAwait()", replaceWith = ReplaceWith("catalogNodes().coAwait()"))
 suspend fun ConsulClient.catalogNodesAwait(): NodeList {
   return awaitResult {
     this.catalogNodes(it)
@@ -602,7 +602,7 @@ suspend fun ConsulClient.catalogNodesAwait(): NodeList {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use catalogNodesWithOptions returning a future and chain with await()", replaceWith = ReplaceWith("catalogNodesWithOptions(options).await()"))
+@Deprecated(message = "Instead use catalogNodesWithOptions returning a future and chain with coAwait()", replaceWith = ReplaceWith("catalogNodesWithOptions(options).coAwait()"))
 suspend fun ConsulClient.catalogNodesWithOptionsAwait(options: NodeQueryOptions): NodeList {
   return awaitResult {
     this.catalogNodesWithOptions(options, it)
@@ -617,7 +617,7 @@ suspend fun ConsulClient.catalogNodesWithOptionsAwait(options: NodeQueryOptions)
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use healthChecks returning a future and chain with await()", replaceWith = ReplaceWith("healthChecks(service).await()"))
+@Deprecated(message = "Instead use healthChecks returning a future and chain with coAwait()", replaceWith = ReplaceWith("healthChecks(service).coAwait()"))
 suspend fun ConsulClient.healthChecksAwait(service: String): CheckList {
   return awaitResult {
     this.healthChecks(service, it)
@@ -633,7 +633,7 @@ suspend fun ConsulClient.healthChecksAwait(service: String): CheckList {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use healthChecksWithOptions returning a future and chain with await()", replaceWith = ReplaceWith("healthChecksWithOptions(service, options).await()"))
+@Deprecated(message = "Instead use healthChecksWithOptions returning a future and chain with coAwait()", replaceWith = ReplaceWith("healthChecksWithOptions(service, options).coAwait()"))
 suspend fun ConsulClient.healthChecksWithOptionsAwait(service: String, options: CheckQueryOptions): CheckList {
   return awaitResult {
     this.healthChecksWithOptions(service, options, it)
@@ -648,7 +648,7 @@ suspend fun ConsulClient.healthChecksWithOptionsAwait(service: String, options: 
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use healthState returning a future and chain with await()", replaceWith = ReplaceWith("healthState(healthState).await()"))
+@Deprecated(message = "Instead use healthState returning a future and chain with coAwait()", replaceWith = ReplaceWith("healthState(healthState).coAwait()"))
 suspend fun ConsulClient.healthStateAwait(healthState: HealthState): CheckList {
   return awaitResult {
     this.healthState(healthState, it)
@@ -664,7 +664,7 @@ suspend fun ConsulClient.healthStateAwait(healthState: HealthState): CheckList {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use healthStateWithOptions returning a future and chain with await()", replaceWith = ReplaceWith("healthStateWithOptions(healthState, options).await()"))
+@Deprecated(message = "Instead use healthStateWithOptions returning a future and chain with coAwait()", replaceWith = ReplaceWith("healthStateWithOptions(healthState, options).coAwait()"))
 suspend fun ConsulClient.healthStateWithOptionsAwait(healthState: HealthState, options: CheckQueryOptions): CheckList {
   return awaitResult {
     this.healthStateWithOptions(healthState, options, it)
@@ -680,7 +680,7 @@ suspend fun ConsulClient.healthStateWithOptionsAwait(healthState: HealthState, o
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use healthServiceNodes returning a future and chain with await()", replaceWith = ReplaceWith("healthServiceNodes(service, passing).await()"))
+@Deprecated(message = "Instead use healthServiceNodes returning a future and chain with coAwait()", replaceWith = ReplaceWith("healthServiceNodes(service, passing).coAwait()"))
 suspend fun ConsulClient.healthServiceNodesAwait(service: String, passing: Boolean): ServiceEntryList {
   return awaitResult {
     this.healthServiceNodes(service, passing, it)
@@ -697,7 +697,7 @@ suspend fun ConsulClient.healthServiceNodesAwait(service: String, passing: Boole
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use healthServiceNodesWithOptions returning a future and chain with await()", replaceWith = ReplaceWith("healthServiceNodesWithOptions(service, passing, options).await()"))
+@Deprecated(message = "Instead use healthServiceNodesWithOptions returning a future and chain with coAwait()", replaceWith = ReplaceWith("healthServiceNodesWithOptions(service, passing, options).coAwait()"))
 suspend fun ConsulClient.healthServiceNodesWithOptionsAwait(service: String, passing: Boolean, options: ServiceQueryOptions): ServiceEntryList {
   return awaitResult {
     this.healthServiceNodesWithOptions(service, passing, options, it)
@@ -713,7 +713,7 @@ suspend fun ConsulClient.healthServiceNodesWithOptionsAwait(service: String, pas
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use healthNodesWithOptions returning a future and chain with await()", replaceWith = ReplaceWith("healthNodesWithOptions(node, options).await()"))
+@Deprecated(message = "Instead use healthNodesWithOptions returning a future and chain with coAwait()", replaceWith = ReplaceWith("healthNodesWithOptions(node, options).coAwait()"))
 suspend fun ConsulClient.healthNodesWithOptionsAwait(node: String, options: CheckQueryOptions): CheckList {
   return awaitResult {
     this.healthNodesWithOptions(node, options, it)
@@ -727,7 +727,7 @@ suspend fun ConsulClient.healthNodesWithOptionsAwait(node: String, options: Chec
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use catalogServices returning a future and chain with await()", replaceWith = ReplaceWith("catalogServices().await()"))
+@Deprecated(message = "Instead use catalogServices returning a future and chain with coAwait()", replaceWith = ReplaceWith("catalogServices().coAwait()"))
 suspend fun ConsulClient.catalogServicesAwait(): ServiceList {
   return awaitResult {
     this.catalogServices(it)
@@ -742,7 +742,7 @@ suspend fun ConsulClient.catalogServicesAwait(): ServiceList {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use catalogServicesWithOptions returning a future and chain with await()", replaceWith = ReplaceWith("catalogServicesWithOptions(options).await()"))
+@Deprecated(message = "Instead use catalogServicesWithOptions returning a future and chain with coAwait()", replaceWith = ReplaceWith("catalogServicesWithOptions(options).coAwait()"))
 suspend fun ConsulClient.catalogServicesWithOptionsAwait(options: BlockingQueryOptions): ServiceList {
   return awaitResult {
     this.catalogServicesWithOptions(options, it)
@@ -757,7 +757,7 @@ suspend fun ConsulClient.catalogServicesWithOptionsAwait(options: BlockingQueryO
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use catalogNodeServices returning a future and chain with await()", replaceWith = ReplaceWith("catalogNodeServices(node).await()"))
+@Deprecated(message = "Instead use catalogNodeServices returning a future and chain with coAwait()", replaceWith = ReplaceWith("catalogNodeServices(node).coAwait()"))
 suspend fun ConsulClient.catalogNodeServicesAwait(node: String): ServiceList {
   return awaitResult {
     this.catalogNodeServices(node, it)
@@ -773,7 +773,7 @@ suspend fun ConsulClient.catalogNodeServicesAwait(node: String): ServiceList {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use catalogNodeServicesWithOptions returning a future and chain with await()", replaceWith = ReplaceWith("catalogNodeServicesWithOptions(node, options).await()"))
+@Deprecated(message = "Instead use catalogNodeServicesWithOptions returning a future and chain with coAwait()", replaceWith = ReplaceWith("catalogNodeServicesWithOptions(node, options).coAwait()"))
 suspend fun ConsulClient.catalogNodeServicesWithOptionsAwait(node: String, options: BlockingQueryOptions): ServiceList {
   return awaitResult {
     this.catalogNodeServicesWithOptions(node, options, it)
@@ -787,7 +787,7 @@ suspend fun ConsulClient.catalogNodeServicesWithOptionsAwait(node: String, optio
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use localServices returning a future and chain with await()", replaceWith = ReplaceWith("localServices().await()"))
+@Deprecated(message = "Instead use localServices returning a future and chain with coAwait()", replaceWith = ReplaceWith("localServices().coAwait()"))
 suspend fun ConsulClient.localServicesAwait(): List<Service> {
   return awaitResult {
     this.localServices(it)
@@ -801,7 +801,7 @@ suspend fun ConsulClient.localServicesAwait(): List<Service> {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use localChecks returning a future and chain with await()", replaceWith = ReplaceWith("localChecks().await()"))
+@Deprecated(message = "Instead use localChecks returning a future and chain with coAwait()", replaceWith = ReplaceWith("localChecks().coAwait()"))
 suspend fun ConsulClient.localChecksAwait(): List<Check> {
   return awaitResult {
     this.localChecks(it)
@@ -815,7 +815,7 @@ suspend fun ConsulClient.localChecksAwait(): List<Check> {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use registerCheck returning a future and chain with await()", replaceWith = ReplaceWith("registerCheck(checkOptions).await()"))
+@Deprecated(message = "Instead use registerCheck returning a future and chain with coAwait()", replaceWith = ReplaceWith("registerCheck(checkOptions).coAwait()"))
 suspend fun ConsulClient.registerCheckAwait(checkOptions: CheckOptions): Unit {
   return awaitResult {
     this.registerCheck(checkOptions, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -829,7 +829,7 @@ suspend fun ConsulClient.registerCheckAwait(checkOptions: CheckOptions): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use deregisterCheck returning a future and chain with await()", replaceWith = ReplaceWith("deregisterCheck(checkId).await()"))
+@Deprecated(message = "Instead use deregisterCheck returning a future and chain with coAwait()", replaceWith = ReplaceWith("deregisterCheck(checkId).coAwait()"))
 suspend fun ConsulClient.deregisterCheckAwait(checkId: String): Unit {
   return awaitResult {
     this.deregisterCheck(checkId, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -843,7 +843,7 @@ suspend fun ConsulClient.deregisterCheckAwait(checkId: String): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use passCheck returning a future and chain with await()", replaceWith = ReplaceWith("passCheck(checkId).await()"))
+@Deprecated(message = "Instead use passCheck returning a future and chain with coAwait()", replaceWith = ReplaceWith("passCheck(checkId).coAwait()"))
 suspend fun ConsulClient.passCheckAwait(checkId: String): Unit {
   return awaitResult {
     this.passCheck(checkId, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -858,7 +858,7 @@ suspend fun ConsulClient.passCheckAwait(checkId: String): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use passCheckWithNote returning a future and chain with await()", replaceWith = ReplaceWith("passCheckWithNote(checkId, note).await()"))
+@Deprecated(message = "Instead use passCheckWithNote returning a future and chain with coAwait()", replaceWith = ReplaceWith("passCheckWithNote(checkId, note).coAwait()"))
 suspend fun ConsulClient.passCheckWithNoteAwait(checkId: String, note: String): Unit {
   return awaitResult {
     this.passCheckWithNote(checkId, note, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -872,7 +872,7 @@ suspend fun ConsulClient.passCheckWithNoteAwait(checkId: String, note: String): 
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use warnCheck returning a future and chain with await()", replaceWith = ReplaceWith("warnCheck(checkId).await()"))
+@Deprecated(message = "Instead use warnCheck returning a future and chain with coAwait()", replaceWith = ReplaceWith("warnCheck(checkId).coAwait()"))
 suspend fun ConsulClient.warnCheckAwait(checkId: String): Unit {
   return awaitResult {
     this.warnCheck(checkId, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -887,7 +887,7 @@ suspend fun ConsulClient.warnCheckAwait(checkId: String): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use warnCheckWithNote returning a future and chain with await()", replaceWith = ReplaceWith("warnCheckWithNote(checkId, note).await()"))
+@Deprecated(message = "Instead use warnCheckWithNote returning a future and chain with coAwait()", replaceWith = ReplaceWith("warnCheckWithNote(checkId, note).coAwait()"))
 suspend fun ConsulClient.warnCheckWithNoteAwait(checkId: String, note: String): Unit {
   return awaitResult {
     this.warnCheckWithNote(checkId, note, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -901,7 +901,7 @@ suspend fun ConsulClient.warnCheckWithNoteAwait(checkId: String, note: String): 
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use failCheck returning a future and chain with await()", replaceWith = ReplaceWith("failCheck(checkId).await()"))
+@Deprecated(message = "Instead use failCheck returning a future and chain with coAwait()", replaceWith = ReplaceWith("failCheck(checkId).coAwait()"))
 suspend fun ConsulClient.failCheckAwait(checkId: String): Unit {
   return awaitResult {
     this.failCheck(checkId, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -916,7 +916,7 @@ suspend fun ConsulClient.failCheckAwait(checkId: String): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use failCheckWithNote returning a future and chain with await()", replaceWith = ReplaceWith("failCheckWithNote(checkId, note).await()"))
+@Deprecated(message = "Instead use failCheckWithNote returning a future and chain with coAwait()", replaceWith = ReplaceWith("failCheckWithNote(checkId, note).coAwait()"))
 suspend fun ConsulClient.failCheckWithNoteAwait(checkId: String, note: String): Unit {
   return awaitResult {
     this.failCheckWithNote(checkId, note, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -931,7 +931,7 @@ suspend fun ConsulClient.failCheckWithNoteAwait(checkId: String, note: String): 
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use updateCheck returning a future and chain with await()", replaceWith = ReplaceWith("updateCheck(checkId, status).await()"))
+@Deprecated(message = "Instead use updateCheck returning a future and chain with coAwait()", replaceWith = ReplaceWith("updateCheck(checkId, status).coAwait()"))
 suspend fun ConsulClient.updateCheckAwait(checkId: String, status: CheckStatus): Unit {
   return awaitResult {
     this.updateCheck(checkId, status, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -947,7 +947,7 @@ suspend fun ConsulClient.updateCheckAwait(checkId: String, status: CheckStatus):
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use updateCheckWithNote returning a future and chain with await()", replaceWith = ReplaceWith("updateCheckWithNote(checkId, status, note).await()"))
+@Deprecated(message = "Instead use updateCheckWithNote returning a future and chain with coAwait()", replaceWith = ReplaceWith("updateCheckWithNote(checkId, status, note).coAwait()"))
 suspend fun ConsulClient.updateCheckWithNoteAwait(checkId: String, status: CheckStatus, note: String): Unit {
   return awaitResult {
     this.updateCheckWithNote(checkId, status, note, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -961,7 +961,7 @@ suspend fun ConsulClient.updateCheckWithNoteAwait(checkId: String, status: Check
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use leaderStatus returning a future and chain with await()", replaceWith = ReplaceWith("leaderStatus().await()"))
+@Deprecated(message = "Instead use leaderStatus returning a future and chain with coAwait()", replaceWith = ReplaceWith("leaderStatus().coAwait()"))
 suspend fun ConsulClient.leaderStatusAwait(): String {
   return awaitResult {
     this.leaderStatus(it)
@@ -975,7 +975,7 @@ suspend fun ConsulClient.leaderStatusAwait(): String {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use peersStatus returning a future and chain with await()", replaceWith = ReplaceWith("peersStatus().await()"))
+@Deprecated(message = "Instead use peersStatus returning a future and chain with coAwait()", replaceWith = ReplaceWith("peersStatus().coAwait()"))
 suspend fun ConsulClient.peersStatusAwait(): List<String> {
   return awaitResult {
     this.peersStatus(it)
@@ -989,7 +989,7 @@ suspend fun ConsulClient.peersStatusAwait(): List<String> {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use createSession returning a future and chain with await()", replaceWith = ReplaceWith("createSession().await()"))
+@Deprecated(message = "Instead use createSession returning a future and chain with coAwait()", replaceWith = ReplaceWith("createSession().coAwait()"))
 suspend fun ConsulClient.createSessionAwait(): String {
   return awaitResult {
     this.createSession(it)
@@ -1004,7 +1004,7 @@ suspend fun ConsulClient.createSessionAwait(): String {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use createSessionWithOptions returning a future and chain with await()", replaceWith = ReplaceWith("createSessionWithOptions(options).await()"))
+@Deprecated(message = "Instead use createSessionWithOptions returning a future and chain with coAwait()", replaceWith = ReplaceWith("createSessionWithOptions(options).coAwait()"))
 suspend fun ConsulClient.createSessionWithOptionsAwait(options: SessionOptions): String {
   return awaitResult {
     this.createSessionWithOptions(options, it)
@@ -1019,7 +1019,7 @@ suspend fun ConsulClient.createSessionWithOptionsAwait(options: SessionOptions):
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use infoSession returning a future and chain with await()", replaceWith = ReplaceWith("infoSession(id).await()"))
+@Deprecated(message = "Instead use infoSession returning a future and chain with coAwait()", replaceWith = ReplaceWith("infoSession(id).coAwait()"))
 suspend fun ConsulClient.infoSessionAwait(id: String): Session {
   return awaitResult {
     this.infoSession(id, it)
@@ -1035,7 +1035,7 @@ suspend fun ConsulClient.infoSessionAwait(id: String): Session {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use infoSessionWithOptions returning a future and chain with await()", replaceWith = ReplaceWith("infoSessionWithOptions(id, options).await()"))
+@Deprecated(message = "Instead use infoSessionWithOptions returning a future and chain with coAwait()", replaceWith = ReplaceWith("infoSessionWithOptions(id, options).coAwait()"))
 suspend fun ConsulClient.infoSessionWithOptionsAwait(id: String, options: BlockingQueryOptions): Session {
   return awaitResult {
     this.infoSessionWithOptions(id, options, it)
@@ -1050,7 +1050,7 @@ suspend fun ConsulClient.infoSessionWithOptionsAwait(id: String, options: Blocki
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use renewSession returning a future and chain with await()", replaceWith = ReplaceWith("renewSession(id).await()"))
+@Deprecated(message = "Instead use renewSession returning a future and chain with coAwait()", replaceWith = ReplaceWith("renewSession(id).coAwait()"))
 suspend fun ConsulClient.renewSessionAwait(id: String): Session {
   return awaitResult {
     this.renewSession(id, it)
@@ -1064,7 +1064,7 @@ suspend fun ConsulClient.renewSessionAwait(id: String): Session {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use listSessions returning a future and chain with await()", replaceWith = ReplaceWith("listSessions().await()"))
+@Deprecated(message = "Instead use listSessions returning a future and chain with coAwait()", replaceWith = ReplaceWith("listSessions().coAwait()"))
 suspend fun ConsulClient.listSessionsAwait(): SessionList {
   return awaitResult {
     this.listSessions(it)
@@ -1079,7 +1079,7 @@ suspend fun ConsulClient.listSessionsAwait(): SessionList {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use listSessionsWithOptions returning a future and chain with await()", replaceWith = ReplaceWith("listSessionsWithOptions(options).await()"))
+@Deprecated(message = "Instead use listSessionsWithOptions returning a future and chain with coAwait()", replaceWith = ReplaceWith("listSessionsWithOptions(options).coAwait()"))
 suspend fun ConsulClient.listSessionsWithOptionsAwait(options: BlockingQueryOptions): SessionList {
   return awaitResult {
     this.listSessionsWithOptions(options, it)
@@ -1094,7 +1094,7 @@ suspend fun ConsulClient.listSessionsWithOptionsAwait(options: BlockingQueryOpti
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use listNodeSessions returning a future and chain with await()", replaceWith = ReplaceWith("listNodeSessions(nodeId).await()"))
+@Deprecated(message = "Instead use listNodeSessions returning a future and chain with coAwait()", replaceWith = ReplaceWith("listNodeSessions(nodeId).coAwait()"))
 suspend fun ConsulClient.listNodeSessionsAwait(nodeId: String): SessionList {
   return awaitResult {
     this.listNodeSessions(nodeId, it)
@@ -1110,7 +1110,7 @@ suspend fun ConsulClient.listNodeSessionsAwait(nodeId: String): SessionList {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use listNodeSessionsWithOptions returning a future and chain with await()", replaceWith = ReplaceWith("listNodeSessionsWithOptions(nodeId, options).await()"))
+@Deprecated(message = "Instead use listNodeSessionsWithOptions returning a future and chain with coAwait()", replaceWith = ReplaceWith("listNodeSessionsWithOptions(nodeId, options).coAwait()"))
 suspend fun ConsulClient.listNodeSessionsWithOptionsAwait(nodeId: String, options: BlockingQueryOptions): SessionList {
   return awaitResult {
     this.listNodeSessionsWithOptions(nodeId, options, it)
@@ -1124,7 +1124,7 @@ suspend fun ConsulClient.listNodeSessionsWithOptionsAwait(nodeId: String, option
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use destroySession returning a future and chain with await()", replaceWith = ReplaceWith("destroySession(id).await()"))
+@Deprecated(message = "Instead use destroySession returning a future and chain with coAwait()", replaceWith = ReplaceWith("destroySession(id).coAwait()"))
 suspend fun ConsulClient.destroySessionAwait(id: String): Unit {
   return awaitResult {
     this.destroySession(id, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -1139,7 +1139,7 @@ suspend fun ConsulClient.destroySessionAwait(id: String): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use createPreparedQuery returning a future and chain with await()", replaceWith = ReplaceWith("createPreparedQuery(definition).await()"))
+@Deprecated(message = "Instead use createPreparedQuery returning a future and chain with coAwait()", replaceWith = ReplaceWith("createPreparedQuery(definition).coAwait()"))
 suspend fun ConsulClient.createPreparedQueryAwait(definition: PreparedQueryDefinition): String {
   return awaitResult {
     this.createPreparedQuery(definition, it)
@@ -1154,7 +1154,7 @@ suspend fun ConsulClient.createPreparedQueryAwait(definition: PreparedQueryDefin
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use getPreparedQuery returning a future and chain with await()", replaceWith = ReplaceWith("getPreparedQuery(id).await()"))
+@Deprecated(message = "Instead use getPreparedQuery returning a future and chain with coAwait()", replaceWith = ReplaceWith("getPreparedQuery(id).coAwait()"))
 suspend fun ConsulClient.getPreparedQueryAwait(id: String): PreparedQueryDefinition {
   return awaitResult {
     this.getPreparedQuery(id, it)
@@ -1168,7 +1168,7 @@ suspend fun ConsulClient.getPreparedQueryAwait(id: String): PreparedQueryDefinit
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use getAllPreparedQueries returning a future and chain with await()", replaceWith = ReplaceWith("getAllPreparedQueries().await()"))
+@Deprecated(message = "Instead use getAllPreparedQueries returning a future and chain with coAwait()", replaceWith = ReplaceWith("getAllPreparedQueries().coAwait()"))
 suspend fun ConsulClient.getAllPreparedQueriesAwait(): List<PreparedQueryDefinition> {
   return awaitResult {
     this.getAllPreparedQueries(it)
@@ -1182,7 +1182,7 @@ suspend fun ConsulClient.getAllPreparedQueriesAwait(): List<PreparedQueryDefinit
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use updatePreparedQuery returning a future and chain with await()", replaceWith = ReplaceWith("updatePreparedQuery(definition).await()"))
+@Deprecated(message = "Instead use updatePreparedQuery returning a future and chain with coAwait()", replaceWith = ReplaceWith("updatePreparedQuery(definition).coAwait()"))
 suspend fun ConsulClient.updatePreparedQueryAwait(definition: PreparedQueryDefinition): Unit {
   return awaitResult {
     this.updatePreparedQuery(definition, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -1196,7 +1196,7 @@ suspend fun ConsulClient.updatePreparedQueryAwait(definition: PreparedQueryDefin
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use deletePreparedQuery returning a future and chain with await()", replaceWith = ReplaceWith("deletePreparedQuery(id).await()"))
+@Deprecated(message = "Instead use deletePreparedQuery returning a future and chain with coAwait()", replaceWith = ReplaceWith("deletePreparedQuery(id).coAwait()"))
 suspend fun ConsulClient.deletePreparedQueryAwait(id: String): Unit {
   return awaitResult {
     this.deletePreparedQuery(id, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -1211,7 +1211,7 @@ suspend fun ConsulClient.deletePreparedQueryAwait(id: String): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use executePreparedQuery returning a future and chain with await()", replaceWith = ReplaceWith("executePreparedQuery(query).await()"))
+@Deprecated(message = "Instead use executePreparedQuery returning a future and chain with coAwait()", replaceWith = ReplaceWith("executePreparedQuery(query).coAwait()"))
 suspend fun ConsulClient.executePreparedQueryAwait(query: String): PreparedQueryExecuteResponse {
   return awaitResult {
     this.executePreparedQuery(query, it)
@@ -1227,7 +1227,7 @@ suspend fun ConsulClient.executePreparedQueryAwait(query: String): PreparedQuery
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use executePreparedQueryWithOptions returning a future and chain with await()", replaceWith = ReplaceWith("executePreparedQueryWithOptions(query, options).await()"))
+@Deprecated(message = "Instead use executePreparedQueryWithOptions returning a future and chain with coAwait()", replaceWith = ReplaceWith("executePreparedQueryWithOptions(query, options).coAwait()"))
 suspend fun ConsulClient.executePreparedQueryWithOptionsAwait(query: String, options: PreparedQueryExecuteOptions): PreparedQueryExecuteResponse {
   return awaitResult {
     this.executePreparedQueryWithOptions(query, options, it)
@@ -1242,7 +1242,7 @@ suspend fun ConsulClient.executePreparedQueryWithOptionsAwait(query: String, opt
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use registerCatalogService returning a future and chain with await()", replaceWith = ReplaceWith("registerCatalogService(nodeOptions, serviceOptions).await()"))
+@Deprecated(message = "Instead use registerCatalogService returning a future and chain with coAwait()", replaceWith = ReplaceWith("registerCatalogService(nodeOptions, serviceOptions).coAwait()"))
 suspend fun ConsulClient.registerCatalogServiceAwait(nodeOptions: Node, serviceOptions: ServiceOptions): Unit {
   return awaitResult {
     this.registerCatalogService(nodeOptions, serviceOptions, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -1257,7 +1257,7 @@ suspend fun ConsulClient.registerCatalogServiceAwait(nodeOptions: Node, serviceO
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.consul.ConsulClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use deregisterCatalogService returning a future and chain with await()", replaceWith = ReplaceWith("deregisterCatalogService(nodeId, serviceId).await()"))
+@Deprecated(message = "Instead use deregisterCatalogService returning a future and chain with coAwait()", replaceWith = ReplaceWith("deregisterCatalogService(nodeId, serviceId).coAwait()"))
 suspend fun ConsulClient.deregisterCatalogServiceAwait(nodeId: String, serviceId: String): Unit {
   return awaitResult {
     this.deregisterCatalogService(nodeId, serviceId, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/consul/TxnServiceOperation.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/consul/TxnServiceOperation.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package io.vertx.kotlin.ext.consul
+
+import io.vertx.ext.consul.TxnServiceOperation
+import io.vertx.ext.consul.ServiceOptions
+import io.vertx.ext.consul.TxnServiceVerb
+
+/**
+ * A function providing a DSL for building [io.vertx.ext.consul.TxnServiceOperation] objects.
+ *
+ * Holds the operation to apply to the service inside a transaction
+ *
+ * @param node  Set the node
+ * @param serviceOptions  Set the service
+ * @param type  Set the type of operation to perform
+ *
+ * <p/>
+ * NOTE: This function has been automatically generated from the [io.vertx.ext.consul.TxnServiceOperation original] using Vert.x codegen.
+ */
+fun txnServiceOperationOf(
+  node: String? = null,
+  serviceOptions: io.vertx.ext.consul.ServiceOptions? = null,
+  type: TxnServiceVerb? = null): TxnServiceOperation = io.vertx.ext.consul.TxnServiceOperation().apply {
+
+  if (node != null) {
+    this.setNode(node)
+  }
+  if (serviceOptions != null) {
+    this.setServiceOptions(serviceOptions)
+  }
+  if (type != null) {
+    this.setType(type)
+  }
+}
+

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/eventbus/bridge/tcp/TcpEventBusBridge.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/eventbus/bridge/tcp/TcpEventBusBridge.kt
@@ -25,7 +25,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.eventbus.bridge.tcp.TcpEventBusBridge] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use listen returning a future and chain with await()", replaceWith = ReplaceWith("listen().await()"))
+@Deprecated(message = "Instead use listen returning a future and chain with coAwait()", replaceWith = ReplaceWith("listen().coAwait()"))
 suspend fun TcpEventBusBridge.listenAwait(): TcpEventBusBridge {
   return awaitResult {
     this.listen(it)
@@ -41,7 +41,7 @@ suspend fun TcpEventBusBridge.listenAwait(): TcpEventBusBridge {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.eventbus.bridge.tcp.TcpEventBusBridge] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use listen returning a future and chain with await()", replaceWith = ReplaceWith("listen(port, address).await()"))
+@Deprecated(message = "Instead use listen returning a future and chain with coAwait()", replaceWith = ReplaceWith("listen(port, address).coAwait()"))
 suspend fun TcpEventBusBridge.listenAwait(port: Int, address: String): TcpEventBusBridge {
   return awaitResult {
     this.listen(port, address, it)
@@ -56,7 +56,7 @@ suspend fun TcpEventBusBridge.listenAwait(port: Int, address: String): TcpEventB
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.eventbus.bridge.tcp.TcpEventBusBridge] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use listen returning a future and chain with await()", replaceWith = ReplaceWith("listen(port).await()"))
+@Deprecated(message = "Instead use listen returning a future and chain with coAwait()", replaceWith = ReplaceWith("listen(port).coAwait()"))
 suspend fun TcpEventBusBridge.listenAwait(port: Int): TcpEventBusBridge {
   return awaitResult {
     this.listen(port, it)
@@ -69,7 +69,7 @@ suspend fun TcpEventBusBridge.listenAwait(port: Int): TcpEventBusBridge {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.eventbus.bridge.tcp.TcpEventBusBridge] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use close returning a future and chain with await()", replaceWith = ReplaceWith("close().await()"))
+@Deprecated(message = "Instead use close returning a future and chain with coAwait()", replaceWith = ReplaceWith("close().coAwait()"))
 suspend fun TcpEventBusBridge.closeAwait(): Unit {
   return awaitResult {
     this.close(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/healthchecks/HealthChecks.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/healthchecks/HealthChecks.kt
@@ -28,7 +28,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.healthchecks.HealthChecks] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use invoke returning a future and chain with await()", replaceWith = ReplaceWith("invoke(name).await()"))
+@Deprecated(message = "Instead use invoke returning a future and chain with coAwait()", replaceWith = ReplaceWith("invoke(name).coAwait()"))
 suspend fun HealthChecks.invokeAwait(name: String): JsonObject {
   return awaitResult {
     this.invoke(name, it)
@@ -42,7 +42,7 @@ suspend fun HealthChecks.invokeAwait(name: String): JsonObject {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.healthchecks.HealthChecks] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use checkStatus returning a future and chain with await()", replaceWith = ReplaceWith("checkStatus().await()"))
+@Deprecated(message = "Instead use checkStatus returning a future and chain with coAwait()", replaceWith = ReplaceWith("checkStatus().coAwait()"))
 suspend fun HealthChecks.checkStatusAwait(): CheckResult {
   return awaitResult {
     this.checkStatus(it)
@@ -57,7 +57,7 @@ suspend fun HealthChecks.checkStatusAwait(): CheckResult {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.healthchecks.HealthChecks] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use checkStatus returning a future and chain with await()", replaceWith = ReplaceWith("checkStatus(name).await()"))
+@Deprecated(message = "Instead use checkStatus returning a future and chain with coAwait()", replaceWith = ReplaceWith("checkStatus(name).coAwait()"))
 suspend fun HealthChecks.checkStatusAwait(name: String): CheckResult {
   return awaitResult {
     this.checkStatus(name, it)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/jdbc/JDBCClient.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/jdbc/JDBCClient.kt
@@ -27,7 +27,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.jdbc.JDBCClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use querySingle returning a future and chain with await()", replaceWith = ReplaceWith("querySingle(sql).await()"))
+@Deprecated(message = "Instead use querySingle returning a future and chain with coAwait()", replaceWith = ReplaceWith("querySingle(sql).coAwait()"))
 suspend fun JDBCClient.querySingleAwait(sql: String): JsonArray? {
   return awaitResult {
     this.querySingle(sql, it)
@@ -43,7 +43,7 @@ suspend fun JDBCClient.querySingleAwait(sql: String): JsonArray? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.jdbc.JDBCClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use querySingleWithParams returning a future and chain with await()", replaceWith = ReplaceWith("querySingleWithParams(sql, arguments).await()"))
+@Deprecated(message = "Instead use querySingleWithParams returning a future and chain with coAwait()", replaceWith = ReplaceWith("querySingleWithParams(sql, arguments).coAwait()"))
 suspend fun JDBCClient.querySingleWithParamsAwait(sql: String, arguments: JsonArray): JsonArray? {
   return awaitResult {
     this.querySingleWithParams(sql, arguments, it)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/mail/MailClient.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/mail/MailClient.kt
@@ -28,7 +28,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.mail.MailClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use sendMail returning a future and chain with await()", replaceWith = ReplaceWith("sendMail(email).await()"))
+@Deprecated(message = "Instead use sendMail returning a future and chain with coAwait()", replaceWith = ReplaceWith("sendMail(email).coAwait()"))
 suspend fun MailClient.sendMailAwait(email: MailMessage): MailResult {
   return awaitResult {
     this.sendMail(email, it)
@@ -41,7 +41,7 @@ suspend fun MailClient.sendMailAwait(email: MailMessage): MailResult {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.mail.MailClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use close returning a future and chain with await()", replaceWith = ReplaceWith("close().await()"))
+@Deprecated(message = "Instead use close returning a future and chain with coAwait()", replaceWith = ReplaceWith("close().coAwait()"))
 suspend fun MailClient.closeAwait(): Unit {
   return awaitResult {
     this.close(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/mongo/MongoClient.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/mongo/MongoClient.kt
@@ -43,7 +43,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use save returning a future and chain with await()", replaceWith = ReplaceWith("save(collection, document).await()"))
+@Deprecated(message = "Instead use save returning a future and chain with coAwait()", replaceWith = ReplaceWith("save(collection, document).coAwait()"))
 suspend fun MongoClient.saveAwait(collection: String, document: JsonObject): String? {
   return awaitResult {
     this.save(collection, document, it)
@@ -60,7 +60,7 @@ suspend fun MongoClient.saveAwait(collection: String, document: JsonObject): Str
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use saveWithOptions returning a future and chain with await()", replaceWith = ReplaceWith("saveWithOptions(collection, document, writeOption).await()"))
+@Deprecated(message = "Instead use saveWithOptions returning a future and chain with coAwait()", replaceWith = ReplaceWith("saveWithOptions(collection, document, writeOption).coAwait()"))
 suspend fun MongoClient.saveWithOptionsAwait(collection: String, document: JsonObject, writeOption: WriteOption?): String? {
   return awaitResult {
     this.saveWithOptions(collection, document, writeOption, it)
@@ -76,7 +76,7 @@ suspend fun MongoClient.saveWithOptionsAwait(collection: String, document: JsonO
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use insert returning a future and chain with await()", replaceWith = ReplaceWith("insert(collection, document).await()"))
+@Deprecated(message = "Instead use insert returning a future and chain with coAwait()", replaceWith = ReplaceWith("insert(collection, document).coAwait()"))
 suspend fun MongoClient.insertAwait(collection: String, document: JsonObject): String? {
   return awaitResult {
     this.insert(collection, document, it)
@@ -93,7 +93,7 @@ suspend fun MongoClient.insertAwait(collection: String, document: JsonObject): S
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use insertWithOptions returning a future and chain with await()", replaceWith = ReplaceWith("insertWithOptions(collection, document, writeOption).await()"))
+@Deprecated(message = "Instead use insertWithOptions returning a future and chain with coAwait()", replaceWith = ReplaceWith("insertWithOptions(collection, document, writeOption).coAwait()"))
 suspend fun MongoClient.insertWithOptionsAwait(collection: String, document: JsonObject, writeOption: WriteOption?): String? {
   return awaitResult {
     this.insertWithOptions(collection, document, writeOption, it)
@@ -110,7 +110,7 @@ suspend fun MongoClient.insertWithOptionsAwait(collection: String, document: Jso
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use updateCollection returning a future and chain with await()", replaceWith = ReplaceWith("updateCollection(collection, query, update).await()"))
+@Deprecated(message = "Instead use updateCollection returning a future and chain with coAwait()", replaceWith = ReplaceWith("updateCollection(collection, query, update).coAwait()"))
 suspend fun MongoClient.updateCollectionAwait(collection: String, query: JsonObject, update: JsonObject): MongoClientUpdateResult? {
   return awaitResult {
     this.updateCollection(collection, query, update, it)
@@ -127,7 +127,7 @@ suspend fun MongoClient.updateCollectionAwait(collection: String, query: JsonObj
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use updateCollection returning a future and chain with await()", replaceWith = ReplaceWith("updateCollection(collection, query, update).await()"))
+@Deprecated(message = "Instead use updateCollection returning a future and chain with coAwait()", replaceWith = ReplaceWith("updateCollection(collection, query, update).coAwait()"))
 suspend fun MongoClient.updateCollectionAwait(collection: String, query: JsonObject, update: JsonArray): MongoClientUpdateResult? {
   return awaitResult {
     this.updateCollection(collection, query, update, it)
@@ -145,7 +145,7 @@ suspend fun MongoClient.updateCollectionAwait(collection: String, query: JsonObj
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use updateCollectionWithOptions returning a future and chain with await()", replaceWith = ReplaceWith("updateCollectionWithOptions(collection, query, update, options).await()"))
+@Deprecated(message = "Instead use updateCollectionWithOptions returning a future and chain with coAwait()", replaceWith = ReplaceWith("updateCollectionWithOptions(collection, query, update, options).coAwait()"))
 suspend fun MongoClient.updateCollectionWithOptionsAwait(collection: String, query: JsonObject, update: JsonObject, options: UpdateOptions): MongoClientUpdateResult? {
   return awaitResult {
     this.updateCollectionWithOptions(collection, query, update, options, it)
@@ -163,7 +163,7 @@ suspend fun MongoClient.updateCollectionWithOptionsAwait(collection: String, que
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use updateCollectionWithOptions returning a future and chain with await()", replaceWith = ReplaceWith("updateCollectionWithOptions(collection, query, update, options).await()"))
+@Deprecated(message = "Instead use updateCollectionWithOptions returning a future and chain with coAwait()", replaceWith = ReplaceWith("updateCollectionWithOptions(collection, query, update, options).coAwait()"))
 suspend fun MongoClient.updateCollectionWithOptionsAwait(collection: String, query: JsonObject, update: JsonArray, options: UpdateOptions): MongoClientUpdateResult? {
   return awaitResult {
     this.updateCollectionWithOptions(collection, query, update, options, it)
@@ -180,7 +180,7 @@ suspend fun MongoClient.updateCollectionWithOptionsAwait(collection: String, que
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use replaceDocuments returning a future and chain with await()", replaceWith = ReplaceWith("replaceDocuments(collection, query, replace).await()"))
+@Deprecated(message = "Instead use replaceDocuments returning a future and chain with coAwait()", replaceWith = ReplaceWith("replaceDocuments(collection, query, replace).coAwait()"))
 suspend fun MongoClient.replaceDocumentsAwait(collection: String, query: JsonObject, replace: JsonObject): MongoClientUpdateResult? {
   return awaitResult {
     this.replaceDocuments(collection, query, replace, it)
@@ -198,7 +198,7 @@ suspend fun MongoClient.replaceDocumentsAwait(collection: String, query: JsonObj
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use replaceDocumentsWithOptions returning a future and chain with await()", replaceWith = ReplaceWith("replaceDocumentsWithOptions(collection, query, replace, options).await()"))
+@Deprecated(message = "Instead use replaceDocumentsWithOptions returning a future and chain with coAwait()", replaceWith = ReplaceWith("replaceDocumentsWithOptions(collection, query, replace, options).coAwait()"))
 suspend fun MongoClient.replaceDocumentsWithOptionsAwait(collection: String, query: JsonObject, replace: JsonObject, options: UpdateOptions): MongoClientUpdateResult? {
   return awaitResult {
     this.replaceDocumentsWithOptions(collection, query, replace, options, it)
@@ -214,7 +214,7 @@ suspend fun MongoClient.replaceDocumentsWithOptionsAwait(collection: String, que
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use bulkWrite returning a future and chain with await()", replaceWith = ReplaceWith("bulkWrite(collection, operations).await()"))
+@Deprecated(message = "Instead use bulkWrite returning a future and chain with coAwait()", replaceWith = ReplaceWith("bulkWrite(collection, operations).coAwait()"))
 suspend fun MongoClient.bulkWriteAwait(collection: String, operations: List<BulkOperation>): MongoClientBulkWriteResult? {
   return awaitResult {
     this.bulkWrite(collection, operations, it)
@@ -231,7 +231,7 @@ suspend fun MongoClient.bulkWriteAwait(collection: String, operations: List<Bulk
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use bulkWriteWithOptions returning a future and chain with await()", replaceWith = ReplaceWith("bulkWriteWithOptions(collection, operations, bulkWriteOptions).await()"))
+@Deprecated(message = "Instead use bulkWriteWithOptions returning a future and chain with coAwait()", replaceWith = ReplaceWith("bulkWriteWithOptions(collection, operations, bulkWriteOptions).coAwait()"))
 suspend fun MongoClient.bulkWriteWithOptionsAwait(collection: String, operations: List<BulkOperation>, bulkWriteOptions: BulkWriteOptions): MongoClientBulkWriteResult? {
   return awaitResult {
     this.bulkWriteWithOptions(collection, operations, bulkWriteOptions, it)
@@ -247,7 +247,7 @@ suspend fun MongoClient.bulkWriteWithOptionsAwait(collection: String, operations
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use find returning a future and chain with await()", replaceWith = ReplaceWith("find(collection, query).await()"))
+@Deprecated(message = "Instead use find returning a future and chain with coAwait()", replaceWith = ReplaceWith("find(collection, query).coAwait()"))
 suspend fun MongoClient.findAwait(collection: String, query: JsonObject): List<JsonObject> {
   return awaitResult {
     this.find(collection, query, it)
@@ -264,7 +264,7 @@ suspend fun MongoClient.findAwait(collection: String, query: JsonObject): List<J
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use findWithOptions returning a future and chain with await()", replaceWith = ReplaceWith("findWithOptions(collection, query, options).await()"))
+@Deprecated(message = "Instead use findWithOptions returning a future and chain with coAwait()", replaceWith = ReplaceWith("findWithOptions(collection, query, options).coAwait()"))
 suspend fun MongoClient.findWithOptionsAwait(collection: String, query: JsonObject, options: FindOptions): List<JsonObject> {
   return awaitResult {
     this.findWithOptions(collection, query, options, it)
@@ -281,7 +281,7 @@ suspend fun MongoClient.findWithOptionsAwait(collection: String, query: JsonObje
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use findOne returning a future and chain with await()", replaceWith = ReplaceWith("findOne(collection, query, fields).await()"))
+@Deprecated(message = "Instead use findOne returning a future and chain with coAwait()", replaceWith = ReplaceWith("findOne(collection, query, fields).coAwait()"))
 suspend fun MongoClient.findOneAwait(collection: String, query: JsonObject, fields: JsonObject?): JsonObject? {
   return awaitResult {
     this.findOne(collection, query, fields, it)
@@ -298,7 +298,7 @@ suspend fun MongoClient.findOneAwait(collection: String, query: JsonObject, fiel
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use findOneAndUpdate returning a future and chain with await()", replaceWith = ReplaceWith("findOneAndUpdate(collection, query, update).await()"))
+@Deprecated(message = "Instead use findOneAndUpdate returning a future and chain with coAwait()", replaceWith = ReplaceWith("findOneAndUpdate(collection, query, update).coAwait()"))
 suspend fun MongoClient.findOneAndUpdateAwait(collection: String, query: JsonObject, update: JsonObject): JsonObject? {
   return awaitResult {
     this.findOneAndUpdate(collection, query, update, it)
@@ -317,7 +317,7 @@ suspend fun MongoClient.findOneAndUpdateAwait(collection: String, query: JsonObj
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use findOneAndUpdateWithOptions returning a future and chain with await()", replaceWith = ReplaceWith("findOneAndUpdateWithOptions(collection, query, update, findOptions, updateOptions).await()"))
+@Deprecated(message = "Instead use findOneAndUpdateWithOptions returning a future and chain with coAwait()", replaceWith = ReplaceWith("findOneAndUpdateWithOptions(collection, query, update, findOptions, updateOptions).coAwait()"))
 suspend fun MongoClient.findOneAndUpdateWithOptionsAwait(collection: String, query: JsonObject, update: JsonObject, findOptions: FindOptions, updateOptions: UpdateOptions): JsonObject? {
   return awaitResult {
     this.findOneAndUpdateWithOptions(collection, query, update, findOptions, updateOptions, it)
@@ -334,7 +334,7 @@ suspend fun MongoClient.findOneAndUpdateWithOptionsAwait(collection: String, que
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use findOneAndReplace returning a future and chain with await()", replaceWith = ReplaceWith("findOneAndReplace(collection, query, replace).await()"))
+@Deprecated(message = "Instead use findOneAndReplace returning a future and chain with coAwait()", replaceWith = ReplaceWith("findOneAndReplace(collection, query, replace).coAwait()"))
 suspend fun MongoClient.findOneAndReplaceAwait(collection: String, query: JsonObject, replace: JsonObject): JsonObject? {
   return awaitResult {
     this.findOneAndReplace(collection, query, replace, it)
@@ -353,7 +353,7 @@ suspend fun MongoClient.findOneAndReplaceAwait(collection: String, query: JsonOb
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use findOneAndReplaceWithOptions returning a future and chain with await()", replaceWith = ReplaceWith("findOneAndReplaceWithOptions(collection, query, replace, findOptions, updateOptions).await()"))
+@Deprecated(message = "Instead use findOneAndReplaceWithOptions returning a future and chain with coAwait()", replaceWith = ReplaceWith("findOneAndReplaceWithOptions(collection, query, replace, findOptions, updateOptions).coAwait()"))
 suspend fun MongoClient.findOneAndReplaceWithOptionsAwait(collection: String, query: JsonObject, replace: JsonObject, findOptions: FindOptions, updateOptions: UpdateOptions): JsonObject? {
   return awaitResult {
     this.findOneAndReplaceWithOptions(collection, query, replace, findOptions, updateOptions, it)
@@ -369,7 +369,7 @@ suspend fun MongoClient.findOneAndReplaceWithOptionsAwait(collection: String, qu
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use findOneAndDelete returning a future and chain with await()", replaceWith = ReplaceWith("findOneAndDelete(collection, query).await()"))
+@Deprecated(message = "Instead use findOneAndDelete returning a future and chain with coAwait()", replaceWith = ReplaceWith("findOneAndDelete(collection, query).coAwait()"))
 suspend fun MongoClient.findOneAndDeleteAwait(collection: String, query: JsonObject): JsonObject? {
   return awaitResult {
     this.findOneAndDelete(collection, query, it)
@@ -386,7 +386,7 @@ suspend fun MongoClient.findOneAndDeleteAwait(collection: String, query: JsonObj
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use findOneAndDeleteWithOptions returning a future and chain with await()", replaceWith = ReplaceWith("findOneAndDeleteWithOptions(collection, query, findOptions).await()"))
+@Deprecated(message = "Instead use findOneAndDeleteWithOptions returning a future and chain with coAwait()", replaceWith = ReplaceWith("findOneAndDeleteWithOptions(collection, query, findOptions).coAwait()"))
 suspend fun MongoClient.findOneAndDeleteWithOptionsAwait(collection: String, query: JsonObject, findOptions: FindOptions): JsonObject? {
   return awaitResult {
     this.findOneAndDeleteWithOptions(collection, query, findOptions, it)
@@ -402,7 +402,7 @@ suspend fun MongoClient.findOneAndDeleteWithOptionsAwait(collection: String, que
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use count returning a future and chain with await()", replaceWith = ReplaceWith("count(collection, query).await()"))
+@Deprecated(message = "Instead use count returning a future and chain with coAwait()", replaceWith = ReplaceWith("count(collection, query).coAwait()"))
 suspend fun MongoClient.countAwait(collection: String, query: JsonObject): Long {
   return awaitResult {
     this.count(collection, query, it)
@@ -419,7 +419,7 @@ suspend fun MongoClient.countAwait(collection: String, query: JsonObject): Long 
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use countWithOptions returning a future and chain with await()", replaceWith = ReplaceWith("countWithOptions(collection, query, countOptions).await()"))
+@Deprecated(message = "Instead use countWithOptions returning a future and chain with coAwait()", replaceWith = ReplaceWith("countWithOptions(collection, query, countOptions).coAwait()"))
 suspend fun MongoClient.countWithOptionsAwait(collection: String, query: JsonObject, countOptions: CountOptions): Long {
   return awaitResult {
     this.countWithOptions(collection, query, countOptions, it)
@@ -435,7 +435,7 @@ suspend fun MongoClient.countWithOptionsAwait(collection: String, query: JsonObj
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use removeDocuments returning a future and chain with await()", replaceWith = ReplaceWith("removeDocuments(collection, query).await()"))
+@Deprecated(message = "Instead use removeDocuments returning a future and chain with coAwait()", replaceWith = ReplaceWith("removeDocuments(collection, query).coAwait()"))
 suspend fun MongoClient.removeDocumentsAwait(collection: String, query: JsonObject): MongoClientDeleteResult? {
   return awaitResult {
     this.removeDocuments(collection, query, it)
@@ -452,7 +452,7 @@ suspend fun MongoClient.removeDocumentsAwait(collection: String, query: JsonObje
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use removeDocumentsWithOptions returning a future and chain with await()", replaceWith = ReplaceWith("removeDocumentsWithOptions(collection, query, writeOption).await()"))
+@Deprecated(message = "Instead use removeDocumentsWithOptions returning a future and chain with coAwait()", replaceWith = ReplaceWith("removeDocumentsWithOptions(collection, query, writeOption).coAwait()"))
 suspend fun MongoClient.removeDocumentsWithOptionsAwait(collection: String, query: JsonObject, writeOption: WriteOption?): MongoClientDeleteResult? {
   return awaitResult {
     this.removeDocumentsWithOptions(collection, query, writeOption, it)
@@ -468,7 +468,7 @@ suspend fun MongoClient.removeDocumentsWithOptionsAwait(collection: String, quer
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use removeDocument returning a future and chain with await()", replaceWith = ReplaceWith("removeDocument(collection, query).await()"))
+@Deprecated(message = "Instead use removeDocument returning a future and chain with coAwait()", replaceWith = ReplaceWith("removeDocument(collection, query).coAwait()"))
 suspend fun MongoClient.removeDocumentAwait(collection: String, query: JsonObject): MongoClientDeleteResult? {
   return awaitResult {
     this.removeDocument(collection, query, it)
@@ -485,7 +485,7 @@ suspend fun MongoClient.removeDocumentAwait(collection: String, query: JsonObjec
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use removeDocumentWithOptions returning a future and chain with await()", replaceWith = ReplaceWith("removeDocumentWithOptions(collection, query, writeOption).await()"))
+@Deprecated(message = "Instead use removeDocumentWithOptions returning a future and chain with coAwait()", replaceWith = ReplaceWith("removeDocumentWithOptions(collection, query, writeOption).coAwait()"))
 suspend fun MongoClient.removeDocumentWithOptionsAwait(collection: String, query: JsonObject, writeOption: WriteOption?): MongoClientDeleteResult? {
   return awaitResult {
     this.removeDocumentWithOptions(collection, query, writeOption, it)
@@ -499,7 +499,7 @@ suspend fun MongoClient.removeDocumentWithOptionsAwait(collection: String, query
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use createCollection returning a future and chain with await()", replaceWith = ReplaceWith("createCollection(collectionName).await()"))
+@Deprecated(message = "Instead use createCollection returning a future and chain with coAwait()", replaceWith = ReplaceWith("createCollection(collectionName).coAwait()"))
 suspend fun MongoClient.createCollectionAwait(collectionName: String): Unit {
   return awaitResult {
     this.createCollection(collectionName, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -514,7 +514,7 @@ suspend fun MongoClient.createCollectionAwait(collectionName: String): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use createCollectionWithOptions returning a future and chain with await()", replaceWith = ReplaceWith("createCollectionWithOptions(collectionName, collectionOptions).await()"))
+@Deprecated(message = "Instead use createCollectionWithOptions returning a future and chain with coAwait()", replaceWith = ReplaceWith("createCollectionWithOptions(collectionName, collectionOptions).coAwait()"))
 suspend fun MongoClient.createCollectionWithOptionsAwait(collectionName: String, collectionOptions: CreateCollectionOptions): Unit {
   return awaitResult {
     this.createCollectionWithOptions(collectionName, collectionOptions, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -528,7 +528,7 @@ suspend fun MongoClient.createCollectionWithOptionsAwait(collectionName: String,
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use getCollections returning a future and chain with await()", replaceWith = ReplaceWith("getCollections().await()"))
+@Deprecated(message = "Instead use getCollections returning a future and chain with coAwait()", replaceWith = ReplaceWith("getCollections().coAwait()"))
 suspend fun MongoClient.getCollectionsAwait(): List<String> {
   return awaitResult {
     this.getCollections(it)
@@ -542,7 +542,7 @@ suspend fun MongoClient.getCollectionsAwait(): List<String> {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use dropCollection returning a future and chain with await()", replaceWith = ReplaceWith("dropCollection(collection).await()"))
+@Deprecated(message = "Instead use dropCollection returning a future and chain with coAwait()", replaceWith = ReplaceWith("dropCollection(collection).coAwait()"))
 suspend fun MongoClient.dropCollectionAwait(collection: String): Unit {
   return awaitResult {
     this.dropCollection(collection, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -557,7 +557,7 @@ suspend fun MongoClient.dropCollectionAwait(collection: String): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use createIndex returning a future and chain with await()", replaceWith = ReplaceWith("createIndex(collection, key).await()"))
+@Deprecated(message = "Instead use createIndex returning a future and chain with coAwait()", replaceWith = ReplaceWith("createIndex(collection, key).coAwait()"))
 suspend fun MongoClient.createIndexAwait(collection: String, key: JsonObject): Unit {
   return awaitResult {
     this.createIndex(collection, key, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -573,7 +573,7 @@ suspend fun MongoClient.createIndexAwait(collection: String, key: JsonObject): U
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use createIndexWithOptions returning a future and chain with await()", replaceWith = ReplaceWith("createIndexWithOptions(collection, key, options).await()"))
+@Deprecated(message = "Instead use createIndexWithOptions returning a future and chain with coAwait()", replaceWith = ReplaceWith("createIndexWithOptions(collection, key, options).coAwait()"))
 suspend fun MongoClient.createIndexWithOptionsAwait(collection: String, key: JsonObject, options: IndexOptions): Unit {
   return awaitResult {
     this.createIndexWithOptions(collection, key, options, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -588,7 +588,7 @@ suspend fun MongoClient.createIndexWithOptionsAwait(collection: String, key: Jso
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use createIndexes returning a future and chain with await()", replaceWith = ReplaceWith("createIndexes(collection, indexes).await()"))
+@Deprecated(message = "Instead use createIndexes returning a future and chain with coAwait()", replaceWith = ReplaceWith("createIndexes(collection, indexes).coAwait()"))
 suspend fun MongoClient.createIndexesAwait(collection: String, indexes: List<IndexModel>): Unit {
   return awaitResult {
     this.createIndexes(collection, indexes, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -603,7 +603,7 @@ suspend fun MongoClient.createIndexesAwait(collection: String, indexes: List<Ind
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use listIndexes returning a future and chain with await()", replaceWith = ReplaceWith("listIndexes(collection).await()"))
+@Deprecated(message = "Instead use listIndexes returning a future and chain with coAwait()", replaceWith = ReplaceWith("listIndexes(collection).coAwait()"))
 suspend fun MongoClient.listIndexesAwait(collection: String): JsonArray {
   return awaitResult {
     this.listIndexes(collection, it)
@@ -618,7 +618,7 @@ suspend fun MongoClient.listIndexesAwait(collection: String): JsonArray {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use dropIndex returning a future and chain with await()", replaceWith = ReplaceWith("dropIndex(collection, indexName).await()"))
+@Deprecated(message = "Instead use dropIndex returning a future and chain with coAwait()", replaceWith = ReplaceWith("dropIndex(collection, indexName).coAwait()"))
 suspend fun MongoClient.dropIndexAwait(collection: String, indexName: String): Unit {
   return awaitResult {
     this.dropIndex(collection, indexName, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -634,7 +634,7 @@ suspend fun MongoClient.dropIndexAwait(collection: String, indexName: String): U
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use runCommand returning a future and chain with await()", replaceWith = ReplaceWith("runCommand(commandName, command).await()"))
+@Deprecated(message = "Instead use runCommand returning a future and chain with coAwait()", replaceWith = ReplaceWith("runCommand(commandName, command).coAwait()"))
 suspend fun MongoClient.runCommandAwait(commandName: String, command: JsonObject): JsonObject? {
   return awaitResult {
     this.runCommand(commandName, command, it)
@@ -651,7 +651,7 @@ suspend fun MongoClient.runCommandAwait(commandName: String, command: JsonObject
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use distinct returning a future and chain with await()", replaceWith = ReplaceWith("distinct(collection, fieldName, resultClassname).await()"))
+@Deprecated(message = "Instead use distinct returning a future and chain with coAwait()", replaceWith = ReplaceWith("distinct(collection, fieldName, resultClassname).coAwait()"))
 suspend fun MongoClient.distinctAwait(collection: String, fieldName: String, resultClassname: String): JsonArray {
   return awaitResult {
     this.distinct(collection, fieldName, resultClassname, it)
@@ -669,7 +669,7 @@ suspend fun MongoClient.distinctAwait(collection: String, fieldName: String, res
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use distinct returning a future and chain with await()", replaceWith = ReplaceWith("distinct(collection, fieldName, resultClassname, distinctOptions).await()"))
+@Deprecated(message = "Instead use distinct returning a future and chain with coAwait()", replaceWith = ReplaceWith("distinct(collection, fieldName, resultClassname, distinctOptions).coAwait()"))
 suspend fun MongoClient.distinctAwait(collection: String, fieldName: String, resultClassname: String, distinctOptions: DistinctOptions): JsonArray {
   return awaitResult {
     this.distinct(collection, fieldName, resultClassname, distinctOptions, it)
@@ -687,7 +687,7 @@ suspend fun MongoClient.distinctAwait(collection: String, fieldName: String, res
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use distinctWithQuery returning a future and chain with await()", replaceWith = ReplaceWith("distinctWithQuery(collection, fieldName, resultClassname, query).await()"))
+@Deprecated(message = "Instead use distinctWithQuery returning a future and chain with coAwait()", replaceWith = ReplaceWith("distinctWithQuery(collection, fieldName, resultClassname, query).coAwait()"))
 suspend fun MongoClient.distinctWithQueryAwait(collection: String, fieldName: String, resultClassname: String, query: JsonObject): JsonArray {
   return awaitResult {
     this.distinctWithQuery(collection, fieldName, resultClassname, query, it)
@@ -706,7 +706,7 @@ suspend fun MongoClient.distinctWithQueryAwait(collection: String, fieldName: St
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use distinctWithQuery returning a future and chain with await()", replaceWith = ReplaceWith("distinctWithQuery(collection, fieldName, resultClassname, query, distinctOptions).await()"))
+@Deprecated(message = "Instead use distinctWithQuery returning a future and chain with coAwait()", replaceWith = ReplaceWith("distinctWithQuery(collection, fieldName, resultClassname, query, distinctOptions).coAwait()"))
 suspend fun MongoClient.distinctWithQueryAwait(collection: String, fieldName: String, resultClassname: String, query: JsonObject, distinctOptions: DistinctOptions): JsonArray {
   return awaitResult {
     this.distinctWithQuery(collection, fieldName, resultClassname, query, distinctOptions, it)
@@ -720,7 +720,7 @@ suspend fun MongoClient.distinctWithQueryAwait(collection: String, fieldName: St
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use createDefaultGridFsBucketService returning a future and chain with await()", replaceWith = ReplaceWith("createDefaultGridFsBucketService().await()"))
+@Deprecated(message = "Instead use createDefaultGridFsBucketService returning a future and chain with coAwait()", replaceWith = ReplaceWith("createDefaultGridFsBucketService().coAwait()"))
 suspend fun MongoClient.createDefaultGridFsBucketServiceAwait(): MongoGridFsClient {
   return awaitResult {
     this.createDefaultGridFsBucketService(it)
@@ -735,7 +735,7 @@ suspend fun MongoClient.createDefaultGridFsBucketServiceAwait(): MongoGridFsClie
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use createGridFsBucketService returning a future and chain with await()", replaceWith = ReplaceWith("createGridFsBucketService(bucketName).await()"))
+@Deprecated(message = "Instead use createGridFsBucketService returning a future and chain with coAwait()", replaceWith = ReplaceWith("createGridFsBucketService(bucketName).coAwait()"))
 suspend fun MongoClient.createGridFsBucketServiceAwait(bucketName: String): MongoGridFsClient {
   return awaitResult {
     this.createGridFsBucketService(bucketName, it)
@@ -748,7 +748,7 @@ suspend fun MongoClient.createGridFsBucketServiceAwait(bucketName: String): Mong
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use close returning a future and chain with await()", replaceWith = ReplaceWith("close().await()"))
+@Deprecated(message = "Instead use close returning a future and chain with coAwait()", replaceWith = ReplaceWith("close().coAwait()"))
 suspend fun MongoClient.closeAwait(): Unit {
   return awaitResult {
     this.close(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/mongo/MongoGridFsClient.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/mongo/MongoGridFsClient.kt
@@ -31,28 +31,28 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoGridFsClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use delete returning a future and chain with await()", replaceWith = ReplaceWith("delete(id).await()"))
+@Deprecated(message = "Instead use delete returning a future and chain with coAwait()", replaceWith = ReplaceWith("delete(id).coAwait()"))
 suspend fun MongoGridFsClient.deleteAwait(id: String): Unit {
   return awaitResult {
     this.delete(id, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
   }
 }
 
-@Deprecated(message = "Instead use downloadByFileName returning a future and chain with await()", replaceWith = ReplaceWith("downloadByFileName(stream, fileName).await()"))
+@Deprecated(message = "Instead use downloadByFileName returning a future and chain with coAwait()", replaceWith = ReplaceWith("downloadByFileName(stream, fileName).coAwait()"))
 suspend fun MongoGridFsClient.downloadByFileNameAwait(stream: WriteStream<Buffer>, fileName: String): Long {
   return awaitResult {
     this.downloadByFileName(stream, fileName, it)
   }
 }
 
-@Deprecated(message = "Instead use downloadByFileNameWithOptions returning a future and chain with await()", replaceWith = ReplaceWith("downloadByFileNameWithOptions(stream, fileName, options).await()"))
+@Deprecated(message = "Instead use downloadByFileNameWithOptions returning a future and chain with coAwait()", replaceWith = ReplaceWith("downloadByFileNameWithOptions(stream, fileName, options).coAwait()"))
 suspend fun MongoGridFsClient.downloadByFileNameWithOptionsAwait(stream: WriteStream<Buffer>, fileName: String, options: GridFsDownloadOptions): Long {
   return awaitResult {
     this.downloadByFileNameWithOptions(stream, fileName, options, it)
   }
 }
 
-@Deprecated(message = "Instead use downloadById returning a future and chain with await()", replaceWith = ReplaceWith("downloadById(stream, id).await()"))
+@Deprecated(message = "Instead use downloadById returning a future and chain with coAwait()", replaceWith = ReplaceWith("downloadById(stream, id).coAwait()"))
 suspend fun MongoGridFsClient.downloadByIdAwait(stream: WriteStream<Buffer>, id: String): Long {
   return awaitResult {
     this.downloadById(stream, id, it)
@@ -67,7 +67,7 @@ suspend fun MongoGridFsClient.downloadByIdAwait(stream: WriteStream<Buffer>, id:
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoGridFsClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use downloadFile returning a future and chain with await()", replaceWith = ReplaceWith("downloadFile(fileName).await()"))
+@Deprecated(message = "Instead use downloadFile returning a future and chain with coAwait()", replaceWith = ReplaceWith("downloadFile(fileName).coAwait()"))
 suspend fun MongoGridFsClient.downloadFileAwait(fileName: String): Long {
   return awaitResult {
     this.downloadFile(fileName, it)
@@ -83,7 +83,7 @@ suspend fun MongoGridFsClient.downloadFileAwait(fileName: String): Long {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoGridFsClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use downloadFileAs returning a future and chain with await()", replaceWith = ReplaceWith("downloadFileAs(fileName, newFileName).await()"))
+@Deprecated(message = "Instead use downloadFileAs returning a future and chain with coAwait()", replaceWith = ReplaceWith("downloadFileAs(fileName, newFileName).coAwait()"))
 suspend fun MongoGridFsClient.downloadFileAsAwait(fileName: String, newFileName: String): Long {
   return awaitResult {
     this.downloadFileAs(fileName, newFileName, it)
@@ -99,7 +99,7 @@ suspend fun MongoGridFsClient.downloadFileAsAwait(fileName: String, newFileName:
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoGridFsClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use downloadFileByID returning a future and chain with await()", replaceWith = ReplaceWith("downloadFileByID(id, fileName).await()"))
+@Deprecated(message = "Instead use downloadFileByID returning a future and chain with coAwait()", replaceWith = ReplaceWith("downloadFileByID(id, fileName).coAwait()"))
 suspend fun MongoGridFsClient.downloadFileByIDAwait(id: String, fileName: String): Long {
   return awaitResult {
     this.downloadFileByID(id, fileName, it)
@@ -112,7 +112,7 @@ suspend fun MongoGridFsClient.downloadFileByIDAwait(id: String, fileName: String
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoGridFsClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use drop returning a future and chain with await()", replaceWith = ReplaceWith("drop().await()"))
+@Deprecated(message = "Instead use drop returning a future and chain with coAwait()", replaceWith = ReplaceWith("drop().coAwait()"))
 suspend fun MongoGridFsClient.dropAwait(): Unit {
   return awaitResult {
     this.drop(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -126,7 +126,7 @@ suspend fun MongoGridFsClient.dropAwait(): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoGridFsClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use findAllIds returning a future and chain with await()", replaceWith = ReplaceWith("findAllIds().await()"))
+@Deprecated(message = "Instead use findAllIds returning a future and chain with coAwait()", replaceWith = ReplaceWith("findAllIds().coAwait()"))
 suspend fun MongoGridFsClient.findAllIdsAwait(): List<String> {
   return awaitResult {
     this.findAllIds(it)
@@ -141,21 +141,21 @@ suspend fun MongoGridFsClient.findAllIdsAwait(): List<String> {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoGridFsClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use findIds returning a future and chain with await()", replaceWith = ReplaceWith("findIds(query).await()"))
+@Deprecated(message = "Instead use findIds returning a future and chain with coAwait()", replaceWith = ReplaceWith("findIds(query).coAwait()"))
 suspend fun MongoGridFsClient.findIdsAwait(query: JsonObject): List<String> {
   return awaitResult {
     this.findIds(query, it)
   }
 }
 
-@Deprecated(message = "Instead use uploadByFileName returning a future and chain with await()", replaceWith = ReplaceWith("uploadByFileName(stream, fileName).await()"))
+@Deprecated(message = "Instead use uploadByFileName returning a future and chain with coAwait()", replaceWith = ReplaceWith("uploadByFileName(stream, fileName).coAwait()"))
 suspend fun MongoGridFsClient.uploadByFileNameAwait(stream: ReadStream<Buffer>, fileName: String): String {
   return awaitResult {
     this.uploadByFileName(stream, fileName, it)
   }
 }
 
-@Deprecated(message = "Instead use uploadByFileNameWithOptions returning a future and chain with await()", replaceWith = ReplaceWith("uploadByFileNameWithOptions(stream, fileName, options).await()"))
+@Deprecated(message = "Instead use uploadByFileNameWithOptions returning a future and chain with coAwait()", replaceWith = ReplaceWith("uploadByFileNameWithOptions(stream, fileName, options).coAwait()"))
 suspend fun MongoGridFsClient.uploadByFileNameWithOptionsAwait(stream: ReadStream<Buffer>, fileName: String, options: GridFsUploadOptions): String {
   return awaitResult {
     this.uploadByFileNameWithOptions(stream, fileName, options, it)
@@ -170,7 +170,7 @@ suspend fun MongoGridFsClient.uploadByFileNameWithOptionsAwait(stream: ReadStrea
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoGridFsClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use uploadFile returning a future and chain with await()", replaceWith = ReplaceWith("uploadFile(fileName).await()"))
+@Deprecated(message = "Instead use uploadFile returning a future and chain with coAwait()", replaceWith = ReplaceWith("uploadFile(fileName).coAwait()"))
 suspend fun MongoGridFsClient.uploadFileAwait(fileName: String): String {
   return awaitResult {
     this.uploadFile(fileName, it)
@@ -186,7 +186,7 @@ suspend fun MongoGridFsClient.uploadFileAwait(fileName: String): String {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.mongo.MongoGridFsClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use uploadFileWithOptions returning a future and chain with await()", replaceWith = ReplaceWith("uploadFileWithOptions(fileName, options).await()"))
+@Deprecated(message = "Instead use uploadFileWithOptions returning a future and chain with coAwait()", replaceWith = ReplaceWith("uploadFileWithOptions(fileName, options).coAwait()"))
 suspend fun MongoGridFsClient.uploadFileWithOptionsAwait(fileName: String, options: GridFsUploadOptions): String {
   return awaitResult {
     this.uploadFileWithOptions(fileName, options, it)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/shell/ShellServer.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/shell/ShellServer.kt
@@ -24,7 +24,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.shell.ShellServer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use listen returning a future and chain with await()", replaceWith = ReplaceWith("listen().await()"))
+@Deprecated(message = "Instead use listen returning a future and chain with coAwait()", replaceWith = ReplaceWith("listen().coAwait()"))
 suspend fun ShellServer.listenAwait(): Unit {
   return awaitResult {
     this.listen(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -37,7 +37,7 @@ suspend fun ShellServer.listenAwait(): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.shell.ShellServer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use close returning a future and chain with await()", replaceWith = ReplaceWith("close().await()"))
+@Deprecated(message = "Instead use close returning a future and chain with coAwait()", replaceWith = ReplaceWith("close().coAwait()"))
 suspend fun ShellServer.closeAwait(): Unit {
   return awaitResult {
     this.close(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/shell/ShellService.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/shell/ShellService.kt
@@ -24,7 +24,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.shell.ShellService] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use start returning a future and chain with await()", replaceWith = ReplaceWith("start().await()"))
+@Deprecated(message = "Instead use start returning a future and chain with coAwait()", replaceWith = ReplaceWith("start().coAwait()"))
 suspend fun ShellService.startAwait(): Unit {
   return awaitResult {
     this.start(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -37,7 +37,7 @@ suspend fun ShellService.startAwait(): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.shell.ShellService] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use stop returning a future and chain with await()", replaceWith = ReplaceWith("stop().await()"))
+@Deprecated(message = "Instead use stop returning a future and chain with coAwait()", replaceWith = ReplaceWith("stop().coAwait()"))
 suspend fun ShellService.stopAwait(): Unit {
   return awaitResult {
     this.stop(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/shell/command/CommandRegistry.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/shell/command/CommandRegistry.kt
@@ -27,7 +27,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.shell.command.CommandRegistry] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use registerCommand returning a future and chain with await()", replaceWith = ReplaceWith("registerCommand(command).await()"))
+@Deprecated(message = "Instead use registerCommand returning a future and chain with coAwait()", replaceWith = ReplaceWith("registerCommand(command).coAwait()"))
 suspend fun CommandRegistry.registerCommandAwait(command: Command): Command {
   return awaitResult {
     this.registerCommand(command, it)
@@ -42,7 +42,7 @@ suspend fun CommandRegistry.registerCommandAwait(command: Command): Command {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.shell.command.CommandRegistry] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use registerCommands returning a future and chain with await()", replaceWith = ReplaceWith("registerCommands(commands).await()"))
+@Deprecated(message = "Instead use registerCommands returning a future and chain with coAwait()", replaceWith = ReplaceWith("registerCommands(commands).coAwait()"))
 suspend fun CommandRegistry.registerCommandsAwait(commands: List<Command>): List<Command> {
   return awaitResult {
     this.registerCommands(commands, it)
@@ -56,7 +56,7 @@ suspend fun CommandRegistry.registerCommandsAwait(commands: List<Command>): List
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.shell.command.CommandRegistry] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use unregisterCommand returning a future and chain with await()", replaceWith = ReplaceWith("unregisterCommand(commandName).await()"))
+@Deprecated(message = "Instead use unregisterCommand returning a future and chain with coAwait()", replaceWith = ReplaceWith("unregisterCommand(commandName).coAwait()"))
 suspend fun CommandRegistry.unregisterCommandAwait(commandName: String): Unit {
   return awaitResult {
     this.unregisterCommand(commandName, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/shell/term/TermServer.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/shell/term/TermServer.kt
@@ -24,7 +24,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.shell.term.TermServer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use listen returning a future and chain with await()", replaceWith = ReplaceWith("listen().await()"))
+@Deprecated(message = "Instead use listen returning a future and chain with coAwait()", replaceWith = ReplaceWith("listen().coAwait()"))
 suspend fun TermServer.listenAwait(): Unit {
   return awaitResult {
     this.listen(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -37,7 +37,7 @@ suspend fun TermServer.listenAwait(): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.shell.term.TermServer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use close returning a future and chain with await()", replaceWith = ReplaceWith("close().await()"))
+@Deprecated(message = "Instead use close returning a future and chain with coAwait()", replaceWith = ReplaceWith("close().coAwait()"))
 suspend fun TermServer.closeAwait(): Unit {
   return awaitResult {
     this.close(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/sql/SQLClient.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/sql/SQLClient.kt
@@ -31,7 +31,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use querySingle returning a future and chain with await()", replaceWith = ReplaceWith("querySingle(sql).await()"))
+@Deprecated(message = "Instead use querySingle returning a future and chain with coAwait()", replaceWith = ReplaceWith("querySingle(sql).coAwait()"))
 suspend fun SQLClient.querySingleAwait(sql: String): JsonArray? {
   return awaitResult {
     this.querySingle(sql, it)
@@ -47,7 +47,7 @@ suspend fun SQLClient.querySingleAwait(sql: String): JsonArray? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use querySingleWithParams returning a future and chain with await()", replaceWith = ReplaceWith("querySingleWithParams(sql, arguments).await()"))
+@Deprecated(message = "Instead use querySingleWithParams returning a future and chain with coAwait()", replaceWith = ReplaceWith("querySingleWithParams(sql, arguments).coAwait()"))
 suspend fun SQLClient.querySingleWithParamsAwait(sql: String, arguments: JsonArray): JsonArray? {
   return awaitResult {
     this.querySingleWithParams(sql, arguments, it)
@@ -61,7 +61,7 @@ suspend fun SQLClient.querySingleWithParamsAwait(sql: String, arguments: JsonArr
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use getConnection returning a future and chain with await()", replaceWith = ReplaceWith("getConnection().await()"))
+@Deprecated(message = "Instead use getConnection returning a future and chain with coAwait()", replaceWith = ReplaceWith("getConnection().coAwait()"))
 suspend fun SQLClient.getConnectionAwait(): SQLConnection {
   return awaitResult {
     this.getConnection(it)
@@ -74,7 +74,7 @@ suspend fun SQLClient.getConnectionAwait(): SQLConnection {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use close returning a future and chain with await()", replaceWith = ReplaceWith("close().await()"))
+@Deprecated(message = "Instead use close returning a future and chain with coAwait()", replaceWith = ReplaceWith("close().coAwait()"))
 suspend fun SQLClient.closeAwait(): Unit {
   return awaitResult {
     this.close(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -89,7 +89,7 @@ suspend fun SQLClient.closeAwait(): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use query returning a future and chain with await()", replaceWith = ReplaceWith("query(sql).await()"))
+@Deprecated(message = "Instead use query returning a future and chain with coAwait()", replaceWith = ReplaceWith("query(sql).coAwait()"))
 suspend fun SQLClient.queryAwait(sql: String): ResultSet {
   return awaitResult {
     this.query(sql, it)
@@ -104,7 +104,7 @@ suspend fun SQLClient.queryAwait(sql: String): ResultSet {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use queryStream returning a future and chain with await()", replaceWith = ReplaceWith("queryStream(sql).await()"))
+@Deprecated(message = "Instead use queryStream returning a future and chain with coAwait()", replaceWith = ReplaceWith("queryStream(sql).coAwait()"))
 suspend fun SQLClient.queryStreamAwait(sql: String): SQLRowStream {
   return awaitResult {
     this.queryStream(sql, it)
@@ -120,7 +120,7 @@ suspend fun SQLClient.queryStreamAwait(sql: String): SQLRowStream {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use queryStreamWithParams returning a future and chain with await()", replaceWith = ReplaceWith("queryStreamWithParams(sql, params).await()"))
+@Deprecated(message = "Instead use queryStreamWithParams returning a future and chain with coAwait()", replaceWith = ReplaceWith("queryStreamWithParams(sql, params).coAwait()"))
 suspend fun SQLClient.queryStreamWithParamsAwait(sql: String, params: JsonArray): SQLRowStream {
   return awaitResult {
     this.queryStreamWithParams(sql, params, it)
@@ -136,7 +136,7 @@ suspend fun SQLClient.queryStreamWithParamsAwait(sql: String, params: JsonArray)
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use queryWithParams returning a future and chain with await()", replaceWith = ReplaceWith("queryWithParams(sql, arguments).await()"))
+@Deprecated(message = "Instead use queryWithParams returning a future and chain with coAwait()", replaceWith = ReplaceWith("queryWithParams(sql, arguments).coAwait()"))
 suspend fun SQLClient.queryWithParamsAwait(sql: String, arguments: JsonArray): ResultSet {
   return awaitResult {
     this.queryWithParams(sql, arguments, it)
@@ -151,7 +151,7 @@ suspend fun SQLClient.queryWithParamsAwait(sql: String, arguments: JsonArray): R
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use update returning a future and chain with await()", replaceWith = ReplaceWith("update(sql).await()"))
+@Deprecated(message = "Instead use update returning a future and chain with coAwait()", replaceWith = ReplaceWith("update(sql).coAwait()"))
 suspend fun SQLClient.updateAwait(sql: String): UpdateResult {
   return awaitResult {
     this.update(sql, it)
@@ -167,7 +167,7 @@ suspend fun SQLClient.updateAwait(sql: String): UpdateResult {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use updateWithParams returning a future and chain with await()", replaceWith = ReplaceWith("updateWithParams(sql, params).await()"))
+@Deprecated(message = "Instead use updateWithParams returning a future and chain with coAwait()", replaceWith = ReplaceWith("updateWithParams(sql, params).coAwait()"))
 suspend fun SQLClient.updateWithParamsAwait(sql: String, params: JsonArray): UpdateResult {
   return awaitResult {
     this.updateWithParams(sql, params, it)
@@ -182,7 +182,7 @@ suspend fun SQLClient.updateWithParamsAwait(sql: String, params: JsonArray): Upd
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use call returning a future and chain with await()", replaceWith = ReplaceWith("call(sql).await()"))
+@Deprecated(message = "Instead use call returning a future and chain with coAwait()", replaceWith = ReplaceWith("call(sql).coAwait()"))
 suspend fun SQLClient.callAwait(sql: String): ResultSet {
   return awaitResult {
     this.call(sql, it)
@@ -199,7 +199,7 @@ suspend fun SQLClient.callAwait(sql: String): ResultSet {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use callWithParams returning a future and chain with await()", replaceWith = ReplaceWith("callWithParams(sql, params, outputs).await()"))
+@Deprecated(message = "Instead use callWithParams returning a future and chain with coAwait()", replaceWith = ReplaceWith("callWithParams(sql, params, outputs).coAwait()"))
 suspend fun SQLClient.callWithParamsAwait(sql: String, params: JsonArray, outputs: JsonArray): ResultSet {
   return awaitResult {
     this.callWithParams(sql, params, outputs, it)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/sql/SQLConnection.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/sql/SQLConnection.kt
@@ -31,7 +31,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use querySingle returning a future and chain with await()", replaceWith = ReplaceWith("querySingle(sql).await()"))
+@Deprecated(message = "Instead use querySingle returning a future and chain with coAwait()", replaceWith = ReplaceWith("querySingle(sql).coAwait()"))
 suspend fun SQLConnection.querySingleAwait(sql: String): JsonArray? {
   return awaitResult {
     this.querySingle(sql, it)
@@ -47,7 +47,7 @@ suspend fun SQLConnection.querySingleAwait(sql: String): JsonArray? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use querySingleWithParams returning a future and chain with await()", replaceWith = ReplaceWith("querySingleWithParams(sql, arguments).await()"))
+@Deprecated(message = "Instead use querySingleWithParams returning a future and chain with coAwait()", replaceWith = ReplaceWith("querySingleWithParams(sql, arguments).coAwait()"))
 suspend fun SQLConnection.querySingleWithParamsAwait(sql: String, arguments: JsonArray): JsonArray? {
   return awaitResult {
     this.querySingleWithParams(sql, arguments, it)
@@ -61,7 +61,7 @@ suspend fun SQLConnection.querySingleWithParamsAwait(sql: String, arguments: Jso
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use setAutoCommit returning a future and chain with await()", replaceWith = ReplaceWith("setAutoCommit(autoCommit).await()"))
+@Deprecated(message = "Instead use setAutoCommit returning a future and chain with coAwait()", replaceWith = ReplaceWith("setAutoCommit(autoCommit).coAwait()"))
 suspend fun SQLConnection.setAutoCommitAwait(autoCommit: Boolean): Unit {
   return awaitResult {
     this.setAutoCommit(autoCommit, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -75,7 +75,7 @@ suspend fun SQLConnection.setAutoCommitAwait(autoCommit: Boolean): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use execute returning a future and chain with await()", replaceWith = ReplaceWith("execute(sql).await()"))
+@Deprecated(message = "Instead use execute returning a future and chain with coAwait()", replaceWith = ReplaceWith("execute(sql).coAwait()"))
 suspend fun SQLConnection.executeAwait(sql: String): Unit {
   return awaitResult {
     this.execute(sql, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -90,7 +90,7 @@ suspend fun SQLConnection.executeAwait(sql: String): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use query returning a future and chain with await()", replaceWith = ReplaceWith("query(sql).await()"))
+@Deprecated(message = "Instead use query returning a future and chain with coAwait()", replaceWith = ReplaceWith("query(sql).coAwait()"))
 suspend fun SQLConnection.queryAwait(sql: String): ResultSet {
   return awaitResult {
     this.query(sql, it)
@@ -105,7 +105,7 @@ suspend fun SQLConnection.queryAwait(sql: String): ResultSet {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use queryStream returning a future and chain with await()", replaceWith = ReplaceWith("queryStream(sql).await()"))
+@Deprecated(message = "Instead use queryStream returning a future and chain with coAwait()", replaceWith = ReplaceWith("queryStream(sql).coAwait()"))
 suspend fun SQLConnection.queryStreamAwait(sql: String): SQLRowStream {
   return awaitResult {
     this.queryStream(sql, it)
@@ -121,7 +121,7 @@ suspend fun SQLConnection.queryStreamAwait(sql: String): SQLRowStream {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use queryWithParams returning a future and chain with await()", replaceWith = ReplaceWith("queryWithParams(sql, params).await()"))
+@Deprecated(message = "Instead use queryWithParams returning a future and chain with coAwait()", replaceWith = ReplaceWith("queryWithParams(sql, params).coAwait()"))
 suspend fun SQLConnection.queryWithParamsAwait(sql: String, params: JsonArray): ResultSet {
   return awaitResult {
     this.queryWithParams(sql, params, it)
@@ -137,7 +137,7 @@ suspend fun SQLConnection.queryWithParamsAwait(sql: String, params: JsonArray): 
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use queryStreamWithParams returning a future and chain with await()", replaceWith = ReplaceWith("queryStreamWithParams(sql, params).await()"))
+@Deprecated(message = "Instead use queryStreamWithParams returning a future and chain with coAwait()", replaceWith = ReplaceWith("queryStreamWithParams(sql, params).coAwait()"))
 suspend fun SQLConnection.queryStreamWithParamsAwait(sql: String, params: JsonArray): SQLRowStream {
   return awaitResult {
     this.queryStreamWithParams(sql, params, it)
@@ -152,7 +152,7 @@ suspend fun SQLConnection.queryStreamWithParamsAwait(sql: String, params: JsonAr
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use update returning a future and chain with await()", replaceWith = ReplaceWith("update(sql).await()"))
+@Deprecated(message = "Instead use update returning a future and chain with coAwait()", replaceWith = ReplaceWith("update(sql).coAwait()"))
 suspend fun SQLConnection.updateAwait(sql: String): UpdateResult {
   return awaitResult {
     this.update(sql, it)
@@ -168,7 +168,7 @@ suspend fun SQLConnection.updateAwait(sql: String): UpdateResult {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use updateWithParams returning a future and chain with await()", replaceWith = ReplaceWith("updateWithParams(sql, params).await()"))
+@Deprecated(message = "Instead use updateWithParams returning a future and chain with coAwait()", replaceWith = ReplaceWith("updateWithParams(sql, params).coAwait()"))
 suspend fun SQLConnection.updateWithParamsAwait(sql: String, params: JsonArray): UpdateResult {
   return awaitResult {
     this.updateWithParams(sql, params, it)
@@ -183,7 +183,7 @@ suspend fun SQLConnection.updateWithParamsAwait(sql: String, params: JsonArray):
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use call returning a future and chain with await()", replaceWith = ReplaceWith("call(sql).await()"))
+@Deprecated(message = "Instead use call returning a future and chain with coAwait()", replaceWith = ReplaceWith("call(sql).coAwait()"))
 suspend fun SQLConnection.callAwait(sql: String): ResultSet {
   return awaitResult {
     this.call(sql, it)
@@ -200,7 +200,7 @@ suspend fun SQLConnection.callAwait(sql: String): ResultSet {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use callWithParams returning a future and chain with await()", replaceWith = ReplaceWith("callWithParams(sql, params, outputs).await()"))
+@Deprecated(message = "Instead use callWithParams returning a future and chain with coAwait()", replaceWith = ReplaceWith("callWithParams(sql, params, outputs).coAwait()"))
 suspend fun SQLConnection.callWithParamsAwait(sql: String, params: JsonArray, outputs: JsonArray): ResultSet {
   return awaitResult {
     this.callWithParams(sql, params, outputs, it)
@@ -213,7 +213,7 @@ suspend fun SQLConnection.callWithParamsAwait(sql: String, params: JsonArray, ou
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use close returning a future and chain with await()", replaceWith = ReplaceWith("close().await()"))
+@Deprecated(message = "Instead use close returning a future and chain with coAwait()", replaceWith = ReplaceWith("close().coAwait()"))
 suspend fun SQLConnection.closeAwait(): Unit {
   return awaitResult {
     this.close(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -226,7 +226,7 @@ suspend fun SQLConnection.closeAwait(): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use commit returning a future and chain with await()", replaceWith = ReplaceWith("commit().await()"))
+@Deprecated(message = "Instead use commit returning a future and chain with coAwait()", replaceWith = ReplaceWith("commit().coAwait()"))
 suspend fun SQLConnection.commitAwait(): Unit {
   return awaitResult {
     this.commit(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -239,7 +239,7 @@ suspend fun SQLConnection.commitAwait(): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use rollback returning a future and chain with await()", replaceWith = ReplaceWith("rollback().await()"))
+@Deprecated(message = "Instead use rollback returning a future and chain with coAwait()", replaceWith = ReplaceWith("rollback().coAwait()"))
 suspend fun SQLConnection.rollbackAwait(): Unit {
   return awaitResult {
     this.rollback(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -254,7 +254,7 @@ suspend fun SQLConnection.rollbackAwait(): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use batch returning a future and chain with await()", replaceWith = ReplaceWith("batch(sqlStatements).await()"))
+@Deprecated(message = "Instead use batch returning a future and chain with coAwait()", replaceWith = ReplaceWith("batch(sqlStatements).coAwait()"))
 suspend fun SQLConnection.batchAwait(sqlStatements: List<String>): List<Int> {
   return awaitResult {
     this.batch(sqlStatements, it)
@@ -270,7 +270,7 @@ suspend fun SQLConnection.batchAwait(sqlStatements: List<String>): List<Int> {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use batchWithParams returning a future and chain with await()", replaceWith = ReplaceWith("batchWithParams(sqlStatement, args).await()"))
+@Deprecated(message = "Instead use batchWithParams returning a future and chain with coAwait()", replaceWith = ReplaceWith("batchWithParams(sqlStatement, args).coAwait()"))
 suspend fun SQLConnection.batchWithParamsAwait(sqlStatement: String, args: List<JsonArray>): List<Int> {
   return awaitResult {
     this.batchWithParams(sqlStatement, args, it)
@@ -287,7 +287,7 @@ suspend fun SQLConnection.batchWithParamsAwait(sqlStatement: String, args: List<
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use batchCallableWithParams returning a future and chain with await()", replaceWith = ReplaceWith("batchCallableWithParams(sqlStatement, inArgs, outArgs).await()"))
+@Deprecated(message = "Instead use batchCallableWithParams returning a future and chain with coAwait()", replaceWith = ReplaceWith("batchCallableWithParams(sqlStatement, inArgs, outArgs).coAwait()"))
 suspend fun SQLConnection.batchCallableWithParamsAwait(sqlStatement: String, inArgs: List<JsonArray>, outArgs: List<JsonArray>): List<Int> {
   return awaitResult {
     this.batchCallableWithParams(sqlStatement, inArgs, outArgs, it)
@@ -301,7 +301,7 @@ suspend fun SQLConnection.batchCallableWithParamsAwait(sqlStatement: String, inA
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use setTransactionIsolation returning a future and chain with await()", replaceWith = ReplaceWith("setTransactionIsolation(isolation).await()"))
+@Deprecated(message = "Instead use setTransactionIsolation returning a future and chain with coAwait()", replaceWith = ReplaceWith("setTransactionIsolation(isolation).coAwait()"))
 suspend fun SQLConnection.setTransactionIsolationAwait(isolation: TransactionIsolation): Unit {
   return awaitResult {
     this.setTransactionIsolation(isolation, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -315,7 +315,7 @@ suspend fun SQLConnection.setTransactionIsolationAwait(isolation: TransactionIso
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use getTransactionIsolation returning a future and chain with await()", replaceWith = ReplaceWith("getTransactionIsolation().await()"))
+@Deprecated(message = "Instead use getTransactionIsolation returning a future and chain with coAwait()", replaceWith = ReplaceWith("getTransactionIsolation().coAwait()"))
 suspend fun SQLConnection.getTransactionIsolationAwait(): TransactionIsolation {
   return awaitResult {
     this.getTransactionIsolation(it)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/sql/SQLOperations.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/sql/SQLOperations.kt
@@ -30,7 +30,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLOperations] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use query returning a future and chain with await()", replaceWith = ReplaceWith("query(sql).await()"))
+@Deprecated(message = "Instead use query returning a future and chain with coAwait()", replaceWith = ReplaceWith("query(sql).coAwait()"))
 suspend fun SQLOperations.queryAwait(sql: String): ResultSet {
   return awaitResult {
     this.query(sql, it)
@@ -46,7 +46,7 @@ suspend fun SQLOperations.queryAwait(sql: String): ResultSet {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLOperations] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use queryWithParams returning a future and chain with await()", replaceWith = ReplaceWith("queryWithParams(sql, params).await()"))
+@Deprecated(message = "Instead use queryWithParams returning a future and chain with coAwait()", replaceWith = ReplaceWith("queryWithParams(sql, params).coAwait()"))
 suspend fun SQLOperations.queryWithParamsAwait(sql: String, params: JsonArray): ResultSet {
   return awaitResult {
     this.queryWithParams(sql, params, it)
@@ -61,7 +61,7 @@ suspend fun SQLOperations.queryWithParamsAwait(sql: String, params: JsonArray): 
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLOperations] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use queryStream returning a future and chain with await()", replaceWith = ReplaceWith("queryStream(sql).await()"))
+@Deprecated(message = "Instead use queryStream returning a future and chain with coAwait()", replaceWith = ReplaceWith("queryStream(sql).coAwait()"))
 suspend fun SQLOperations.queryStreamAwait(sql: String): SQLRowStream {
   return awaitResult {
     this.queryStream(sql, it)
@@ -77,7 +77,7 @@ suspend fun SQLOperations.queryStreamAwait(sql: String): SQLRowStream {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLOperations] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use queryStreamWithParams returning a future and chain with await()", replaceWith = ReplaceWith("queryStreamWithParams(sql, params).await()"))
+@Deprecated(message = "Instead use queryStreamWithParams returning a future and chain with coAwait()", replaceWith = ReplaceWith("queryStreamWithParams(sql, params).coAwait()"))
 suspend fun SQLOperations.queryStreamWithParamsAwait(sql: String, params: JsonArray): SQLRowStream {
   return awaitResult {
     this.queryStreamWithParams(sql, params, it)
@@ -92,7 +92,7 @@ suspend fun SQLOperations.queryStreamWithParamsAwait(sql: String, params: JsonAr
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLOperations] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use querySingle returning a future and chain with await()", replaceWith = ReplaceWith("querySingle(sql).await()"))
+@Deprecated(message = "Instead use querySingle returning a future and chain with coAwait()", replaceWith = ReplaceWith("querySingle(sql).coAwait()"))
 suspend fun SQLOperations.querySingleAwait(sql: String): JsonArray? {
   return awaitResult {
     this.querySingle(sql, it)
@@ -108,7 +108,7 @@ suspend fun SQLOperations.querySingleAwait(sql: String): JsonArray? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLOperations] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use querySingleWithParams returning a future and chain with await()", replaceWith = ReplaceWith("querySingleWithParams(sql, arguments).await()"))
+@Deprecated(message = "Instead use querySingleWithParams returning a future and chain with coAwait()", replaceWith = ReplaceWith("querySingleWithParams(sql, arguments).coAwait()"))
 suspend fun SQLOperations.querySingleWithParamsAwait(sql: String, arguments: JsonArray): JsonArray? {
   return awaitResult {
     this.querySingleWithParams(sql, arguments, it)
@@ -123,7 +123,7 @@ suspend fun SQLOperations.querySingleWithParamsAwait(sql: String, arguments: Jso
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLOperations] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use update returning a future and chain with await()", replaceWith = ReplaceWith("update(sql).await()"))
+@Deprecated(message = "Instead use update returning a future and chain with coAwait()", replaceWith = ReplaceWith("update(sql).coAwait()"))
 suspend fun SQLOperations.updateAwait(sql: String): UpdateResult {
   return awaitResult {
     this.update(sql, it)
@@ -139,7 +139,7 @@ suspend fun SQLOperations.updateAwait(sql: String): UpdateResult {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLOperations] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use updateWithParams returning a future and chain with await()", replaceWith = ReplaceWith("updateWithParams(sql, params).await()"))
+@Deprecated(message = "Instead use updateWithParams returning a future and chain with coAwait()", replaceWith = ReplaceWith("updateWithParams(sql, params).coAwait()"))
 suspend fun SQLOperations.updateWithParamsAwait(sql: String, params: JsonArray): UpdateResult {
   return awaitResult {
     this.updateWithParams(sql, params, it)
@@ -154,7 +154,7 @@ suspend fun SQLOperations.updateWithParamsAwait(sql: String, params: JsonArray):
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLOperations] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use call returning a future and chain with await()", replaceWith = ReplaceWith("call(sql).await()"))
+@Deprecated(message = "Instead use call returning a future and chain with coAwait()", replaceWith = ReplaceWith("call(sql).coAwait()"))
 suspend fun SQLOperations.callAwait(sql: String): ResultSet {
   return awaitResult {
     this.call(sql, it)
@@ -171,7 +171,7 @@ suspend fun SQLOperations.callAwait(sql: String): ResultSet {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLOperations] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use callWithParams returning a future and chain with await()", replaceWith = ReplaceWith("callWithParams(sql, params, outputs).await()"))
+@Deprecated(message = "Instead use callWithParams returning a future and chain with coAwait()", replaceWith = ReplaceWith("callWithParams(sql, params, outputs).coAwait()"))
 suspend fun SQLOperations.callWithParamsAwait(sql: String, params: JsonArray, outputs: JsonArray): ResultSet {
   return awaitResult {
     this.callWithParams(sql, params, outputs, it)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/sql/SQLRowStream.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/sql/SQLRowStream.kt
@@ -27,7 +27,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLRowStream] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use pipeTo returning a future and chain with await()", replaceWith = ReplaceWith("pipeTo(dst).await()"))
+@Deprecated(message = "Instead use pipeTo returning a future and chain with coAwait()", replaceWith = ReplaceWith("pipeTo(dst).coAwait()"))
 suspend fun SQLRowStream.pipeToAwait(dst: WriteStream<JsonArray>): Unit {
   return awaitResult {
     this.pipeTo(dst, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -40,7 +40,7 @@ suspend fun SQLRowStream.pipeToAwait(dst: WriteStream<JsonArray>): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.sql.SQLRowStream] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use close returning a future and chain with await()", replaceWith = ReplaceWith("close().await()"))
+@Deprecated(message = "Instead use close returning a future and chain with coAwait()", replaceWith = ReplaceWith("close().coAwait()"))
 suspend fun SQLRowStream.closeAwait(): Unit {
   return awaitResult {
     this.close(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/stomp/StompClient.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/stomp/StompClient.kt
@@ -29,7 +29,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.stomp.StompClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use connect returning a future and chain with await()", replaceWith = ReplaceWith("connect(port, host).await()"))
+@Deprecated(message = "Instead use connect returning a future and chain with coAwait()", replaceWith = ReplaceWith("connect(port, host).coAwait()"))
 suspend fun StompClient.connectAwait(port: Int, host: String): StompClientConnection {
   return awaitResult {
     this.connect(port, host, it)
@@ -44,7 +44,7 @@ suspend fun StompClient.connectAwait(port: Int, host: String): StompClientConnec
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.stomp.StompClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use connect returning a future and chain with await()", replaceWith = ReplaceWith("connect(net).await()"))
+@Deprecated(message = "Instead use connect returning a future and chain with coAwait()", replaceWith = ReplaceWith("connect(net).coAwait()"))
 suspend fun StompClient.connectAwait(net: NetClient): StompClientConnection {
   return awaitResult {
     this.connect(net, it)
@@ -61,7 +61,7 @@ suspend fun StompClient.connectAwait(net: NetClient): StompClientConnection {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.stomp.StompClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use connect returning a future and chain with await()", replaceWith = ReplaceWith("connect(port, host, net).await()"))
+@Deprecated(message = "Instead use connect returning a future and chain with coAwait()", replaceWith = ReplaceWith("connect(port, host, net).coAwait()"))
 suspend fun StompClient.connectAwait(port: Int, host: String, net: NetClient): StompClientConnection {
   return awaitResult {
     this.connect(port, host, net, it)
@@ -75,7 +75,7 @@ suspend fun StompClient.connectAwait(port: Int, host: String, net: NetClient): S
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.stomp.StompClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use connect returning a future and chain with await()", replaceWith = ReplaceWith("connect().await()"))
+@Deprecated(message = "Instead use connect returning a future and chain with coAwait()", replaceWith = ReplaceWith("connect().coAwait()"))
 suspend fun StompClient.connectAwait(): StompClientConnection {
   return awaitResult {
     this.connect(it)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/stomp/StompClientConnection.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/stomp/StompClientConnection.kt
@@ -29,7 +29,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.stomp.StompClientConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use send returning a future and chain with await()", replaceWith = ReplaceWith("send(headers, body).await()"))
+@Deprecated(message = "Instead use send returning a future and chain with coAwait()", replaceWith = ReplaceWith("send(headers, body).coAwait()"))
 suspend fun StompClientConnection.sendAwait(headers: Map<String,String>, body: Buffer): Frame {
   return awaitResult {
     this.send(headers, body, it)
@@ -45,7 +45,7 @@ suspend fun StompClientConnection.sendAwait(headers: Map<String,String>, body: B
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.stomp.StompClientConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use send returning a future and chain with await()", replaceWith = ReplaceWith("send(destination, body).await()"))
+@Deprecated(message = "Instead use send returning a future and chain with coAwait()", replaceWith = ReplaceWith("send(destination, body).coAwait()"))
 suspend fun StompClientConnection.sendAwait(destination: String, body: Buffer): Frame {
   return awaitResult {
     this.send(destination, body, it)
@@ -60,7 +60,7 @@ suspend fun StompClientConnection.sendAwait(destination: String, body: Buffer): 
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.stomp.StompClientConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use send returning a future and chain with await()", replaceWith = ReplaceWith("send(frame).await()"))
+@Deprecated(message = "Instead use send returning a future and chain with coAwait()", replaceWith = ReplaceWith("send(frame).coAwait()"))
 suspend fun StompClientConnection.sendAwait(frame: Frame): Frame {
   return awaitResult {
     this.send(frame, it)
@@ -77,7 +77,7 @@ suspend fun StompClientConnection.sendAwait(frame: Frame): Frame {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.stomp.StompClientConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use send returning a future and chain with await()", replaceWith = ReplaceWith("send(destination, headers, body).await()"))
+@Deprecated(message = "Instead use send returning a future and chain with coAwait()", replaceWith = ReplaceWith("send(destination, headers, body).coAwait()"))
 suspend fun StompClientConnection.sendAwait(destination: String, headers: Map<String,String>, body: Buffer): Frame {
   return awaitResult {
     this.send(destination, headers, body, it)
@@ -93,7 +93,7 @@ suspend fun StompClientConnection.sendAwait(destination: String, headers: Map<St
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.stomp.StompClientConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use subscribe returning a future and chain with await()", replaceWith = ReplaceWith("subscribe(destination, handler).await()"))
+@Deprecated(message = "Instead use subscribe returning a future and chain with coAwait()", replaceWith = ReplaceWith("subscribe(destination, handler).coAwait()"))
 suspend fun StompClientConnection.subscribeAwait(destination: String, handler: (Frame) -> Unit): String {
   return awaitResult {
     this.subscribe(destination, handler, it::handle)
@@ -110,7 +110,7 @@ suspend fun StompClientConnection.subscribeAwait(destination: String, handler: (
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.stomp.StompClientConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use subscribe returning a future and chain with await()", replaceWith = ReplaceWith("subscribe(destination, headers, handler).await()"))
+@Deprecated(message = "Instead use subscribe returning a future and chain with coAwait()", replaceWith = ReplaceWith("subscribe(destination, headers, handler).coAwait()"))
 suspend fun StompClientConnection.subscribeAwait(destination: String, headers: Map<String,String>, handler: (Frame) -> Unit): String {
   return awaitResult {
     this.subscribe(destination, headers, handler, it::handle)
@@ -125,7 +125,7 @@ suspend fun StompClientConnection.subscribeAwait(destination: String, headers: M
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.stomp.StompClientConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use unsubscribe returning a future and chain with await()", replaceWith = ReplaceWith("unsubscribe(destination).await()"))
+@Deprecated(message = "Instead use unsubscribe returning a future and chain with coAwait()", replaceWith = ReplaceWith("unsubscribe(destination).coAwait()"))
 suspend fun StompClientConnection.unsubscribeAwait(destination: String): Frame {
   return awaitResult {
     this.unsubscribe(destination, it)
@@ -141,7 +141,7 @@ suspend fun StompClientConnection.unsubscribeAwait(destination: String): Frame {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.stomp.StompClientConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use unsubscribe returning a future and chain with await()", replaceWith = ReplaceWith("unsubscribe(destination, headers).await()"))
+@Deprecated(message = "Instead use unsubscribe returning a future and chain with coAwait()", replaceWith = ReplaceWith("unsubscribe(destination, headers).coAwait()"))
 suspend fun StompClientConnection.unsubscribeAwait(destination: String, headers: Map<String,String>): Frame {
   return awaitResult {
     this.unsubscribe(destination, headers, it)
@@ -156,7 +156,7 @@ suspend fun StompClientConnection.unsubscribeAwait(destination: String, headers:
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.stomp.StompClientConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use beginTX returning a future and chain with await()", replaceWith = ReplaceWith("beginTX(id).await()"))
+@Deprecated(message = "Instead use beginTX returning a future and chain with coAwait()", replaceWith = ReplaceWith("beginTX(id).coAwait()"))
 suspend fun StompClientConnection.beginTXAwait(id: String): Frame {
   return awaitResult {
     this.beginTX(id, it)
@@ -172,7 +172,7 @@ suspend fun StompClientConnection.beginTXAwait(id: String): Frame {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.stomp.StompClientConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use beginTX returning a future and chain with await()", replaceWith = ReplaceWith("beginTX(id, headers).await()"))
+@Deprecated(message = "Instead use beginTX returning a future and chain with coAwait()", replaceWith = ReplaceWith("beginTX(id, headers).coAwait()"))
 suspend fun StompClientConnection.beginTXAwait(id: String, headers: Map<String,String>): Frame {
   return awaitResult {
     this.beginTX(id, headers, it)
@@ -187,7 +187,7 @@ suspend fun StompClientConnection.beginTXAwait(id: String, headers: Map<String,S
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.stomp.StompClientConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use commit returning a future and chain with await()", replaceWith = ReplaceWith("commit(id).await()"))
+@Deprecated(message = "Instead use commit returning a future and chain with coAwait()", replaceWith = ReplaceWith("commit(id).coAwait()"))
 suspend fun StompClientConnection.commitAwait(id: String): Frame {
   return awaitResult {
     this.commit(id, it)
@@ -203,7 +203,7 @@ suspend fun StompClientConnection.commitAwait(id: String): Frame {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.stomp.StompClientConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use commit returning a future and chain with await()", replaceWith = ReplaceWith("commit(id, headers).await()"))
+@Deprecated(message = "Instead use commit returning a future and chain with coAwait()", replaceWith = ReplaceWith("commit(id, headers).coAwait()"))
 suspend fun StompClientConnection.commitAwait(id: String, headers: Map<String,String>): Frame {
   return awaitResult {
     this.commit(id, headers, it)
@@ -218,7 +218,7 @@ suspend fun StompClientConnection.commitAwait(id: String, headers: Map<String,St
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.stomp.StompClientConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use abort returning a future and chain with await()", replaceWith = ReplaceWith("abort(id).await()"))
+@Deprecated(message = "Instead use abort returning a future and chain with coAwait()", replaceWith = ReplaceWith("abort(id).coAwait()"))
 suspend fun StompClientConnection.abortAwait(id: String): Frame {
   return awaitResult {
     this.abort(id, it)
@@ -234,7 +234,7 @@ suspend fun StompClientConnection.abortAwait(id: String): Frame {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.stomp.StompClientConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use abort returning a future and chain with await()", replaceWith = ReplaceWith("abort(id, headers).await()"))
+@Deprecated(message = "Instead use abort returning a future and chain with coAwait()", replaceWith = ReplaceWith("abort(id, headers).coAwait()"))
 suspend fun StompClientConnection.abortAwait(id: String, headers: Map<String,String>): Frame {
   return awaitResult {
     this.abort(id, headers, it)
@@ -248,7 +248,7 @@ suspend fun StompClientConnection.abortAwait(id: String, headers: Map<String,Str
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.stomp.StompClientConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use disconnect returning a future and chain with await()", replaceWith = ReplaceWith("disconnect().await()"))
+@Deprecated(message = "Instead use disconnect returning a future and chain with coAwait()", replaceWith = ReplaceWith("disconnect().coAwait()"))
 suspend fun StompClientConnection.disconnectAwait(): Frame {
   return awaitResult {
     this.disconnect(it)
@@ -263,7 +263,7 @@ suspend fun StompClientConnection.disconnectAwait(): Frame {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.stomp.StompClientConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use disconnect returning a future and chain with await()", replaceWith = ReplaceWith("disconnect(frame).await()"))
+@Deprecated(message = "Instead use disconnect returning a future and chain with coAwait()", replaceWith = ReplaceWith("disconnect(frame).coAwait()"))
 suspend fun StompClientConnection.disconnectAwait(frame: Frame): Frame {
   return awaitResult {
     this.disconnect(frame, it)
@@ -278,7 +278,7 @@ suspend fun StompClientConnection.disconnectAwait(frame: Frame): Frame {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.stomp.StompClientConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use ack returning a future and chain with await()", replaceWith = ReplaceWith("ack(id).await()"))
+@Deprecated(message = "Instead use ack returning a future and chain with coAwait()", replaceWith = ReplaceWith("ack(id).coAwait()"))
 suspend fun StompClientConnection.ackAwait(id: String): Frame {
   return awaitResult {
     this.ack(id, it)
@@ -293,7 +293,7 @@ suspend fun StompClientConnection.ackAwait(id: String): Frame {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.stomp.StompClientConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use nack returning a future and chain with await()", replaceWith = ReplaceWith("nack(id).await()"))
+@Deprecated(message = "Instead use nack returning a future and chain with coAwait()", replaceWith = ReplaceWith("nack(id).coAwait()"))
 suspend fun StompClientConnection.nackAwait(id: String): Frame {
   return awaitResult {
     this.nack(id, it)
@@ -309,7 +309,7 @@ suspend fun StompClientConnection.nackAwait(id: String): Frame {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.stomp.StompClientConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use ack returning a future and chain with await()", replaceWith = ReplaceWith("ack(id, txId).await()"))
+@Deprecated(message = "Instead use ack returning a future and chain with coAwait()", replaceWith = ReplaceWith("ack(id, txId).coAwait()"))
 suspend fun StompClientConnection.ackAwait(id: String, txId: String): Frame {
   return awaitResult {
     this.ack(id, txId, it)
@@ -325,7 +325,7 @@ suspend fun StompClientConnection.ackAwait(id: String, txId: String): Frame {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.stomp.StompClientConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use nack returning a future and chain with await()", replaceWith = ReplaceWith("nack(id, txId).await()"))
+@Deprecated(message = "Instead use nack returning a future and chain with coAwait()", replaceWith = ReplaceWith("nack(id, txId).coAwait()"))
 suspend fun StompClientConnection.nackAwait(id: String, txId: String): Frame {
   return awaitResult {
     this.nack(id, txId, it)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/stomp/StompServer.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/stomp/StompServer.kt
@@ -25,7 +25,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.stomp.StompServer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use listen returning a future and chain with await()", replaceWith = ReplaceWith("listen().await()"))
+@Deprecated(message = "Instead use listen returning a future and chain with coAwait()", replaceWith = ReplaceWith("listen().coAwait()"))
 suspend fun StompServer.listenAwait(): StompServer {
   return awaitResult {
     this.listen(it)
@@ -40,7 +40,7 @@ suspend fun StompServer.listenAwait(): StompServer {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.stomp.StompServer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use listen returning a future and chain with await()", replaceWith = ReplaceWith("listen(port).await()"))
+@Deprecated(message = "Instead use listen returning a future and chain with coAwait()", replaceWith = ReplaceWith("listen(port).coAwait()"))
 suspend fun StompServer.listenAwait(port: Int): StompServer {
   return awaitResult {
     this.listen(port, it)
@@ -56,7 +56,7 @@ suspend fun StompServer.listenAwait(port: Int): StompServer {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.stomp.StompServer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use listen returning a future and chain with await()", replaceWith = ReplaceWith("listen(port, host).await()"))
+@Deprecated(message = "Instead use listen returning a future and chain with coAwait()", replaceWith = ReplaceWith("listen(port, host).coAwait()"))
 suspend fun StompServer.listenAwait(port: Int, host: String): StompServer {
   return awaitResult {
     this.listen(port, host, it)
@@ -69,7 +69,7 @@ suspend fun StompServer.listenAwait(port: Int, host: String): StompServer {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.stomp.StompServer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use close returning a future and chain with await()", replaceWith = ReplaceWith("close().await()"))
+@Deprecated(message = "Instead use close returning a future and chain with coAwait()", replaceWith = ReplaceWith("close().coAwait()"))
 suspend fun StompServer.closeAwait(): Unit {
   return awaitResult {
     this.close(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/stomp/StompServerHandler.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/stomp/StompServerHandler.kt
@@ -29,7 +29,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.stomp.StompServerHandler] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use onAuthenticationRequest returning a future and chain with await()", replaceWith = ReplaceWith("onAuthenticationRequest(connection, login, passcode).await()"))
+@Deprecated(message = "Instead use onAuthenticationRequest returning a future and chain with coAwait()", replaceWith = ReplaceWith("onAuthenticationRequest(connection, login, passcode).coAwait()"))
 suspend fun StompServerHandler.onAuthenticationRequestAwait(connection: StompServerConnection, login: String, passcode: String): Boolean {
   return awaitResult {
     this.onAuthenticationRequest(connection, login, passcode, it)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/unit/Async.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/unit/Async.kt
@@ -25,7 +25,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.unit.Async] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use handler returning a future and chain with await()", replaceWith = ReplaceWith("handler().await()"))
+@Deprecated(message = "Instead use handler returning a future and chain with coAwait()", replaceWith = ReplaceWith("handler().coAwait()"))
 suspend fun Async.handlerAwait(): Unit? {
   return awaitResult {
     this.handler(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/unit/Completion.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/unit/Completion.kt
@@ -25,7 +25,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.unit.Completion] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use handler returning a future and chain with await()", replaceWith = ReplaceWith("handler().await()"))
+@Deprecated(message = "Instead use handler returning a future and chain with coAwait()", replaceWith = ReplaceWith("handler().coAwait()"))
 suspend fun <T> Completion<T>.handlerAwait(): T? {
   return awaitResult {
     this.handler(it)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/unit/TestCompletion.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/unit/TestCompletion.kt
@@ -25,7 +25,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.unit.TestCompletion] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use handler returning a future and chain with await()", replaceWith = ReplaceWith("handler().await()"))
+@Deprecated(message = "Instead use handler returning a future and chain with coAwait()", replaceWith = ReplaceWith("handler().coAwait()"))
 suspend fun TestCompletion.handlerAwait(): Unit? {
   return awaitResult {
     this.handler(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/unit/report/TestSuiteReport.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/unit/report/TestSuiteReport.kt
@@ -27,7 +27,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.unit.report.TestSuiteReport] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use pipeTo returning a future and chain with await()", replaceWith = ReplaceWith("pipeTo(dst).await()"))
+@Deprecated(message = "Instead use pipeTo returning a future and chain with coAwait()", replaceWith = ReplaceWith("pipeTo(dst).coAwait()"))
 suspend fun TestSuiteReport.pipeToAwait(dst: WriteStream<TestCaseReport>): Unit {
   return awaitResult {
     this.pipeTo(dst, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/web/RoutingContext.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/web/RoutingContext.kt
@@ -26,7 +26,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.web.RoutingContext] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use redirect returning a future and chain with await()", replaceWith = ReplaceWith("redirect(url).await()"))
+@Deprecated(message = "Instead use redirect returning a future and chain with coAwait()", replaceWith = ReplaceWith("redirect(url).coAwait()"))
 suspend fun RoutingContext.redirectAwait(url: String): Unit {
   return awaitResult {
     this.redirect(url, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -40,7 +40,7 @@ suspend fun RoutingContext.redirectAwait(url: String): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.web.RoutingContext] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use json returning a future and chain with await()", replaceWith = ReplaceWith("json(json).await()"))
+@Deprecated(message = "Instead use json returning a future and chain with coAwait()", replaceWith = ReplaceWith("json(json).coAwait()"))
 suspend fun RoutingContext.jsonAwait(json: Any): Unit {
   return awaitResult {
     this.json(json, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -54,7 +54,7 @@ suspend fun RoutingContext.jsonAwait(json: Any): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.web.RoutingContext] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use end returning a future and chain with await()", replaceWith = ReplaceWith("end(chunk).await()"))
+@Deprecated(message = "Instead use end returning a future and chain with coAwait()", replaceWith = ReplaceWith("end(chunk).coAwait()"))
 suspend fun RoutingContext.endAwait(chunk: String): Unit {
   return awaitResult {
     this.end(chunk, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -68,7 +68,7 @@ suspend fun RoutingContext.endAwait(chunk: String): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.web.RoutingContext] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use end returning a future and chain with await()", replaceWith = ReplaceWith("end(buffer).await()"))
+@Deprecated(message = "Instead use end returning a future and chain with coAwait()", replaceWith = ReplaceWith("end(buffer).coAwait()"))
 suspend fun RoutingContext.endAwait(buffer: Buffer): Unit {
   return awaitResult {
     this.end(buffer, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -81,7 +81,7 @@ suspend fun RoutingContext.endAwait(buffer: Buffer): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.web.RoutingContext] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use end returning a future and chain with await()", replaceWith = ReplaceWith("end().await()"))
+@Deprecated(message = "Instead use end returning a future and chain with coAwait()", replaceWith = ReplaceWith("end().coAwait()"))
 suspend fun RoutingContext.endAwait(): Unit {
   return awaitResult {
     this.end(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/web/client/HttpRequest.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/web/client/HttpRequest.kt
@@ -32,7 +32,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.web.client.HttpRequest] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use sendStream returning a future and chain with await()", replaceWith = ReplaceWith("sendStream(body).await()"))
+@Deprecated(message = "Instead use sendStream returning a future and chain with coAwait()", replaceWith = ReplaceWith("sendStream(body).coAwait()"))
 suspend fun <T> HttpRequest<T>.sendStreamAwait(body: ReadStream<Buffer>): HttpResponse<T> {
   return awaitResult {
     this.sendStream(body, it)
@@ -47,7 +47,7 @@ suspend fun <T> HttpRequest<T>.sendStreamAwait(body: ReadStream<Buffer>): HttpRe
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.web.client.HttpRequest] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use sendBuffer returning a future and chain with await()", replaceWith = ReplaceWith("sendBuffer(body).await()"))
+@Deprecated(message = "Instead use sendBuffer returning a future and chain with coAwait()", replaceWith = ReplaceWith("sendBuffer(body).coAwait()"))
 suspend fun <T> HttpRequest<T>.sendBufferAwait(body: Buffer): HttpResponse<T> {
   return awaitResult {
     this.sendBuffer(body, it)
@@ -62,7 +62,7 @@ suspend fun <T> HttpRequest<T>.sendBufferAwait(body: Buffer): HttpResponse<T> {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.web.client.HttpRequest] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use sendJsonObject returning a future and chain with await()", replaceWith = ReplaceWith("sendJsonObject(body).await()"))
+@Deprecated(message = "Instead use sendJsonObject returning a future and chain with coAwait()", replaceWith = ReplaceWith("sendJsonObject(body).coAwait()"))
 suspend fun <T> HttpRequest<T>.sendJsonObjectAwait(body: JsonObject): HttpResponse<T> {
   return awaitResult {
     this.sendJsonObject(body, it)
@@ -77,7 +77,7 @@ suspend fun <T> HttpRequest<T>.sendJsonObjectAwait(body: JsonObject): HttpRespon
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.web.client.HttpRequest] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use sendJson returning a future and chain with await()", replaceWith = ReplaceWith("sendJson(body).await()"))
+@Deprecated(message = "Instead use sendJson returning a future and chain with coAwait()", replaceWith = ReplaceWith("sendJson(body).coAwait()"))
 suspend fun <T> HttpRequest<T>.sendJsonAwait(body: Any?): HttpResponse<T> {
   return awaitResult {
     this.sendJson(body, it)
@@ -92,7 +92,7 @@ suspend fun <T> HttpRequest<T>.sendJsonAwait(body: Any?): HttpResponse<T> {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.web.client.HttpRequest] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use sendForm returning a future and chain with await()", replaceWith = ReplaceWith("sendForm(body).await()"))
+@Deprecated(message = "Instead use sendForm returning a future and chain with coAwait()", replaceWith = ReplaceWith("sendForm(body).coAwait()"))
 suspend fun <T> HttpRequest<T>.sendFormAwait(body: MultiMap): HttpResponse<T> {
   return awaitResult {
     this.sendForm(body, it)
@@ -108,7 +108,7 @@ suspend fun <T> HttpRequest<T>.sendFormAwait(body: MultiMap): HttpResponse<T> {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.web.client.HttpRequest] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use sendForm returning a future and chain with await()", replaceWith = ReplaceWith("sendForm(body, charset).await()"))
+@Deprecated(message = "Instead use sendForm returning a future and chain with coAwait()", replaceWith = ReplaceWith("sendForm(body, charset).coAwait()"))
 suspend fun <T> HttpRequest<T>.sendFormAwait(body: MultiMap, charset: String): HttpResponse<T> {
   return awaitResult {
     this.sendForm(body, charset, it)
@@ -123,7 +123,7 @@ suspend fun <T> HttpRequest<T>.sendFormAwait(body: MultiMap, charset: String): H
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.web.client.HttpRequest] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use sendMultipartForm returning a future and chain with await()", replaceWith = ReplaceWith("sendMultipartForm(body).await()"))
+@Deprecated(message = "Instead use sendMultipartForm returning a future and chain with coAwait()", replaceWith = ReplaceWith("sendMultipartForm(body).coAwait()"))
 suspend fun <T> HttpRequest<T>.sendMultipartFormAwait(body: MultipartForm): HttpResponse<T> {
   return awaitResult {
     this.sendMultipartForm(body, it)
@@ -137,7 +137,7 @@ suspend fun <T> HttpRequest<T>.sendMultipartFormAwait(body: MultipartForm): Http
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.web.client.HttpRequest] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use send returning a future and chain with await()", replaceWith = ReplaceWith("send().await()"))
+@Deprecated(message = "Instead use send returning a future and chain with coAwait()", replaceWith = ReplaceWith("send().coAwait()"))
 suspend fun <T> HttpRequest<T>.sendAwait(): HttpResponse<T> {
   return awaitResult {
     this.send(it)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/web/client/WebClient.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/web/client/WebClient.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package io.vertx.kotlin.ext.web.client
+
+import io.vertx.core.net.SSLOptions
+import io.vertx.ext.web.client.WebClient
+import io.vertx.kotlin.coroutines.awaitResult
+
+/**
+ * Suspending version of method [io.vertx.ext.web.client.WebClient.updateSSLOptions]
+ *
+ * @param options the new SSL options
+ * @return [Boolean]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.web.client.WebClient] using Vert.x codegen.
+ */
+@Deprecated(message = "Instead use updateSSLOptions returning a future and chain with coAwait()", replaceWith = ReplaceWith("updateSSLOptions(options).coAwait()"))
+suspend fun WebClient.updateSSLOptionsAwait(options: SSLOptions): Boolean {
+  return awaitResult {
+    this.updateSSLOptions(options, it)
+  }
+}
+
+/**
+ * Suspending version of method [io.vertx.ext.web.client.WebClient.updateSSLOptions]
+ *
+ * @param options the new SSL options
+ * @param force force the update when options are equals
+ * @return [Boolean]
+ *
+ * NOTE: This function has been automatically generated from [io.vertx.ext.web.client.WebClient] using Vert.x codegen.
+ */
+@Deprecated(message = "Instead use updateSSLOptions returning a future and chain with coAwait()", replaceWith = ReplaceWith("updateSSLOptions(options, force).coAwait()"))
+suspend fun WebClient.updateSSLOptionsAwait(options: SSLOptions, force: Boolean): Boolean {
+  return awaitResult {
+    this.updateSSLOptions(options, force, it)
+  }
+}
+

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/web/common/template/TemplateEngine.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/web/common/template/TemplateEngine.kt
@@ -29,7 +29,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.web.common.template.TemplateEngine] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use render returning a future and chain with await()", replaceWith = ReplaceWith("render(context, templateFileName).await()"))
+@Deprecated(message = "Instead use render returning a future and chain with coAwait()", replaceWith = ReplaceWith("render(context, templateFileName).coAwait()"))
 suspend fun TemplateEngine.renderAwait(context: JsonObject, templateFileName: String): Buffer {
   return awaitResult {
     this.render(context, templateFileName, it)
@@ -45,7 +45,7 @@ suspend fun TemplateEngine.renderAwait(context: JsonObject, templateFileName: St
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.web.common.template.TemplateEngine] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use render returning a future and chain with await()", replaceWith = ReplaceWith("render(context, templateFileName).await()"))
+@Deprecated(message = "Instead use render returning a future and chain with coAwait()", replaceWith = ReplaceWith("render(context, templateFileName).coAwait()"))
 suspend fun TemplateEngine.renderAwait(context: Map<String,Any>, templateFileName: String): Buffer {
   return awaitResult {
     this.render(context, templateFileName, it)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/web/handler/SessionHandler.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/web/handler/SessionHandler.kt
@@ -27,7 +27,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.web.handler.SessionHandler] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use flush returning a future and chain with await()", replaceWith = ReplaceWith("flush(ctx).await()"))
+@Deprecated(message = "Instead use flush returning a future and chain with coAwait()", replaceWith = ReplaceWith("flush(ctx).coAwait()"))
 suspend fun SessionHandler.flushAwait(ctx: RoutingContext): Unit {
   return awaitResult {
     this.flush(ctx, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -42,7 +42,7 @@ suspend fun SessionHandler.flushAwait(ctx: RoutingContext): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.web.handler.SessionHandler] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use flush returning a future and chain with await()", replaceWith = ReplaceWith("flush(ctx, ignoreStatus).await()"))
+@Deprecated(message = "Instead use flush returning a future and chain with coAwait()", replaceWith = ReplaceWith("flush(ctx, ignoreStatus).coAwait()"))
 suspend fun SessionHandler.flushAwait(ctx: RoutingContext, ignoreStatus: Boolean): Unit {
   return awaitResult {
     this.flush(ctx, ignoreStatus, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -57,7 +57,7 @@ suspend fun SessionHandler.flushAwait(ctx: RoutingContext, ignoreStatus: Boolean
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.web.handler.SessionHandler] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use setUser returning a future and chain with await()", replaceWith = ReplaceWith("setUser(context, user).await()"))
+@Deprecated(message = "Instead use setUser returning a future and chain with coAwait()", replaceWith = ReplaceWith("setUser(context, user).coAwait()"))
 suspend fun SessionHandler.setUserAwait(context: RoutingContext, user: User): Unit {
   return awaitResult {
     this.setUser(context, user, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/web/handler/sockjs/SockJSSocket.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/web/handler/sockjs/SockJSSocket.kt
@@ -26,7 +26,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.web.handler.sockjs.SockJSSocket] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use end returning a future and chain with await()", replaceWith = ReplaceWith("end().await()"))
+@Deprecated(message = "Instead use end returning a future and chain with coAwait()", replaceWith = ReplaceWith("end().coAwait()"))
 suspend fun SockJSSocket.endAwait(): Unit {
   return awaitResult {
     this.end(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -40,7 +40,7 @@ suspend fun SockJSSocket.endAwait(): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.web.handler.sockjs.SockJSSocket] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use end returning a future and chain with await()", replaceWith = ReplaceWith("end(data).await()"))
+@Deprecated(message = "Instead use end returning a future and chain with coAwait()", replaceWith = ReplaceWith("end(data).coAwait()"))
 suspend fun SockJSSocket.endAwait(data: Buffer): Unit {
   return awaitResult {
     this.end(data, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -54,21 +54,21 @@ suspend fun SockJSSocket.endAwait(data: Buffer): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.web.handler.sockjs.SockJSSocket] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use pipeTo returning a future and chain with await()", replaceWith = ReplaceWith("pipeTo(dst).await()"))
+@Deprecated(message = "Instead use pipeTo returning a future and chain with coAwait()", replaceWith = ReplaceWith("pipeTo(dst).coAwait()"))
 suspend fun SockJSSocket.pipeToAwait(dst: WriteStream<Buffer>): Unit {
   return awaitResult {
     this.pipeTo(dst, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
   }
 }
 
-@Deprecated(message = "Instead use write returning a future and chain with await()", replaceWith = ReplaceWith("write(data).await()"))
+@Deprecated(message = "Instead use write returning a future and chain with coAwait()", replaceWith = ReplaceWith("write(data).coAwait()"))
 suspend fun SockJSSocket.writeAwait(data: String): Unit {
   return awaitResult {
     this.write(data, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
   }
 }
 
-@Deprecated(message = "Instead use write returning a future and chain with await()", replaceWith = ReplaceWith("write(data).await()"))
+@Deprecated(message = "Instead use write returning a future and chain with coAwait()", replaceWith = ReplaceWith("write(data).coAwait()"))
 suspend fun SockJSSocket.writeAwait(data: Buffer): Unit {
   return awaitResult {
     this.write(data, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/web/openapi/RouterBuilder.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/web/openapi/RouterBuilder.kt
@@ -30,7 +30,7 @@ object RouterBuilder {
    *
    * NOTE: This function has been automatically generated from [io.vertx.ext.web.openapi.RouterBuilder] using Vert.x codegen.
    */
-  @Deprecated(message = "Instead use create returning a future and chain with await()", replaceWith = ReplaceWith("create(vertx, url).await()"))
+  @Deprecated(message = "Instead use create returning a future and chain with coAwait()", replaceWith = ReplaceWith("create(vertx, url).coAwait()"))
   suspend fun createAwait(vertx: Vertx, url: String): RouterBuilderVertxAlias {
     return awaitResult {
       RouterBuilderVertxAlias.create(vertx, url, it)
@@ -47,7 +47,7 @@ object RouterBuilder {
    *
    * NOTE: This function has been automatically generated from [io.vertx.ext.web.openapi.RouterBuilder] using Vert.x codegen.
    */
-  @Deprecated(message = "Instead use create returning a future and chain with await()", replaceWith = ReplaceWith("create(vertx, url, options).await()"))
+  @Deprecated(message = "Instead use create returning a future and chain with coAwait()", replaceWith = ReplaceWith("create(vertx, url, options).coAwait()"))
   suspend fun createAwait(vertx: Vertx, url: String, options: OpenAPILoaderOptions): RouterBuilderVertxAlias {
     return awaitResult {
       RouterBuilderVertxAlias.create(vertx, url, options, it)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/web/sstore/SessionStore.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/ext/web/sstore/SessionStore.kt
@@ -27,7 +27,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.web.sstore.SessionStore] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use get returning a future and chain with await()", replaceWith = ReplaceWith("get(cookieValue).await()"))
+@Deprecated(message = "Instead use get returning a future and chain with coAwait()", replaceWith = ReplaceWith("get(cookieValue).coAwait()"))
 suspend fun SessionStore.getAwait(cookieValue: String): Session? {
   return awaitResult {
     this.get(cookieValue, it)
@@ -41,7 +41,7 @@ suspend fun SessionStore.getAwait(cookieValue: String): Session? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.web.sstore.SessionStore] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use delete returning a future and chain with await()", replaceWith = ReplaceWith("delete(id).await()"))
+@Deprecated(message = "Instead use delete returning a future and chain with coAwait()", replaceWith = ReplaceWith("delete(id).coAwait()"))
 suspend fun SessionStore.deleteAwait(id: String): Unit {
   return awaitResult {
     this.delete(id, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -55,7 +55,7 @@ suspend fun SessionStore.deleteAwait(id: String): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.web.sstore.SessionStore] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use put returning a future and chain with await()", replaceWith = ReplaceWith("put(session).await()"))
+@Deprecated(message = "Instead use put returning a future and chain with coAwait()", replaceWith = ReplaceWith("put(session).coAwait()"))
 suspend fun SessionStore.putAwait(session: Session): Unit {
   return awaitResult {
     this.put(session, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -68,7 +68,7 @@ suspend fun SessionStore.putAwait(session: Session): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.web.sstore.SessionStore] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use clear returning a future and chain with await()", replaceWith = ReplaceWith("clear().await()"))
+@Deprecated(message = "Instead use clear returning a future and chain with coAwait()", replaceWith = ReplaceWith("clear().coAwait()"))
 suspend fun SessionStore.clearAwait(): Unit {
   return awaitResult {
     this.clear(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -82,7 +82,7 @@ suspend fun SessionStore.clearAwait(): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.ext.web.sstore.SessionStore] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use size returning a future and chain with await()", replaceWith = ReplaceWith("size().await()"))
+@Deprecated(message = "Instead use size returning a future and chain with coAwait()", replaceWith = ReplaceWith("size().coAwait()"))
 suspend fun SessionStore.sizeAwait(): Int {
   return awaitResult {
     this.size(it)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/httpproxy/ProxyOptions.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/httpproxy/ProxyOptions.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package io.vertx.kotlin.httpproxy
+
+import io.vertx.httpproxy.ProxyOptions
+import io.vertx.httpproxy.cache.CacheOptions
+
+/**
+ * A function providing a DSL for building [io.vertx.httpproxy.ProxyOptions] objects.
+ *
+ * Proxy options.
+ *
+ * @param cacheOptions  Set the cache options that configures the proxy. <code>null</code> cache options disables caching, by default cache is disabled.
+ * @param supportWebSocket  Set whether WebSocket are supported.
+ *
+ * <p/>
+ * NOTE: This function has been automatically generated from the [io.vertx.httpproxy.ProxyOptions original] using Vert.x codegen.
+ */
+fun proxyOptionsOf(
+  cacheOptions: io.vertx.httpproxy.cache.CacheOptions? = null,
+  supportWebSocket: Boolean? = null): ProxyOptions = io.vertx.httpproxy.ProxyOptions().apply {
+
+  if (cacheOptions != null) {
+    this.setCacheOptions(cacheOptions)
+  }
+  if (supportWebSocket != null) {
+    this.setSupportWebSocket(supportWebSocket)
+  }
+}
+

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/httpproxy/cache/CacheOptions.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/httpproxy/cache/CacheOptions.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package io.vertx.kotlin.httpproxy.cache
+
+import io.vertx.httpproxy.cache.CacheOptions
+
+/**
+ * A function providing a DSL for building [io.vertx.httpproxy.cache.CacheOptions] objects.
+ *
+ * Cache options.
+ *
+ * @param maxSize  Set the max number of entries the cache can hold.
+ *
+ * <p/>
+ * NOTE: This function has been automatically generated from the [io.vertx.httpproxy.cache.CacheOptions original] using Vert.x codegen.
+ */
+fun cacheOptionsOf(
+  maxSize: Int? = null): CacheOptions = io.vertx.httpproxy.cache.CacheOptions().apply {
+
+  if (maxSize != null) {
+    this.setMaxSize(maxSize)
+  }
+}
+

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/kafka/admin/KafkaAdminClient.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/kafka/admin/KafkaAdminClient.kt
@@ -37,7 +37,7 @@ import org.apache.kafka.common.acl.AclBindingFilter
  *
  * NOTE: This function has been automatically generated from [io.vertx.kafka.admin.KafkaAdminClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use listTopics returning a future and chain with await()", replaceWith = ReplaceWith("listTopics().await()"))
+@Deprecated(message = "Instead use listTopics returning a future and chain with coAwait()", replaceWith = ReplaceWith("listTopics().coAwait()"))
 suspend fun KafkaAdminClient.listTopicsAwait(): Set<String> {
   return awaitResult {
     this.listTopics(it)
@@ -52,7 +52,7 @@ suspend fun KafkaAdminClient.listTopicsAwait(): Set<String> {
  *
  * NOTE: This function has been automatically generated from [io.vertx.kafka.admin.KafkaAdminClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use describeTopics returning a future and chain with await()", replaceWith = ReplaceWith("describeTopics(topicNames).await()"))
+@Deprecated(message = "Instead use describeTopics returning a future and chain with coAwait()", replaceWith = ReplaceWith("describeTopics(topicNames).coAwait()"))
 suspend fun KafkaAdminClient.describeTopicsAwait(topicNames: List<String>): Map<String,TopicDescription> {
   return awaitResult {
     this.describeTopics(topicNames, it)
@@ -68,7 +68,7 @@ suspend fun KafkaAdminClient.describeTopicsAwait(topicNames: List<String>): Map<
  *
  * NOTE: This function has been automatically generated from [io.vertx.kafka.admin.KafkaAdminClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use describeTopics returning a future and chain with await()", replaceWith = ReplaceWith("describeTopics(topicNames, options).await()"))
+@Deprecated(message = "Instead use describeTopics returning a future and chain with coAwait()", replaceWith = ReplaceWith("describeTopics(topicNames, options).coAwait()"))
 suspend fun KafkaAdminClient.describeTopicsAwait(topicNames: List<String>, options: DescribeTopicsOptions): Map<String,TopicDescription> {
   return awaitResult {
     this.describeTopics(topicNames, options, it)
@@ -82,7 +82,7 @@ suspend fun KafkaAdminClient.describeTopicsAwait(topicNames: List<String>, optio
  *
  * NOTE: This function has been automatically generated from [io.vertx.kafka.admin.KafkaAdminClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use createTopics returning a future and chain with await()", replaceWith = ReplaceWith("createTopics(topics).await()"))
+@Deprecated(message = "Instead use createTopics returning a future and chain with coAwait()", replaceWith = ReplaceWith("createTopics(topics).coAwait()"))
 suspend fun KafkaAdminClient.createTopicsAwait(topics: List<NewTopic>): Unit {
   return awaitResult {
     this.createTopics(topics, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -96,7 +96,7 @@ suspend fun KafkaAdminClient.createTopicsAwait(topics: List<NewTopic>): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.kafka.admin.KafkaAdminClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use deleteTopics returning a future and chain with await()", replaceWith = ReplaceWith("deleteTopics(topicNames).await()"))
+@Deprecated(message = "Instead use deleteTopics returning a future and chain with coAwait()", replaceWith = ReplaceWith("deleteTopics(topicNames).coAwait()"))
 suspend fun KafkaAdminClient.deleteTopicsAwait(topicNames: List<String>): Unit {
   return awaitResult {
     this.deleteTopics(topicNames, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -110,7 +110,7 @@ suspend fun KafkaAdminClient.deleteTopicsAwait(topicNames: List<String>): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.kafka.admin.KafkaAdminClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use createPartitions returning a future and chain with await()", replaceWith = ReplaceWith("createPartitions(partitions).await()"))
+@Deprecated(message = "Instead use createPartitions returning a future and chain with coAwait()", replaceWith = ReplaceWith("createPartitions(partitions).coAwait()"))
 suspend fun KafkaAdminClient.createPartitionsAwait(partitions: Map<String,NewPartitions>): Unit {
   return awaitResult {
     this.createPartitions(partitions, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -124,7 +124,7 @@ suspend fun KafkaAdminClient.createPartitionsAwait(partitions: Map<String,NewPar
  *
  * NOTE: This function has been automatically generated from [io.vertx.kafka.admin.KafkaAdminClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use listConsumerGroups returning a future and chain with await()", replaceWith = ReplaceWith("listConsumerGroups().await()"))
+@Deprecated(message = "Instead use listConsumerGroups returning a future and chain with coAwait()", replaceWith = ReplaceWith("listConsumerGroups().coAwait()"))
 suspend fun KafkaAdminClient.listConsumerGroupsAwait(): List<ConsumerGroupListing> {
   return awaitResult {
     this.listConsumerGroups(it)
@@ -139,7 +139,7 @@ suspend fun KafkaAdminClient.listConsumerGroupsAwait(): List<ConsumerGroupListin
  *
  * NOTE: This function has been automatically generated from [io.vertx.kafka.admin.KafkaAdminClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use describeConsumerGroups returning a future and chain with await()", replaceWith = ReplaceWith("describeConsumerGroups(groupIds).await()"))
+@Deprecated(message = "Instead use describeConsumerGroups returning a future and chain with coAwait()", replaceWith = ReplaceWith("describeConsumerGroups(groupIds).coAwait()"))
 suspend fun KafkaAdminClient.describeConsumerGroupsAwait(groupIds: List<String>): Map<String,ConsumerGroupDescription> {
   return awaitResult {
     this.describeConsumerGroups(groupIds, it)
@@ -155,7 +155,7 @@ suspend fun KafkaAdminClient.describeConsumerGroupsAwait(groupIds: List<String>)
  *
  * NOTE: This function has been automatically generated from [io.vertx.kafka.admin.KafkaAdminClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use describeConsumerGroups returning a future and chain with await()", replaceWith = ReplaceWith("describeConsumerGroups(groupIds, options).await()"))
+@Deprecated(message = "Instead use describeConsumerGroups returning a future and chain with coAwait()", replaceWith = ReplaceWith("describeConsumerGroups(groupIds, options).coAwait()"))
 suspend fun KafkaAdminClient.describeConsumerGroupsAwait(groupIds: List<String>, options: DescribeConsumerGroupsOptions): Map<String,ConsumerGroupDescription> {
   return awaitResult {
     this.describeConsumerGroups(groupIds, options, it)
@@ -169,7 +169,7 @@ suspend fun KafkaAdminClient.describeConsumerGroupsAwait(groupIds: List<String>,
  *
  * NOTE: This function has been automatically generated from [io.vertx.kafka.admin.KafkaAdminClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use describeCluster returning a future and chain with await()", replaceWith = ReplaceWith("describeCluster().await()"))
+@Deprecated(message = "Instead use describeCluster returning a future and chain with coAwait()", replaceWith = ReplaceWith("describeCluster().coAwait()"))
 suspend fun KafkaAdminClient.describeClusterAwait(): ClusterDescription {
   return awaitResult {
     this.describeCluster(it)
@@ -184,7 +184,7 @@ suspend fun KafkaAdminClient.describeClusterAwait(): ClusterDescription {
  *
  * NOTE: This function has been automatically generated from [io.vertx.kafka.admin.KafkaAdminClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use describeCluster returning a future and chain with await()", replaceWith = ReplaceWith("describeCluster(options).await()"))
+@Deprecated(message = "Instead use describeCluster returning a future and chain with coAwait()", replaceWith = ReplaceWith("describeCluster(options).coAwait()"))
 suspend fun KafkaAdminClient.describeClusterAwait(options: DescribeClusterOptions): ClusterDescription {
   return awaitResult {
     this.describeCluster(options, it)
@@ -198,7 +198,7 @@ suspend fun KafkaAdminClient.describeClusterAwait(options: DescribeClusterOption
  *
  * NOTE: This function has been automatically generated from [io.vertx.kafka.admin.KafkaAdminClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use deleteConsumerGroups returning a future and chain with await()", replaceWith = ReplaceWith("deleteConsumerGroups(groupIds).await()"))
+@Deprecated(message = "Instead use deleteConsumerGroups returning a future and chain with coAwait()", replaceWith = ReplaceWith("deleteConsumerGroups(groupIds).coAwait()"))
 suspend fun KafkaAdminClient.deleteConsumerGroupsAwait(groupIds: List<String>): Unit {
   return awaitResult {
     this.deleteConsumerGroups(groupIds, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -213,7 +213,7 @@ suspend fun KafkaAdminClient.deleteConsumerGroupsAwait(groupIds: List<String>): 
  *
  * NOTE: This function has been automatically generated from [io.vertx.kafka.admin.KafkaAdminClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use deleteConsumerGroupOffsets returning a future and chain with await()", replaceWith = ReplaceWith("deleteConsumerGroupOffsets(groupId, partitions).await()"))
+@Deprecated(message = "Instead use deleteConsumerGroupOffsets returning a future and chain with coAwait()", replaceWith = ReplaceWith("deleteConsumerGroupOffsets(groupId, partitions).coAwait()"))
 suspend fun KafkaAdminClient.deleteConsumerGroupOffsetsAwait(groupId: String, partitions: Set<TopicPartition>): Unit {
   return awaitResult {
     this.deleteConsumerGroupOffsets(groupId, partitions, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -226,7 +226,7 @@ suspend fun KafkaAdminClient.deleteConsumerGroupOffsetsAwait(groupId: String, pa
  *
  * NOTE: This function has been automatically generated from [io.vertx.kafka.admin.KafkaAdminClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use close returning a future and chain with await()", replaceWith = ReplaceWith("close().await()"))
+@Deprecated(message = "Instead use close returning a future and chain with coAwait()", replaceWith = ReplaceWith("close().coAwait()"))
 suspend fun KafkaAdminClient.closeAwait(): Unit {
   return awaitResult {
     this.close(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -240,7 +240,7 @@ suspend fun KafkaAdminClient.closeAwait(): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.kafka.admin.KafkaAdminClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use close returning a future and chain with await()", replaceWith = ReplaceWith("close(timeout).await()"))
+@Deprecated(message = "Instead use close returning a future and chain with coAwait()", replaceWith = ReplaceWith("close(timeout).coAwait()"))
 suspend fun KafkaAdminClient.closeAwait(timeout: Long): Unit {
   return awaitResult {
     this.close(timeout, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -255,7 +255,7 @@ suspend fun KafkaAdminClient.closeAwait(timeout: Long): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.kafka.admin.KafkaAdminClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use describeAcls returning a future and chain with await()", replaceWith = ReplaceWith("describeAcls(aclBindingFilter).await()"))
+@Deprecated(message = "Instead use describeAcls returning a future and chain with coAwait()", replaceWith = ReplaceWith("describeAcls(aclBindingFilter).coAwait()"))
 suspend fun KafkaAdminClient.describeAclsAwait(aclBindingFilter: AclBindingFilter): List<AclBinding> {
   return awaitResult {
     this.describeAcls(aclBindingFilter, it)
@@ -270,7 +270,7 @@ suspend fun KafkaAdminClient.describeAclsAwait(aclBindingFilter: AclBindingFilte
  *
  * NOTE: This function has been automatically generated from [io.vertx.kafka.admin.KafkaAdminClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use createAcls returning a future and chain with await()", replaceWith = ReplaceWith("createAcls(aclBindings).await()"))
+@Deprecated(message = "Instead use createAcls returning a future and chain with coAwait()", replaceWith = ReplaceWith("createAcls(aclBindings).coAwait()"))
 suspend fun KafkaAdminClient.createAclsAwait(aclBindings: List<AclBinding>): List<AclBinding> {
   return awaitResult {
     this.createAcls(aclBindings, it)
@@ -285,7 +285,7 @@ suspend fun KafkaAdminClient.createAclsAwait(aclBindings: List<AclBinding>): Lis
  *
  * NOTE: This function has been automatically generated from [io.vertx.kafka.admin.KafkaAdminClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use deleteAcls returning a future and chain with await()", replaceWith = ReplaceWith("deleteAcls(aclBindings).await()"))
+@Deprecated(message = "Instead use deleteAcls returning a future and chain with coAwait()", replaceWith = ReplaceWith("deleteAcls(aclBindings).coAwait()"))
 suspend fun KafkaAdminClient.deleteAclsAwait(aclBindings: List<AclBindingFilter>): List<AclBinding> {
   return awaitResult {
     this.deleteAcls(aclBindings, it)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/kafka/client/consumer/KafkaConsumer.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/kafka/client/consumer/KafkaConsumer.kt
@@ -33,7 +33,7 @@ import java.time.Duration
  *
  * NOTE: This function has been automatically generated from [io.vertx.kafka.client.consumer.KafkaConsumer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use pipeTo returning a future and chain with await()", replaceWith = ReplaceWith("pipeTo(dst).await()"))
+@Deprecated(message = "Instead use pipeTo returning a future and chain with coAwait()", replaceWith = ReplaceWith("pipeTo(dst).coAwait()"))
 suspend fun <K,V> KafkaConsumer<K,V>.pipeToAwait(dst: WriteStream<KafkaConsumerRecord<K,V>>): Unit {
   return awaitResult {
     this.pipeTo(dst, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -47,7 +47,7 @@ suspend fun <K,V> KafkaConsumer<K,V>.pipeToAwait(dst: WriteStream<KafkaConsumerR
  *
  * NOTE: This function has been automatically generated from [io.vertx.kafka.client.consumer.KafkaConsumer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use subscribe returning a future and chain with await()", replaceWith = ReplaceWith("subscribe(topic).await()"))
+@Deprecated(message = "Instead use subscribe returning a future and chain with coAwait()", replaceWith = ReplaceWith("subscribe(topic).coAwait()"))
 suspend fun <K,V> KafkaConsumer<K,V>.subscribeAwait(topic: String): Unit {
   return awaitResult {
     this.subscribe(topic, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -61,7 +61,7 @@ suspend fun <K,V> KafkaConsumer<K,V>.subscribeAwait(topic: String): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.kafka.client.consumer.KafkaConsumer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use subscribe returning a future and chain with await()", replaceWith = ReplaceWith("subscribe(topics).await()"))
+@Deprecated(message = "Instead use subscribe returning a future and chain with coAwait()", replaceWith = ReplaceWith("subscribe(topics).coAwait()"))
 suspend fun <K,V> KafkaConsumer<K,V>.subscribeAwait(topics: Set<String>): Unit {
   return awaitResult {
     this.subscribe(topics, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -75,7 +75,7 @@ suspend fun <K,V> KafkaConsumer<K,V>.subscribeAwait(topics: Set<String>): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.kafka.client.consumer.KafkaConsumer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use assign returning a future and chain with await()", replaceWith = ReplaceWith("assign(topicPartition).await()"))
+@Deprecated(message = "Instead use assign returning a future and chain with coAwait()", replaceWith = ReplaceWith("assign(topicPartition).coAwait()"))
 suspend fun <K,V> KafkaConsumer<K,V>.assignAwait(topicPartition: TopicPartition): Unit {
   return awaitResult {
     this.assign(topicPartition, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -89,7 +89,7 @@ suspend fun <K,V> KafkaConsumer<K,V>.assignAwait(topicPartition: TopicPartition)
  *
  * NOTE: This function has been automatically generated from [io.vertx.kafka.client.consumer.KafkaConsumer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use assign returning a future and chain with await()", replaceWith = ReplaceWith("assign(topicPartitions).await()"))
+@Deprecated(message = "Instead use assign returning a future and chain with coAwait()", replaceWith = ReplaceWith("assign(topicPartitions).coAwait()"))
 suspend fun <K,V> KafkaConsumer<K,V>.assignAwait(topicPartitions: Set<TopicPartition>): Unit {
   return awaitResult {
     this.assign(topicPartitions, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -103,7 +103,7 @@ suspend fun <K,V> KafkaConsumer<K,V>.assignAwait(topicPartitions: Set<TopicParti
  *
  * NOTE: This function has been automatically generated from [io.vertx.kafka.client.consumer.KafkaConsumer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use assignment returning a future and chain with await()", replaceWith = ReplaceWith("assignment().await()"))
+@Deprecated(message = "Instead use assignment returning a future and chain with coAwait()", replaceWith = ReplaceWith("assignment().coAwait()"))
 suspend fun <K,V> KafkaConsumer<K,V>.assignmentAwait(): Set<TopicPartition> {
   return awaitResult {
     this.assignment(it)
@@ -116,7 +116,7 @@ suspend fun <K,V> KafkaConsumer<K,V>.assignmentAwait(): Set<TopicPartition> {
  *
  * NOTE: This function has been automatically generated from [io.vertx.kafka.client.consumer.KafkaConsumer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use unsubscribe returning a future and chain with await()", replaceWith = ReplaceWith("unsubscribe().await()"))
+@Deprecated(message = "Instead use unsubscribe returning a future and chain with coAwait()", replaceWith = ReplaceWith("unsubscribe().coAwait()"))
 suspend fun <K,V> KafkaConsumer<K,V>.unsubscribeAwait(): Unit {
   return awaitResult {
     this.unsubscribe(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -130,7 +130,7 @@ suspend fun <K,V> KafkaConsumer<K,V>.unsubscribeAwait(): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.kafka.client.consumer.KafkaConsumer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use subscription returning a future and chain with await()", replaceWith = ReplaceWith("subscription().await()"))
+@Deprecated(message = "Instead use subscription returning a future and chain with coAwait()", replaceWith = ReplaceWith("subscription().coAwait()"))
 suspend fun <K,V> KafkaConsumer<K,V>.subscriptionAwait(): Set<String> {
   return awaitResult {
     this.subscription(it)
@@ -144,7 +144,7 @@ suspend fun <K,V> KafkaConsumer<K,V>.subscriptionAwait(): Set<String> {
  *
  * NOTE: This function has been automatically generated from [io.vertx.kafka.client.consumer.KafkaConsumer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use pause returning a future and chain with await()", replaceWith = ReplaceWith("pause(topicPartition).await()"))
+@Deprecated(message = "Instead use pause returning a future and chain with coAwait()", replaceWith = ReplaceWith("pause(topicPartition).coAwait()"))
 suspend fun <K,V> KafkaConsumer<K,V>.pauseAwait(topicPartition: TopicPartition): Unit {
   return awaitResult {
     this.pause(topicPartition, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -158,7 +158,7 @@ suspend fun <K,V> KafkaConsumer<K,V>.pauseAwait(topicPartition: TopicPartition):
  *
  * NOTE: This function has been automatically generated from [io.vertx.kafka.client.consumer.KafkaConsumer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use pause returning a future and chain with await()", replaceWith = ReplaceWith("pause(topicPartitions).await()"))
+@Deprecated(message = "Instead use pause returning a future and chain with coAwait()", replaceWith = ReplaceWith("pause(topicPartitions).coAwait()"))
 suspend fun <K,V> KafkaConsumer<K,V>.pauseAwait(topicPartitions: Set<TopicPartition>): Unit {
   return awaitResult {
     this.pause(topicPartitions, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -172,7 +172,7 @@ suspend fun <K,V> KafkaConsumer<K,V>.pauseAwait(topicPartitions: Set<TopicPartit
  *
  * NOTE: This function has been automatically generated from [io.vertx.kafka.client.consumer.KafkaConsumer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use paused returning a future and chain with await()", replaceWith = ReplaceWith("paused().await()"))
+@Deprecated(message = "Instead use paused returning a future and chain with coAwait()", replaceWith = ReplaceWith("paused().coAwait()"))
 suspend fun <K,V> KafkaConsumer<K,V>.pausedAwait(): Set<TopicPartition> {
   return awaitResult {
     this.paused(it)
@@ -186,7 +186,7 @@ suspend fun <K,V> KafkaConsumer<K,V>.pausedAwait(): Set<TopicPartition> {
  *
  * NOTE: This function has been automatically generated from [io.vertx.kafka.client.consumer.KafkaConsumer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use resume returning a future and chain with await()", replaceWith = ReplaceWith("resume(topicPartition).await()"))
+@Deprecated(message = "Instead use resume returning a future and chain with coAwait()", replaceWith = ReplaceWith("resume(topicPartition).coAwait()"))
 suspend fun <K,V> KafkaConsumer<K,V>.resumeAwait(topicPartition: TopicPartition): Unit {
   return awaitResult {
     this.resume(topicPartition, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -200,7 +200,7 @@ suspend fun <K,V> KafkaConsumer<K,V>.resumeAwait(topicPartition: TopicPartition)
  *
  * NOTE: This function has been automatically generated from [io.vertx.kafka.client.consumer.KafkaConsumer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use resume returning a future and chain with await()", replaceWith = ReplaceWith("resume(topicPartitions).await()"))
+@Deprecated(message = "Instead use resume returning a future and chain with coAwait()", replaceWith = ReplaceWith("resume(topicPartitions).coAwait()"))
 suspend fun <K,V> KafkaConsumer<K,V>.resumeAwait(topicPartitions: Set<TopicPartition>): Unit {
   return awaitResult {
     this.resume(topicPartitions, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -215,7 +215,7 @@ suspend fun <K,V> KafkaConsumer<K,V>.resumeAwait(topicPartitions: Set<TopicParti
  *
  * NOTE: This function has been automatically generated from [io.vertx.kafka.client.consumer.KafkaConsumer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use seek returning a future and chain with await()", replaceWith = ReplaceWith("seek(topicPartition, offset).await()"))
+@Deprecated(message = "Instead use seek returning a future and chain with coAwait()", replaceWith = ReplaceWith("seek(topicPartition, offset).coAwait()"))
 suspend fun <K,V> KafkaConsumer<K,V>.seekAwait(topicPartition: TopicPartition, offset: Long): Unit {
   return awaitResult {
     this.seek(topicPartition, offset, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -229,7 +229,7 @@ suspend fun <K,V> KafkaConsumer<K,V>.seekAwait(topicPartition: TopicPartition, o
  *
  * NOTE: This function has been automatically generated from [io.vertx.kafka.client.consumer.KafkaConsumer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use seekToBeginning returning a future and chain with await()", replaceWith = ReplaceWith("seekToBeginning(topicPartition).await()"))
+@Deprecated(message = "Instead use seekToBeginning returning a future and chain with coAwait()", replaceWith = ReplaceWith("seekToBeginning(topicPartition).coAwait()"))
 suspend fun <K,V> KafkaConsumer<K,V>.seekToBeginningAwait(topicPartition: TopicPartition): Unit {
   return awaitResult {
     this.seekToBeginning(topicPartition, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -243,7 +243,7 @@ suspend fun <K,V> KafkaConsumer<K,V>.seekToBeginningAwait(topicPartition: TopicP
  *
  * NOTE: This function has been automatically generated from [io.vertx.kafka.client.consumer.KafkaConsumer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use seekToBeginning returning a future and chain with await()", replaceWith = ReplaceWith("seekToBeginning(topicPartitions).await()"))
+@Deprecated(message = "Instead use seekToBeginning returning a future and chain with coAwait()", replaceWith = ReplaceWith("seekToBeginning(topicPartitions).coAwait()"))
 suspend fun <K,V> KafkaConsumer<K,V>.seekToBeginningAwait(topicPartitions: Set<TopicPartition>): Unit {
   return awaitResult {
     this.seekToBeginning(topicPartitions, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -257,7 +257,7 @@ suspend fun <K,V> KafkaConsumer<K,V>.seekToBeginningAwait(topicPartitions: Set<T
  *
  * NOTE: This function has been automatically generated from [io.vertx.kafka.client.consumer.KafkaConsumer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use seekToEnd returning a future and chain with await()", replaceWith = ReplaceWith("seekToEnd(topicPartition).await()"))
+@Deprecated(message = "Instead use seekToEnd returning a future and chain with coAwait()", replaceWith = ReplaceWith("seekToEnd(topicPartition).coAwait()"))
 suspend fun <K,V> KafkaConsumer<K,V>.seekToEndAwait(topicPartition: TopicPartition): Unit {
   return awaitResult {
     this.seekToEnd(topicPartition, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -271,7 +271,7 @@ suspend fun <K,V> KafkaConsumer<K,V>.seekToEndAwait(topicPartition: TopicPartiti
  *
  * NOTE: This function has been automatically generated from [io.vertx.kafka.client.consumer.KafkaConsumer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use seekToEnd returning a future and chain with await()", replaceWith = ReplaceWith("seekToEnd(topicPartitions).await()"))
+@Deprecated(message = "Instead use seekToEnd returning a future and chain with coAwait()", replaceWith = ReplaceWith("seekToEnd(topicPartitions).coAwait()"))
 suspend fun <K,V> KafkaConsumer<K,V>.seekToEndAwait(topicPartitions: Set<TopicPartition>): Unit {
   return awaitResult {
     this.seekToEnd(topicPartitions, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -284,7 +284,7 @@ suspend fun <K,V> KafkaConsumer<K,V>.seekToEndAwait(topicPartitions: Set<TopicPa
  *
  * NOTE: This function has been automatically generated from [io.vertx.kafka.client.consumer.KafkaConsumer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use commit returning a future and chain with await()", replaceWith = ReplaceWith("commit().await()"))
+@Deprecated(message = "Instead use commit returning a future and chain with coAwait()", replaceWith = ReplaceWith("commit().coAwait()"))
 suspend fun <K,V> KafkaConsumer<K,V>.commitAwait(): Unit {
   return awaitResult {
     this.commit(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -299,7 +299,7 @@ suspend fun <K,V> KafkaConsumer<K,V>.commitAwait(): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.kafka.client.consumer.KafkaConsumer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use committed returning a future and chain with await()", replaceWith = ReplaceWith("committed(topicPartition).await()"))
+@Deprecated(message = "Instead use committed returning a future and chain with coAwait()", replaceWith = ReplaceWith("committed(topicPartition).coAwait()"))
 suspend fun <K,V> KafkaConsumer<K,V>.committedAwait(topicPartition: TopicPartition): OffsetAndMetadata {
   return awaitResult {
     this.committed(topicPartition, it)
@@ -314,7 +314,7 @@ suspend fun <K,V> KafkaConsumer<K,V>.committedAwait(topicPartition: TopicPartiti
  *
  * NOTE: This function has been automatically generated from [io.vertx.kafka.client.consumer.KafkaConsumer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use partitionsFor returning a future and chain with await()", replaceWith = ReplaceWith("partitionsFor(topic).await()"))
+@Deprecated(message = "Instead use partitionsFor returning a future and chain with coAwait()", replaceWith = ReplaceWith("partitionsFor(topic).coAwait()"))
 suspend fun <K,V> KafkaConsumer<K,V>.partitionsForAwait(topic: String): List<PartitionInfo> {
   return awaitResult {
     this.partitionsFor(topic, it)
@@ -327,7 +327,7 @@ suspend fun <K,V> KafkaConsumer<K,V>.partitionsForAwait(topic: String): List<Par
  *
  * NOTE: This function has been automatically generated from [io.vertx.kafka.client.consumer.KafkaConsumer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use close returning a future and chain with await()", replaceWith = ReplaceWith("close().await()"))
+@Deprecated(message = "Instead use close returning a future and chain with coAwait()", replaceWith = ReplaceWith("close().coAwait()"))
 suspend fun <K,V> KafkaConsumer<K,V>.closeAwait(): Unit {
   return awaitResult {
     this.close(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -342,7 +342,7 @@ suspend fun <K,V> KafkaConsumer<K,V>.closeAwait(): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.kafka.client.consumer.KafkaConsumer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use position returning a future and chain with await()", replaceWith = ReplaceWith("position(partition).await()"))
+@Deprecated(message = "Instead use position returning a future and chain with coAwait()", replaceWith = ReplaceWith("position(partition).coAwait()"))
 suspend fun <K,V> KafkaConsumer<K,V>.positionAwait(partition: TopicPartition): Long {
   return awaitResult {
     this.position(partition, it)
@@ -358,7 +358,7 @@ suspend fun <K,V> KafkaConsumer<K,V>.positionAwait(partition: TopicPartition): L
  *
  * NOTE: This function has been automatically generated from [io.vertx.kafka.client.consumer.KafkaConsumer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use offsetsForTimes returning a future and chain with await()", replaceWith = ReplaceWith("offsetsForTimes(topicPartition, timestamp).await()"))
+@Deprecated(message = "Instead use offsetsForTimes returning a future and chain with coAwait()", replaceWith = ReplaceWith("offsetsForTimes(topicPartition, timestamp).coAwait()"))
 suspend fun <K,V> KafkaConsumer<K,V>.offsetsForTimesAwait(topicPartition: TopicPartition, timestamp: Long): OffsetAndTimestamp {
   return awaitResult {
     this.offsetsForTimes(topicPartition, timestamp, it)
@@ -373,7 +373,7 @@ suspend fun <K,V> KafkaConsumer<K,V>.offsetsForTimesAwait(topicPartition: TopicP
  *
  * NOTE: This function has been automatically generated from [io.vertx.kafka.client.consumer.KafkaConsumer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use beginningOffsets returning a future and chain with await()", replaceWith = ReplaceWith("beginningOffsets(topicPartition).await()"))
+@Deprecated(message = "Instead use beginningOffsets returning a future and chain with coAwait()", replaceWith = ReplaceWith("beginningOffsets(topicPartition).coAwait()"))
 suspend fun <K,V> KafkaConsumer<K,V>.beginningOffsetsAwait(topicPartition: TopicPartition): Long {
   return awaitResult {
     this.beginningOffsets(topicPartition, it)
@@ -388,7 +388,7 @@ suspend fun <K,V> KafkaConsumer<K,V>.beginningOffsetsAwait(topicPartition: Topic
  *
  * NOTE: This function has been automatically generated from [io.vertx.kafka.client.consumer.KafkaConsumer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use endOffsets returning a future and chain with await()", replaceWith = ReplaceWith("endOffsets(topicPartition).await()"))
+@Deprecated(message = "Instead use endOffsets returning a future and chain with coAwait()", replaceWith = ReplaceWith("endOffsets(topicPartition).coAwait()"))
 suspend fun <K,V> KafkaConsumer<K,V>.endOffsetsAwait(topicPartition: TopicPartition): Long {
   return awaitResult {
     this.endOffsets(topicPartition, it)
@@ -403,7 +403,7 @@ suspend fun <K,V> KafkaConsumer<K,V>.endOffsetsAwait(topicPartition: TopicPartit
  *
  * NOTE: This function has been automatically generated from [io.vertx.kafka.client.consumer.KafkaConsumer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use poll returning a future and chain with await()", replaceWith = ReplaceWith("poll(timeout).await()"))
+@Deprecated(message = "Instead use poll returning a future and chain with coAwait()", replaceWith = ReplaceWith("poll(timeout).coAwait()"))
 suspend fun <K,V> KafkaConsumer<K,V>.pollAwait(timeout: Duration): KafkaConsumerRecords<K,V> {
   return awaitResult {
     this.poll(timeout, it)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/kafka/client/producer/KafkaProducer.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/kafka/client/producer/KafkaProducer.kt
@@ -28,7 +28,7 @@ import io.vertx.kotlin.coroutines.awaitResult
  *
  * NOTE: This function has been automatically generated from [io.vertx.kafka.client.producer.KafkaProducer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use write returning a future and chain with await()", replaceWith = ReplaceWith("write(data).await()"))
+@Deprecated(message = "Instead use write returning a future and chain with coAwait()", replaceWith = ReplaceWith("write(data).coAwait()"))
 suspend fun <K,V> KafkaProducer<K,V>.writeAwait(data: KafkaProducerRecord<K,V>): Unit {
   return awaitResult {
     this.write(data, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -41,7 +41,7 @@ suspend fun <K,V> KafkaProducer<K,V>.writeAwait(data: KafkaProducerRecord<K,V>):
  *
  * NOTE: This function has been automatically generated from [io.vertx.kafka.client.producer.KafkaProducer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use end returning a future and chain with await()", replaceWith = ReplaceWith("end().await()"))
+@Deprecated(message = "Instead use end returning a future and chain with coAwait()", replaceWith = ReplaceWith("end().coAwait()"))
 suspend fun <K,V> KafkaProducer<K,V>.endAwait(): Unit {
   return awaitResult {
     this.end(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -55,7 +55,7 @@ suspend fun <K,V> KafkaProducer<K,V>.endAwait(): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.kafka.client.producer.KafkaProducer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use end returning a future and chain with await()", replaceWith = ReplaceWith("end(data).await()"))
+@Deprecated(message = "Instead use end returning a future and chain with coAwait()", replaceWith = ReplaceWith("end(data).coAwait()"))
 suspend fun <K,V> KafkaProducer<K,V>.endAwait(data: KafkaProducerRecord<K,V>): Unit {
   return awaitResult {
     this.end(data, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -68,7 +68,7 @@ suspend fun <K,V> KafkaProducer<K,V>.endAwait(data: KafkaProducerRecord<K,V>): U
  *
  * NOTE: This function has been automatically generated from [io.vertx.kafka.client.producer.KafkaProducer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use initTransactions returning a future and chain with await()", replaceWith = ReplaceWith("initTransactions().await()"))
+@Deprecated(message = "Instead use initTransactions returning a future and chain with coAwait()", replaceWith = ReplaceWith("initTransactions().coAwait()"))
 suspend fun <K,V> KafkaProducer<K,V>.initTransactionsAwait(): Unit {
   return awaitResult {
     this.initTransactions(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -81,7 +81,7 @@ suspend fun <K,V> KafkaProducer<K,V>.initTransactionsAwait(): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.kafka.client.producer.KafkaProducer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use beginTransaction returning a future and chain with await()", replaceWith = ReplaceWith("beginTransaction().await()"))
+@Deprecated(message = "Instead use beginTransaction returning a future and chain with coAwait()", replaceWith = ReplaceWith("beginTransaction().coAwait()"))
 suspend fun <K,V> KafkaProducer<K,V>.beginTransactionAwait(): Unit {
   return awaitResult {
     this.beginTransaction(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -94,7 +94,7 @@ suspend fun <K,V> KafkaProducer<K,V>.beginTransactionAwait(): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.kafka.client.producer.KafkaProducer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use commitTransaction returning a future and chain with await()", replaceWith = ReplaceWith("commitTransaction().await()"))
+@Deprecated(message = "Instead use commitTransaction returning a future and chain with coAwait()", replaceWith = ReplaceWith("commitTransaction().coAwait()"))
 suspend fun <K,V> KafkaProducer<K,V>.commitTransactionAwait(): Unit {
   return awaitResult {
     this.commitTransaction(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -107,7 +107,7 @@ suspend fun <K,V> KafkaProducer<K,V>.commitTransactionAwait(): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.kafka.client.producer.KafkaProducer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use abortTransaction returning a future and chain with await()", replaceWith = ReplaceWith("abortTransaction().await()"))
+@Deprecated(message = "Instead use abortTransaction returning a future and chain with coAwait()", replaceWith = ReplaceWith("abortTransaction().coAwait()"))
 suspend fun <K,V> KafkaProducer<K,V>.abortTransactionAwait(): Unit {
   return awaitResult {
     this.abortTransaction(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -122,7 +122,7 @@ suspend fun <K,V> KafkaProducer<K,V>.abortTransactionAwait(): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.kafka.client.producer.KafkaProducer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use send returning a future and chain with await()", replaceWith = ReplaceWith("send(record).await()"))
+@Deprecated(message = "Instead use send returning a future and chain with coAwait()", replaceWith = ReplaceWith("send(record).coAwait()"))
 suspend fun <K,V> KafkaProducer<K,V>.sendAwait(record: KafkaProducerRecord<K,V>): RecordMetadata {
   return awaitResult {
     this.send(record, it)
@@ -137,7 +137,7 @@ suspend fun <K,V> KafkaProducer<K,V>.sendAwait(record: KafkaProducerRecord<K,V>)
  *
  * NOTE: This function has been automatically generated from [io.vertx.kafka.client.producer.KafkaProducer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use partitionsFor returning a future and chain with await()", replaceWith = ReplaceWith("partitionsFor(topic).await()"))
+@Deprecated(message = "Instead use partitionsFor returning a future and chain with coAwait()", replaceWith = ReplaceWith("partitionsFor(topic).coAwait()"))
 suspend fun <K,V> KafkaProducer<K,V>.partitionsForAwait(topic: String): List<PartitionInfo> {
   return awaitResult {
     this.partitionsFor(topic, it)
@@ -150,7 +150,7 @@ suspend fun <K,V> KafkaProducer<K,V>.partitionsForAwait(topic: String): List<Par
  *
  * NOTE: This function has been automatically generated from [io.vertx.kafka.client.producer.KafkaProducer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use flush returning a future and chain with await()", replaceWith = ReplaceWith("flush().await()"))
+@Deprecated(message = "Instead use flush returning a future and chain with coAwait()", replaceWith = ReplaceWith("flush().coAwait()"))
 suspend fun <K,V> KafkaProducer<K,V>.flushAwait(): Unit {
   return awaitResult {
     this.flush(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -163,7 +163,7 @@ suspend fun <K,V> KafkaProducer<K,V>.flushAwait(): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.kafka.client.producer.KafkaProducer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use close returning a future and chain with await()", replaceWith = ReplaceWith("close().await()"))
+@Deprecated(message = "Instead use close returning a future and chain with coAwait()", replaceWith = ReplaceWith("close().coAwait()"))
 suspend fun <K,V> KafkaProducer<K,V>.closeAwait(): Unit {
   return awaitResult {
     this.close(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -177,7 +177,7 @@ suspend fun <K,V> KafkaProducer<K,V>.closeAwait(): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.kafka.client.producer.KafkaProducer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use close returning a future and chain with await()", replaceWith = ReplaceWith("close(timeout).await()"))
+@Deprecated(message = "Instead use close returning a future and chain with coAwait()", replaceWith = ReplaceWith("close(timeout).coAwait()"))
 suspend fun <K,V> KafkaProducer<K,V>.closeAwait(timeout: Long): Unit {
   return awaitResult {
     this.close(timeout, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/mqtt/MqttClient.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/mqtt/MqttClient.kt
@@ -30,7 +30,7 @@ import io.vertx.mqtt.messages.MqttConnAckMessage
  *
  * NOTE: This function has been automatically generated from [io.vertx.mqtt.MqttClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use connect returning a future and chain with await()", replaceWith = ReplaceWith("connect(port, host).await()"))
+@Deprecated(message = "Instead use connect returning a future and chain with coAwait()", replaceWith = ReplaceWith("connect(port, host).coAwait()"))
 suspend fun MqttClient.connectAwait(port: Int, host: String): MqttConnAckMessage {
   return awaitResult {
     this.connect(port, host, it)
@@ -47,7 +47,7 @@ suspend fun MqttClient.connectAwait(port: Int, host: String): MqttConnAckMessage
  *
  * NOTE: This function has been automatically generated from [io.vertx.mqtt.MqttClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use connect returning a future and chain with await()", replaceWith = ReplaceWith("connect(port, host, serverName).await()"))
+@Deprecated(message = "Instead use connect returning a future and chain with coAwait()", replaceWith = ReplaceWith("connect(port, host, serverName).coAwait()"))
 suspend fun MqttClient.connectAwait(port: Int, host: String, serverName: String): MqttConnAckMessage {
   return awaitResult {
     this.connect(port, host, serverName, it)
@@ -60,7 +60,7 @@ suspend fun MqttClient.connectAwait(port: Int, host: String, serverName: String)
  *
  * NOTE: This function has been automatically generated from [io.vertx.mqtt.MqttClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use disconnect returning a future and chain with await()", replaceWith = ReplaceWith("disconnect().await()"))
+@Deprecated(message = "Instead use disconnect returning a future and chain with coAwait()", replaceWith = ReplaceWith("disconnect().coAwait()"))
 suspend fun MqttClient.disconnectAwait(): Unit {
   return awaitResult {
     this.disconnect(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -79,7 +79,7 @@ suspend fun MqttClient.disconnectAwait(): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.mqtt.MqttClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use publish returning a future and chain with await()", replaceWith = ReplaceWith("publish(topic, payload, qosLevel, isDup, isRetain).await()"))
+@Deprecated(message = "Instead use publish returning a future and chain with coAwait()", replaceWith = ReplaceWith("publish(topic, payload, qosLevel, isDup, isRetain).coAwait()"))
 suspend fun MqttClient.publishAwait(topic: String, payload: Buffer, qosLevel: MqttQoS, isDup: Boolean, isRetain: Boolean): Int {
   return awaitResult {
     this.publish(topic, payload, qosLevel, isDup, isRetain, it)
@@ -95,7 +95,7 @@ suspend fun MqttClient.publishAwait(topic: String, payload: Buffer, qosLevel: Mq
  *
  * NOTE: This function has been automatically generated from [io.vertx.mqtt.MqttClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use subscribe returning a future and chain with await()", replaceWith = ReplaceWith("subscribe(topic, qos).await()"))
+@Deprecated(message = "Instead use subscribe returning a future and chain with coAwait()", replaceWith = ReplaceWith("subscribe(topic, qos).coAwait()"))
 suspend fun MqttClient.subscribeAwait(topic: String, qos: Int): Int {
   return awaitResult {
     this.subscribe(topic, qos, it)
@@ -110,7 +110,7 @@ suspend fun MqttClient.subscribeAwait(topic: String, qos: Int): Int {
  *
  * NOTE: This function has been automatically generated from [io.vertx.mqtt.MqttClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use subscribe returning a future and chain with await()", replaceWith = ReplaceWith("subscribe(topics).await()"))
+@Deprecated(message = "Instead use subscribe returning a future and chain with coAwait()", replaceWith = ReplaceWith("subscribe(topics).coAwait()"))
 suspend fun MqttClient.subscribeAwait(topics: Map<String,Int>): Int {
   return awaitResult {
     this.subscribe(topics, it)
@@ -125,7 +125,7 @@ suspend fun MqttClient.subscribeAwait(topics: Map<String,Int>): Int {
  *
  * NOTE: This function has been automatically generated from [io.vertx.mqtt.MqttClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use unsubscribe returning a future and chain with await()", replaceWith = ReplaceWith("unsubscribe(topics).await()"))
+@Deprecated(message = "Instead use unsubscribe returning a future and chain with coAwait()", replaceWith = ReplaceWith("unsubscribe(topics).coAwait()"))
 suspend fun MqttClient.unsubscribeAwait(topics: List<String>): Int {
   return awaitResult {
     this.unsubscribe(topics, it)
@@ -140,7 +140,7 @@ suspend fun MqttClient.unsubscribeAwait(topics: List<String>): Int {
  *
  * NOTE: This function has been automatically generated from [io.vertx.mqtt.MqttClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use unsubscribe returning a future and chain with await()", replaceWith = ReplaceWith("unsubscribe(topic).await()"))
+@Deprecated(message = "Instead use unsubscribe returning a future and chain with coAwait()", replaceWith = ReplaceWith("unsubscribe(topic).coAwait()"))
 suspend fun MqttClient.unsubscribeAwait(topic: String): Int {
   return awaitResult {
     this.unsubscribe(topic, it)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/mqtt/MqttEndpoint.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/mqtt/MqttEndpoint.kt
@@ -33,7 +33,7 @@ import io.vertx.mqtt.MqttEndpoint
  *
  * NOTE: This function has been automatically generated from [io.vertx.mqtt.MqttEndpoint] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use publish returning a future and chain with await()", replaceWith = ReplaceWith("publish(topic, payload, qosLevel, isDup, isRetain).await()"))
+@Deprecated(message = "Instead use publish returning a future and chain with coAwait()", replaceWith = ReplaceWith("publish(topic, payload, qosLevel, isDup, isRetain).coAwait()"))
 suspend fun MqttEndpoint.publishAwait(topic: String, payload: Buffer, qosLevel: MqttQoS, isDup: Boolean, isRetain: Boolean): Int {
   return awaitResult {
     this.publish(topic, payload, qosLevel, isDup, isRetain, it)
@@ -53,7 +53,7 @@ suspend fun MqttEndpoint.publishAwait(topic: String, payload: Buffer, qosLevel: 
  *
  * NOTE: This function has been automatically generated from [io.vertx.mqtt.MqttEndpoint] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use publish returning a future and chain with await()", replaceWith = ReplaceWith("publish(topic, payload, qosLevel, isDup, isRetain, messageId).await()"))
+@Deprecated(message = "Instead use publish returning a future and chain with coAwait()", replaceWith = ReplaceWith("publish(topic, payload, qosLevel, isDup, isRetain, messageId).coAwait()"))
 suspend fun MqttEndpoint.publishAwait(topic: String, payload: Buffer, qosLevel: MqttQoS, isDup: Boolean, isRetain: Boolean, messageId: Int): Int {
   return awaitResult {
     this.publish(topic, payload, qosLevel, isDup, isRetain, messageId, it)
@@ -74,7 +74,7 @@ suspend fun MqttEndpoint.publishAwait(topic: String, payload: Buffer, qosLevel: 
  *
  * NOTE: This function has been automatically generated from [io.vertx.mqtt.MqttEndpoint] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use publish returning a future and chain with await()", replaceWith = ReplaceWith("publish(topic, payload, qosLevel, isDup, isRetain, messageId, properties).await()"))
+@Deprecated(message = "Instead use publish returning a future and chain with coAwait()", replaceWith = ReplaceWith("publish(topic, payload, qosLevel, isDup, isRetain, messageId, properties).coAwait()"))
 suspend fun MqttEndpoint.publishAwait(topic: String, payload: Buffer, qosLevel: MqttQoS, isDup: Boolean, isRetain: Boolean, messageId: Int, properties: MqttProperties): Int {
   return awaitResult {
     this.publish(topic, payload, qosLevel, isDup, isRetain, messageId, properties, it)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/mqtt/MqttServer.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/mqtt/MqttServer.kt
@@ -27,7 +27,7 @@ import io.vertx.mqtt.MqttServer
  *
  * NOTE: This function has been automatically generated from [io.vertx.mqtt.MqttServer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use listen returning a future and chain with await()", replaceWith = ReplaceWith("listen(port, host).await()"))
+@Deprecated(message = "Instead use listen returning a future and chain with coAwait()", replaceWith = ReplaceWith("listen(port, host).coAwait()"))
 suspend fun MqttServer.listenAwait(port: Int, host: String): MqttServer {
   return awaitResult {
     this.listen(port, host, it)
@@ -42,7 +42,7 @@ suspend fun MqttServer.listenAwait(port: Int, host: String): MqttServer {
  *
  * NOTE: This function has been automatically generated from [io.vertx.mqtt.MqttServer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use listen returning a future and chain with await()", replaceWith = ReplaceWith("listen(port).await()"))
+@Deprecated(message = "Instead use listen returning a future and chain with coAwait()", replaceWith = ReplaceWith("listen(port).coAwait()"))
 suspend fun MqttServer.listenAwait(port: Int): MqttServer {
   return awaitResult {
     this.listen(port, it)
@@ -56,7 +56,7 @@ suspend fun MqttServer.listenAwait(port: Int): MqttServer {
  *
  * NOTE: This function has been automatically generated from [io.vertx.mqtt.MqttServer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use listen returning a future and chain with await()", replaceWith = ReplaceWith("listen().await()"))
+@Deprecated(message = "Instead use listen returning a future and chain with coAwait()", replaceWith = ReplaceWith("listen().coAwait()"))
 suspend fun MqttServer.listenAwait(): MqttServer {
   return awaitResult {
     this.listen(it)
@@ -69,7 +69,7 @@ suspend fun MqttServer.listenAwait(): MqttServer {
  *
  * NOTE: This function has been automatically generated from [io.vertx.mqtt.MqttServer] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use close returning a future and chain with await()", replaceWith = ReplaceWith("close().await()"))
+@Deprecated(message = "Instead use close returning a future and chain with coAwait()", replaceWith = ReplaceWith("close().coAwait()"))
 suspend fun MqttServer.closeAwait(): Unit {
   return awaitResult {
     this.close(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/mssqlclient/MSSQLConnection.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/mssqlclient/MSSQLConnection.kt
@@ -29,7 +29,7 @@ import io.vertx.sqlclient.PreparedStatement
  *
  * NOTE: This function has been automatically generated from [io.vertx.mssqlclient.MSSQLConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use prepare returning a future and chain with await()", replaceWith = ReplaceWith("prepare(s).await()"))
+@Deprecated(message = "Instead use prepare returning a future and chain with coAwait()", replaceWith = ReplaceWith("prepare(s).coAwait()"))
 suspend fun MSSQLConnectionVertxAlias.prepareAwait(s: String): PreparedStatement {
   return awaitResult {
     this.prepare(s, it)
@@ -46,7 +46,7 @@ object MSSQLConnection {
    *
    * NOTE: This function has been automatically generated from [io.vertx.mssqlclient.MSSQLConnection] using Vert.x codegen.
    */
-  @Deprecated(message = "Instead use connect returning a future and chain with await()", replaceWith = ReplaceWith("connect(vertx, connectOptions).await()"))
+  @Deprecated(message = "Instead use connect returning a future and chain with coAwait()", replaceWith = ReplaceWith("connect(vertx, connectOptions).coAwait()"))
   suspend fun connectAwait(vertx: Vertx, connectOptions: MSSQLConnectOptions): MSSQLConnectionVertxAlias {
     return awaitResult {
       MSSQLConnectionVertxAlias.connect(vertx, connectOptions, it)
@@ -62,7 +62,7 @@ object MSSQLConnection {
    *
    * NOTE: This function has been automatically generated from [io.vertx.mssqlclient.MSSQLConnection] using Vert.x codegen.
    */
-  @Deprecated(message = "Instead use connect returning a future and chain with await()", replaceWith = ReplaceWith("connect(vertx, connectionUri).await()"))
+  @Deprecated(message = "Instead use connect returning a future and chain with coAwait()", replaceWith = ReplaceWith("connect(vertx, connectionUri).coAwait()"))
   suspend fun connectAwait(vertx: Vertx, connectionUri: String): MSSQLConnectionVertxAlias {
     return awaitResult {
       MSSQLConnectionVertxAlias.connect(vertx, connectionUri, it)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/mysqlclient/MySQLConnection.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/mysqlclient/MySQLConnection.kt
@@ -31,7 +31,7 @@ import io.vertx.sqlclient.PreparedStatement
  *
  * NOTE: This function has been automatically generated from [io.vertx.mysqlclient.MySQLConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use prepare returning a future and chain with await()", replaceWith = ReplaceWith("prepare(sql).await()"))
+@Deprecated(message = "Instead use prepare returning a future and chain with coAwait()", replaceWith = ReplaceWith("prepare(sql).coAwait()"))
 suspend fun MySQLConnectionVertxAlias.prepareAwait(sql: String): PreparedStatement {
   return awaitResult {
     this.prepare(sql, it)
@@ -44,7 +44,7 @@ suspend fun MySQLConnectionVertxAlias.prepareAwait(sql: String): PreparedStateme
  *
  * NOTE: This function has been automatically generated from [io.vertx.mysqlclient.MySQLConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use ping returning a future and chain with await()", replaceWith = ReplaceWith("ping().await()"))
+@Deprecated(message = "Instead use ping returning a future and chain with coAwait()", replaceWith = ReplaceWith("ping().coAwait()"))
 suspend fun MySQLConnectionVertxAlias.pingAwait(): Unit {
   return awaitResult {
     this.ping(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -58,7 +58,7 @@ suspend fun MySQLConnectionVertxAlias.pingAwait(): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.mysqlclient.MySQLConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use specifySchema returning a future and chain with await()", replaceWith = ReplaceWith("specifySchema(schemaName).await()"))
+@Deprecated(message = "Instead use specifySchema returning a future and chain with coAwait()", replaceWith = ReplaceWith("specifySchema(schemaName).coAwait()"))
 suspend fun MySQLConnectionVertxAlias.specifySchemaAwait(schemaName: String): Unit {
   return awaitResult {
     this.specifySchema(schemaName, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -72,7 +72,7 @@ suspend fun MySQLConnectionVertxAlias.specifySchemaAwait(schemaName: String): Un
  *
  * NOTE: This function has been automatically generated from [io.vertx.mysqlclient.MySQLConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use getInternalStatistics returning a future and chain with await()", replaceWith = ReplaceWith("getInternalStatistics().await()"))
+@Deprecated(message = "Instead use getInternalStatistics returning a future and chain with coAwait()", replaceWith = ReplaceWith("getInternalStatistics().coAwait()"))
 suspend fun MySQLConnectionVertxAlias.getInternalStatisticsAwait(): String {
   return awaitResult {
     this.getInternalStatistics(it)
@@ -86,7 +86,7 @@ suspend fun MySQLConnectionVertxAlias.getInternalStatisticsAwait(): String {
  *
  * NOTE: This function has been automatically generated from [io.vertx.mysqlclient.MySQLConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use setOption returning a future and chain with await()", replaceWith = ReplaceWith("setOption(option).await()"))
+@Deprecated(message = "Instead use setOption returning a future and chain with coAwait()", replaceWith = ReplaceWith("setOption(option).coAwait()"))
 suspend fun MySQLConnectionVertxAlias.setOptionAwait(option: MySQLSetOption): Unit {
   return awaitResult {
     this.setOption(option, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -99,7 +99,7 @@ suspend fun MySQLConnectionVertxAlias.setOptionAwait(option: MySQLSetOption): Un
  *
  * NOTE: This function has been automatically generated from [io.vertx.mysqlclient.MySQLConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use resetConnection returning a future and chain with await()", replaceWith = ReplaceWith("resetConnection().await()"))
+@Deprecated(message = "Instead use resetConnection returning a future and chain with coAwait()", replaceWith = ReplaceWith("resetConnection().coAwait()"))
 suspend fun MySQLConnectionVertxAlias.resetConnectionAwait(): Unit {
   return awaitResult {
     this.resetConnection(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -112,7 +112,7 @@ suspend fun MySQLConnectionVertxAlias.resetConnectionAwait(): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.mysqlclient.MySQLConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use debug returning a future and chain with await()", replaceWith = ReplaceWith("debug().await()"))
+@Deprecated(message = "Instead use debug returning a future and chain with coAwait()", replaceWith = ReplaceWith("debug().coAwait()"))
 suspend fun MySQLConnectionVertxAlias.debugAwait(): Unit {
   return awaitResult {
     this.debug(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -126,7 +126,7 @@ suspend fun MySQLConnectionVertxAlias.debugAwait(): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.mysqlclient.MySQLConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use changeUser returning a future and chain with await()", replaceWith = ReplaceWith("changeUser(options).await()"))
+@Deprecated(message = "Instead use changeUser returning a future and chain with coAwait()", replaceWith = ReplaceWith("changeUser(options).coAwait()"))
 suspend fun MySQLConnectionVertxAlias.changeUserAwait(options: MySQLAuthOptions): Unit {
   return awaitResult {
     this.changeUser(options, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -143,7 +143,7 @@ object MySQLConnection {
    *
    * NOTE: This function has been automatically generated from [io.vertx.mysqlclient.MySQLConnection] using Vert.x codegen.
    */
-  @Deprecated(message = "Instead use connect returning a future and chain with await()", replaceWith = ReplaceWith("connect(vertx, connectOptions).await()"))
+  @Deprecated(message = "Instead use connect returning a future and chain with coAwait()", replaceWith = ReplaceWith("connect(vertx, connectOptions).coAwait()"))
   suspend fun connectAwait(vertx: Vertx, connectOptions: MySQLConnectOptions): MySQLConnectionVertxAlias {
     return awaitResult {
       MySQLConnectionVertxAlias.connect(vertx, connectOptions, it)
@@ -159,7 +159,7 @@ object MySQLConnection {
    *
    * NOTE: This function has been automatically generated from [io.vertx.mysqlclient.MySQLConnection] using Vert.x codegen.
    */
-  @Deprecated(message = "Instead use connect returning a future and chain with await()", replaceWith = ReplaceWith("connect(vertx, connectionUri).await()"))
+  @Deprecated(message = "Instead use connect returning a future and chain with coAwait()", replaceWith = ReplaceWith("connect(vertx, connectionUri).coAwait()"))
   suspend fun connectAwait(vertx: Vertx, connectionUri: String): MySQLConnectionVertxAlias {
     return awaitResult {
       MySQLConnectionVertxAlias.connect(vertx, connectionUri, it)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/oracleclient/OracleConnection.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/oracleclient/OracleConnection.kt
@@ -29,7 +29,7 @@ import io.vertx.sqlclient.PreparedStatement
  *
  * NOTE: This function has been automatically generated from [io.vertx.oracleclient.OracleConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use prepare returning a future and chain with await()", replaceWith = ReplaceWith("prepare(s).await()"))
+@Deprecated(message = "Instead use prepare returning a future and chain with coAwait()", replaceWith = ReplaceWith("prepare(s).coAwait()"))
 suspend fun OracleConnectionVertxAlias.prepareAwait(s: String): PreparedStatement {
   return awaitResult {
     this.prepare(s, it)
@@ -46,7 +46,7 @@ object OracleConnection {
    *
    * NOTE: This function has been automatically generated from [io.vertx.oracleclient.OracleConnection] using Vert.x codegen.
    */
-  @Deprecated(message = "Instead use connect returning a future and chain with await()", replaceWith = ReplaceWith("connect(vertx, connectOptions).await()"))
+  @Deprecated(message = "Instead use connect returning a future and chain with coAwait()", replaceWith = ReplaceWith("connect(vertx, connectOptions).coAwait()"))
   suspend fun connectAwait(vertx: Vertx, connectOptions: OracleConnectOptions): OracleConnectionVertxAlias {
     return awaitResult {
       OracleConnectionVertxAlias.connect(vertx, connectOptions, it)
@@ -62,7 +62,7 @@ object OracleConnection {
    *
    * NOTE: This function has been automatically generated from [io.vertx.oracleclient.OracleConnection] using Vert.x codegen.
    */
-  @Deprecated(message = "Instead use connect returning a future and chain with await()", replaceWith = ReplaceWith("connect(vertx, connectionUri).await()"))
+  @Deprecated(message = "Instead use connect returning a future and chain with coAwait()", replaceWith = ReplaceWith("connect(vertx, connectionUri).coAwait()"))
   suspend fun connectAwait(vertx: Vertx, connectionUri: String): OracleConnectionVertxAlias {
     return awaitResult {
       OracleConnectionVertxAlias.connect(vertx, connectionUri, it)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/pgclient/PgConnection.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/pgclient/PgConnection.kt
@@ -29,7 +29,7 @@ import io.vertx.sqlclient.PreparedStatement
  *
  * NOTE: This function has been automatically generated from [io.vertx.pgclient.PgConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use prepare returning a future and chain with await()", replaceWith = ReplaceWith("prepare(sql).await()"))
+@Deprecated(message = "Instead use prepare returning a future and chain with coAwait()", replaceWith = ReplaceWith("prepare(sql).coAwait()"))
 suspend fun PgConnectionVertxAlias.prepareAwait(sql: String): PreparedStatement {
   return awaitResult {
     this.prepare(sql, it)
@@ -46,7 +46,7 @@ object PgConnection {
    *
    * NOTE: This function has been automatically generated from [io.vertx.pgclient.PgConnection] using Vert.x codegen.
    */
-  @Deprecated(message = "Instead use connect returning a future and chain with await()", replaceWith = ReplaceWith("connect(vertx, options).await()"))
+  @Deprecated(message = "Instead use connect returning a future and chain with coAwait()", replaceWith = ReplaceWith("connect(vertx, options).coAwait()"))
   suspend fun connectAwait(vertx: Vertx, options: PgConnectOptions): PgConnectionVertxAlias {
     return awaitResult {
       PgConnectionVertxAlias.connect(vertx, options, it)
@@ -61,7 +61,7 @@ object PgConnection {
    *
    * NOTE: This function has been automatically generated from [io.vertx.pgclient.PgConnection] using Vert.x codegen.
    */
-  @Deprecated(message = "Instead use connect returning a future and chain with await()", replaceWith = ReplaceWith("connect(vertx).await()"))
+  @Deprecated(message = "Instead use connect returning a future and chain with coAwait()", replaceWith = ReplaceWith("connect(vertx).coAwait()"))
   suspend fun connectAwait(vertx: Vertx): PgConnectionVertxAlias {
     return awaitResult {
       PgConnectionVertxAlias.connect(vertx, it)
@@ -77,7 +77,7 @@ object PgConnection {
    *
    * NOTE: This function has been automatically generated from [io.vertx.pgclient.PgConnection] using Vert.x codegen.
    */
-  @Deprecated(message = "Instead use connect returning a future and chain with await()", replaceWith = ReplaceWith("connect(vertx, connectionUri).await()"))
+  @Deprecated(message = "Instead use connect returning a future and chain with coAwait()", replaceWith = ReplaceWith("connect(vertx, connectionUri).coAwait()"))
   suspend fun connectAwait(vertx: Vertx, connectionUri: String): PgConnectionVertxAlias {
     return awaitResult {
       PgConnectionVertxAlias.connect(vertx, connectionUri, it)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/pgclient/pubsub/PgChannel.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/pgclient/pubsub/PgChannel.kt
@@ -26,7 +26,7 @@ import io.vertx.pgclient.pubsub.PgChannel
  *
  * NOTE: This function has been automatically generated from [io.vertx.pgclient.pubsub.PgChannel] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use pipeTo returning a future and chain with await()", replaceWith = ReplaceWith("pipeTo(dst).await()"))
+@Deprecated(message = "Instead use pipeTo returning a future and chain with coAwait()", replaceWith = ReplaceWith("pipeTo(dst).coAwait()"))
 suspend fun PgChannel.pipeToAwait(dst: WriteStream<String>): Unit {
   return awaitResult {
     this.pipeTo(dst, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/pgclient/pubsub/PgSubscriber.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/pgclient/pubsub/PgSubscriber.kt
@@ -24,7 +24,7 @@ import io.vertx.pgclient.pubsub.PgSubscriber
  *
  * NOTE: This function has been automatically generated from [io.vertx.pgclient.pubsub.PgSubscriber] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use connect returning a future and chain with await()", replaceWith = ReplaceWith("connect().await()"))
+@Deprecated(message = "Instead use connect returning a future and chain with coAwait()", replaceWith = ReplaceWith("connect().coAwait()"))
 suspend fun PgSubscriber.connectAwait(): Unit {
   return awaitResult {
     this.connect(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -37,7 +37,7 @@ suspend fun PgSubscriber.connectAwait(): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.pgclient.pubsub.PgSubscriber] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use close returning a future and chain with await()", replaceWith = ReplaceWith("close().await()"))
+@Deprecated(message = "Instead use close returning a future and chain with coAwait()", replaceWith = ReplaceWith("close().coAwait()"))
 suspend fun PgSubscriber.closeAwait(): Unit {
   return awaitResult {
     this.close(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/redis/client/Redis.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/redis/client/Redis.kt
@@ -28,7 +28,7 @@ import io.vertx.redis.client.Response
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.Redis] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use connect returning a future and chain with await()", replaceWith = ReplaceWith("connect().await()"))
+@Deprecated(message = "Instead use connect returning a future and chain with coAwait()", replaceWith = ReplaceWith("connect().coAwait()"))
 suspend fun Redis.connectAwait(): RedisConnection {
   return awaitResult {
     this.connect(it)
@@ -43,7 +43,7 @@ suspend fun Redis.connectAwait(): RedisConnection {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.Redis] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use send returning a future and chain with await()", replaceWith = ReplaceWith("send(command).await()"))
+@Deprecated(message = "Instead use send returning a future and chain with coAwait()", replaceWith = ReplaceWith("send(command).coAwait()"))
 suspend fun Redis.sendAwait(command: Request): Response? {
   return awaitResult {
     this.send(command, it)
@@ -58,7 +58,7 @@ suspend fun Redis.sendAwait(command: Request): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.Redis] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use batch returning a future and chain with await()", replaceWith = ReplaceWith("batch(commands).await()"))
+@Deprecated(message = "Instead use batch returning a future and chain with coAwait()", replaceWith = ReplaceWith("batch(commands).coAwait()"))
 suspend fun Redis.batchAwait(commands: List<Request>): List<Response?> {
   return awaitResult {
     this.batch(commands, it)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/redis/client/RedisAPI.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/redis/client/RedisAPI.kt
@@ -27,7 +27,7 @@ import io.vertx.redis.client.Response
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use ftAdd returning a future and chain with await()", replaceWith = ReplaceWith("ftAdd(args).await()"))
+@Deprecated(message = "Instead use ftAdd returning a future and chain with coAwait()", replaceWith = ReplaceWith("ftAdd(args).coAwait()"))
 suspend fun RedisAPI.ftAddAwait(args: List<String>): Response? {
   return awaitResult {
     this.ftAdd(args, it)
@@ -42,7 +42,7 @@ suspend fun RedisAPI.ftAddAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use ftAggregate returning a future and chain with await()", replaceWith = ReplaceWith("ftAggregate(args).await()"))
+@Deprecated(message = "Instead use ftAggregate returning a future and chain with coAwait()", replaceWith = ReplaceWith("ftAggregate(args).coAwait()"))
 suspend fun RedisAPI.ftAggregateAwait(args: List<String>): Response? {
   return awaitResult {
     this.ftAggregate(args, it)
@@ -57,7 +57,7 @@ suspend fun RedisAPI.ftAggregateAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use ftAliasadd returning a future and chain with await()", replaceWith = ReplaceWith("ftAliasadd(args).await()"))
+@Deprecated(message = "Instead use ftAliasadd returning a future and chain with coAwait()", replaceWith = ReplaceWith("ftAliasadd(args).coAwait()"))
 suspend fun RedisAPI.ftAliasaddAwait(args: List<String>): Response? {
   return awaitResult {
     this.ftAliasadd(args, it)
@@ -72,7 +72,7 @@ suspend fun RedisAPI.ftAliasaddAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use ftAliasdel returning a future and chain with await()", replaceWith = ReplaceWith("ftAliasdel(args).await()"))
+@Deprecated(message = "Instead use ftAliasdel returning a future and chain with coAwait()", replaceWith = ReplaceWith("ftAliasdel(args).coAwait()"))
 suspend fun RedisAPI.ftAliasdelAwait(args: List<String>): Response? {
   return awaitResult {
     this.ftAliasdel(args, it)
@@ -87,7 +87,7 @@ suspend fun RedisAPI.ftAliasdelAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use ftAliasupdate returning a future and chain with await()", replaceWith = ReplaceWith("ftAliasupdate(args).await()"))
+@Deprecated(message = "Instead use ftAliasupdate returning a future and chain with coAwait()", replaceWith = ReplaceWith("ftAliasupdate(args).coAwait()"))
 suspend fun RedisAPI.ftAliasupdateAwait(args: List<String>): Response? {
   return awaitResult {
     this.ftAliasupdate(args, it)
@@ -102,7 +102,7 @@ suspend fun RedisAPI.ftAliasupdateAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use ftAlter returning a future and chain with await()", replaceWith = ReplaceWith("ftAlter(args).await()"))
+@Deprecated(message = "Instead use ftAlter returning a future and chain with coAwait()", replaceWith = ReplaceWith("ftAlter(args).coAwait()"))
 suspend fun RedisAPI.ftAlterAwait(args: List<String>): Response? {
   return awaitResult {
     this.ftAlter(args, it)
@@ -117,7 +117,7 @@ suspend fun RedisAPI.ftAlterAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use ftConfig returning a future and chain with await()", replaceWith = ReplaceWith("ftConfig(args).await()"))
+@Deprecated(message = "Instead use ftConfig returning a future and chain with coAwait()", replaceWith = ReplaceWith("ftConfig(args).coAwait()"))
 suspend fun RedisAPI.ftConfigAwait(args: List<String>): Response? {
   return awaitResult {
     this.ftConfig(args, it)
@@ -132,7 +132,7 @@ suspend fun RedisAPI.ftConfigAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use ftCreate returning a future and chain with await()", replaceWith = ReplaceWith("ftCreate(args).await()"))
+@Deprecated(message = "Instead use ftCreate returning a future and chain with coAwait()", replaceWith = ReplaceWith("ftCreate(args).coAwait()"))
 suspend fun RedisAPI.ftCreateAwait(args: List<String>): Response? {
   return awaitResult {
     this.ftCreate(args, it)
@@ -147,7 +147,7 @@ suspend fun RedisAPI.ftCreateAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use ftCursor returning a future and chain with await()", replaceWith = ReplaceWith("ftCursor(args).await()"))
+@Deprecated(message = "Instead use ftCursor returning a future and chain with coAwait()", replaceWith = ReplaceWith("ftCursor(args).coAwait()"))
 suspend fun RedisAPI.ftCursorAwait(args: List<String>): Response? {
   return awaitResult {
     this.ftCursor(args, it)
@@ -162,7 +162,7 @@ suspend fun RedisAPI.ftCursorAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use ftDebug returning a future and chain with await()", replaceWith = ReplaceWith("ftDebug(args).await()"))
+@Deprecated(message = "Instead use ftDebug returning a future and chain with coAwait()", replaceWith = ReplaceWith("ftDebug(args).coAwait()"))
 suspend fun RedisAPI.ftDebugAwait(args: List<String>): Response? {
   return awaitResult {
     this.ftDebug(args, it)
@@ -177,7 +177,7 @@ suspend fun RedisAPI.ftDebugAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use ftDel returning a future and chain with await()", replaceWith = ReplaceWith("ftDel(args).await()"))
+@Deprecated(message = "Instead use ftDel returning a future and chain with coAwait()", replaceWith = ReplaceWith("ftDel(args).coAwait()"))
 suspend fun RedisAPI.ftDelAwait(args: List<String>): Response? {
   return awaitResult {
     this.ftDel(args, it)
@@ -192,7 +192,7 @@ suspend fun RedisAPI.ftDelAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use ftDictadd returning a future and chain with await()", replaceWith = ReplaceWith("ftDictadd(args).await()"))
+@Deprecated(message = "Instead use ftDictadd returning a future and chain with coAwait()", replaceWith = ReplaceWith("ftDictadd(args).coAwait()"))
 suspend fun RedisAPI.ftDictaddAwait(args: List<String>): Response? {
   return awaitResult {
     this.ftDictadd(args, it)
@@ -207,7 +207,7 @@ suspend fun RedisAPI.ftDictaddAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use ftDictdel returning a future and chain with await()", replaceWith = ReplaceWith("ftDictdel(args).await()"))
+@Deprecated(message = "Instead use ftDictdel returning a future and chain with coAwait()", replaceWith = ReplaceWith("ftDictdel(args).coAwait()"))
 suspend fun RedisAPI.ftDictdelAwait(args: List<String>): Response? {
   return awaitResult {
     this.ftDictdel(args, it)
@@ -222,7 +222,7 @@ suspend fun RedisAPI.ftDictdelAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use ftDictdump returning a future and chain with await()", replaceWith = ReplaceWith("ftDictdump(args).await()"))
+@Deprecated(message = "Instead use ftDictdump returning a future and chain with coAwait()", replaceWith = ReplaceWith("ftDictdump(args).coAwait()"))
 suspend fun RedisAPI.ftDictdumpAwait(args: List<String>): Response? {
   return awaitResult {
     this.ftDictdump(args, it)
@@ -237,7 +237,7 @@ suspend fun RedisAPI.ftDictdumpAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use ftDrop returning a future and chain with await()", replaceWith = ReplaceWith("ftDrop(args).await()"))
+@Deprecated(message = "Instead use ftDrop returning a future and chain with coAwait()", replaceWith = ReplaceWith("ftDrop(args).coAwait()"))
 suspend fun RedisAPI.ftDropAwait(args: List<String>): Response? {
   return awaitResult {
     this.ftDrop(args, it)
@@ -252,7 +252,7 @@ suspend fun RedisAPI.ftDropAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use ftDropindex returning a future and chain with await()", replaceWith = ReplaceWith("ftDropindex(args).await()"))
+@Deprecated(message = "Instead use ftDropindex returning a future and chain with coAwait()", replaceWith = ReplaceWith("ftDropindex(args).coAwait()"))
 suspend fun RedisAPI.ftDropindexAwait(args: List<String>): Response? {
   return awaitResult {
     this.ftDropindex(args, it)
@@ -267,7 +267,7 @@ suspend fun RedisAPI.ftDropindexAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use ftExplain returning a future and chain with await()", replaceWith = ReplaceWith("ftExplain(args).await()"))
+@Deprecated(message = "Instead use ftExplain returning a future and chain with coAwait()", replaceWith = ReplaceWith("ftExplain(args).coAwait()"))
 suspend fun RedisAPI.ftExplainAwait(args: List<String>): Response? {
   return awaitResult {
     this.ftExplain(args, it)
@@ -282,7 +282,7 @@ suspend fun RedisAPI.ftExplainAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use ftExplaincli returning a future and chain with await()", replaceWith = ReplaceWith("ftExplaincli(args).await()"))
+@Deprecated(message = "Instead use ftExplaincli returning a future and chain with coAwait()", replaceWith = ReplaceWith("ftExplaincli(args).coAwait()"))
 suspend fun RedisAPI.ftExplaincliAwait(args: List<String>): Response? {
   return awaitResult {
     this.ftExplaincli(args, it)
@@ -297,7 +297,7 @@ suspend fun RedisAPI.ftExplaincliAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use ftGet returning a future and chain with await()", replaceWith = ReplaceWith("ftGet(args).await()"))
+@Deprecated(message = "Instead use ftGet returning a future and chain with coAwait()", replaceWith = ReplaceWith("ftGet(args).coAwait()"))
 suspend fun RedisAPI.ftGetAwait(args: List<String>): Response? {
   return awaitResult {
     this.ftGet(args, it)
@@ -312,7 +312,7 @@ suspend fun RedisAPI.ftGetAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use ftInfo returning a future and chain with await()", replaceWith = ReplaceWith("ftInfo(args).await()"))
+@Deprecated(message = "Instead use ftInfo returning a future and chain with coAwait()", replaceWith = ReplaceWith("ftInfo(args).coAwait()"))
 suspend fun RedisAPI.ftInfoAwait(args: List<String>): Response? {
   return awaitResult {
     this.ftInfo(args, it)
@@ -327,7 +327,7 @@ suspend fun RedisAPI.ftInfoAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use ftMget returning a future and chain with await()", replaceWith = ReplaceWith("ftMget(args).await()"))
+@Deprecated(message = "Instead use ftMget returning a future and chain with coAwait()", replaceWith = ReplaceWith("ftMget(args).coAwait()"))
 suspend fun RedisAPI.ftMgetAwait(args: List<String>): Response? {
   return awaitResult {
     this.ftMget(args, it)
@@ -342,7 +342,7 @@ suspend fun RedisAPI.ftMgetAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use ftProfile returning a future and chain with await()", replaceWith = ReplaceWith("ftProfile(args).await()"))
+@Deprecated(message = "Instead use ftProfile returning a future and chain with coAwait()", replaceWith = ReplaceWith("ftProfile(args).coAwait()"))
 suspend fun RedisAPI.ftProfileAwait(args: List<String>): Response? {
   return awaitResult {
     this.ftProfile(args, it)
@@ -357,7 +357,7 @@ suspend fun RedisAPI.ftProfileAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use ftSafeadd returning a future and chain with await()", replaceWith = ReplaceWith("ftSafeadd(args).await()"))
+@Deprecated(message = "Instead use ftSafeadd returning a future and chain with coAwait()", replaceWith = ReplaceWith("ftSafeadd(args).coAwait()"))
 suspend fun RedisAPI.ftSafeaddAwait(args: List<String>): Response? {
   return awaitResult {
     this.ftSafeadd(args, it)
@@ -372,7 +372,7 @@ suspend fun RedisAPI.ftSafeaddAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use ftSearch returning a future and chain with await()", replaceWith = ReplaceWith("ftSearch(args).await()"))
+@Deprecated(message = "Instead use ftSearch returning a future and chain with coAwait()", replaceWith = ReplaceWith("ftSearch(args).coAwait()"))
 suspend fun RedisAPI.ftSearchAwait(args: List<String>): Response? {
   return awaitResult {
     this.ftSearch(args, it)
@@ -387,7 +387,7 @@ suspend fun RedisAPI.ftSearchAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use ftSpellcheck returning a future and chain with await()", replaceWith = ReplaceWith("ftSpellcheck(args).await()"))
+@Deprecated(message = "Instead use ftSpellcheck returning a future and chain with coAwait()", replaceWith = ReplaceWith("ftSpellcheck(args).coAwait()"))
 suspend fun RedisAPI.ftSpellcheckAwait(args: List<String>): Response? {
   return awaitResult {
     this.ftSpellcheck(args, it)
@@ -402,7 +402,7 @@ suspend fun RedisAPI.ftSpellcheckAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use ftSugadd returning a future and chain with await()", replaceWith = ReplaceWith("ftSugadd(args).await()"))
+@Deprecated(message = "Instead use ftSugadd returning a future and chain with coAwait()", replaceWith = ReplaceWith("ftSugadd(args).coAwait()"))
 suspend fun RedisAPI.ftSugaddAwait(args: List<String>): Response? {
   return awaitResult {
     this.ftSugadd(args, it)
@@ -417,7 +417,7 @@ suspend fun RedisAPI.ftSugaddAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use ftSugdel returning a future and chain with await()", replaceWith = ReplaceWith("ftSugdel(args).await()"))
+@Deprecated(message = "Instead use ftSugdel returning a future and chain with coAwait()", replaceWith = ReplaceWith("ftSugdel(args).coAwait()"))
 suspend fun RedisAPI.ftSugdelAwait(args: List<String>): Response? {
   return awaitResult {
     this.ftSugdel(args, it)
@@ -432,7 +432,7 @@ suspend fun RedisAPI.ftSugdelAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use ftSugget returning a future and chain with await()", replaceWith = ReplaceWith("ftSugget(args).await()"))
+@Deprecated(message = "Instead use ftSugget returning a future and chain with coAwait()", replaceWith = ReplaceWith("ftSugget(args).coAwait()"))
 suspend fun RedisAPI.ftSuggetAwait(args: List<String>): Response? {
   return awaitResult {
     this.ftSugget(args, it)
@@ -447,7 +447,7 @@ suspend fun RedisAPI.ftSuggetAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use ftSuglen returning a future and chain with await()", replaceWith = ReplaceWith("ftSuglen(args).await()"))
+@Deprecated(message = "Instead use ftSuglen returning a future and chain with coAwait()", replaceWith = ReplaceWith("ftSuglen(args).coAwait()"))
 suspend fun RedisAPI.ftSuglenAwait(args: List<String>): Response? {
   return awaitResult {
     this.ftSuglen(args, it)
@@ -462,7 +462,7 @@ suspend fun RedisAPI.ftSuglenAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use ftSynadd returning a future and chain with await()", replaceWith = ReplaceWith("ftSynadd(args).await()"))
+@Deprecated(message = "Instead use ftSynadd returning a future and chain with coAwait()", replaceWith = ReplaceWith("ftSynadd(args).coAwait()"))
 suspend fun RedisAPI.ftSynaddAwait(args: List<String>): Response? {
   return awaitResult {
     this.ftSynadd(args, it)
@@ -477,7 +477,7 @@ suspend fun RedisAPI.ftSynaddAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use ftSyndump returning a future and chain with await()", replaceWith = ReplaceWith("ftSyndump(args).await()"))
+@Deprecated(message = "Instead use ftSyndump returning a future and chain with coAwait()", replaceWith = ReplaceWith("ftSyndump(args).coAwait()"))
 suspend fun RedisAPI.ftSyndumpAwait(args: List<String>): Response? {
   return awaitResult {
     this.ftSyndump(args, it)
@@ -492,7 +492,7 @@ suspend fun RedisAPI.ftSyndumpAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use ftSynupdate returning a future and chain with await()", replaceWith = ReplaceWith("ftSynupdate(args).await()"))
+@Deprecated(message = "Instead use ftSynupdate returning a future and chain with coAwait()", replaceWith = ReplaceWith("ftSynupdate(args).coAwait()"))
 suspend fun RedisAPI.ftSynupdateAwait(args: List<String>): Response? {
   return awaitResult {
     this.ftSynupdate(args, it)
@@ -507,7 +507,7 @@ suspend fun RedisAPI.ftSynupdateAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use ftTagvals returning a future and chain with await()", replaceWith = ReplaceWith("ftTagvals(args).await()"))
+@Deprecated(message = "Instead use ftTagvals returning a future and chain with coAwait()", replaceWith = ReplaceWith("ftTagvals(args).coAwait()"))
 suspend fun RedisAPI.ftTagvalsAwait(args: List<String>): Response? {
   return awaitResult {
     this.ftTagvals(args, it)
@@ -522,7 +522,7 @@ suspend fun RedisAPI.ftTagvalsAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use ftAliasaddifnx returning a future and chain with await()", replaceWith = ReplaceWith("ftAliasaddifnx(args).await()"))
+@Deprecated(message = "Instead use ftAliasaddifnx returning a future and chain with coAwait()", replaceWith = ReplaceWith("ftAliasaddifnx(args).coAwait()"))
 suspend fun RedisAPI.ftAliasaddifnxAwait(args: List<String>): Response? {
   return awaitResult {
     this.ftAliasaddifnx(args, it)
@@ -537,7 +537,7 @@ suspend fun RedisAPI.ftAliasaddifnxAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use ftAliasdelifx returning a future and chain with await()", replaceWith = ReplaceWith("ftAliasdelifx(args).await()"))
+@Deprecated(message = "Instead use ftAliasdelifx returning a future and chain with coAwait()", replaceWith = ReplaceWith("ftAliasdelifx(args).coAwait()"))
 suspend fun RedisAPI.ftAliasdelifxAwait(args: List<String>): Response? {
   return awaitResult {
     this.ftAliasdelifx(args, it)
@@ -552,7 +552,7 @@ suspend fun RedisAPI.ftAliasdelifxAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use ftAlterifnx returning a future and chain with await()", replaceWith = ReplaceWith("ftAlterifnx(args).await()"))
+@Deprecated(message = "Instead use ftAlterifnx returning a future and chain with coAwait()", replaceWith = ReplaceWith("ftAlterifnx(args).coAwait()"))
 suspend fun RedisAPI.ftAlterifnxAwait(args: List<String>): Response? {
   return awaitResult {
     this.ftAlterifnx(args, it)
@@ -567,7 +567,7 @@ suspend fun RedisAPI.ftAlterifnxAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use ftCreateifnx returning a future and chain with await()", replaceWith = ReplaceWith("ftCreateifnx(args).await()"))
+@Deprecated(message = "Instead use ftCreateifnx returning a future and chain with coAwait()", replaceWith = ReplaceWith("ftCreateifnx(args).coAwait()"))
 suspend fun RedisAPI.ftCreateifnxAwait(args: List<String>): Response? {
   return awaitResult {
     this.ftCreateifnx(args, it)
@@ -582,7 +582,7 @@ suspend fun RedisAPI.ftCreateifnxAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use ftDropifx returning a future and chain with await()", replaceWith = ReplaceWith("ftDropifx(args).await()"))
+@Deprecated(message = "Instead use ftDropifx returning a future and chain with coAwait()", replaceWith = ReplaceWith("ftDropifx(args).coAwait()"))
 suspend fun RedisAPI.ftDropifxAwait(args: List<String>): Response? {
   return awaitResult {
     this.ftDropifx(args, it)
@@ -597,7 +597,7 @@ suspend fun RedisAPI.ftDropifxAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use ftDropindexifx returning a future and chain with await()", replaceWith = ReplaceWith("ftDropindexifx(args).await()"))
+@Deprecated(message = "Instead use ftDropindexifx returning a future and chain with coAwait()", replaceWith = ReplaceWith("ftDropindexifx(args).coAwait()"))
 suspend fun RedisAPI.ftDropindexifxAwait(args: List<String>): Response? {
   return awaitResult {
     this.ftDropindexifx(args, it)
@@ -612,7 +612,7 @@ suspend fun RedisAPI.ftDropindexifxAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use ftList returning a future and chain with await()", replaceWith = ReplaceWith("ftList(args).await()"))
+@Deprecated(message = "Instead use ftList returning a future and chain with coAwait()", replaceWith = ReplaceWith("ftList(args).coAwait()"))
 suspend fun RedisAPI.ftListAwait(args: List<String>): Response? {
   return awaitResult {
     this.ftList(args, it)
@@ -627,7 +627,7 @@ suspend fun RedisAPI.ftListAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use acl returning a future and chain with await()", replaceWith = ReplaceWith("acl(args).await()"))
+@Deprecated(message = "Instead use acl returning a future and chain with coAwait()", replaceWith = ReplaceWith("acl(args).coAwait()"))
 suspend fun RedisAPI.aclAwait(args: List<String>): Response? {
   return awaitResult {
     this.acl(args, it)
@@ -643,7 +643,7 @@ suspend fun RedisAPI.aclAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use append returning a future and chain with await()", replaceWith = ReplaceWith("append(arg0, arg1).await()"))
+@Deprecated(message = "Instead use append returning a future and chain with coAwait()", replaceWith = ReplaceWith("append(arg0, arg1).coAwait()"))
 suspend fun RedisAPI.appendAwait(arg0: String, arg1: String): Response? {
   return awaitResult {
     this.append(arg0, arg1, it)
@@ -657,7 +657,7 @@ suspend fun RedisAPI.appendAwait(arg0: String, arg1: String): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use asking returning a future and chain with await()", replaceWith = ReplaceWith("asking().await()"))
+@Deprecated(message = "Instead use asking returning a future and chain with coAwait()", replaceWith = ReplaceWith("asking().coAwait()"))
 suspend fun RedisAPI.askingAwait(): Response? {
   return awaitResult {
     this.asking(it)
@@ -672,7 +672,7 @@ suspend fun RedisAPI.askingAwait(): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use auth returning a future and chain with await()", replaceWith = ReplaceWith("auth(args).await()"))
+@Deprecated(message = "Instead use auth returning a future and chain with coAwait()", replaceWith = ReplaceWith("auth(args).coAwait()"))
 suspend fun RedisAPI.authAwait(args: List<String>): Response? {
   return awaitResult {
     this.auth(args, it)
@@ -687,7 +687,7 @@ suspend fun RedisAPI.authAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use bfAdd returning a future and chain with await()", replaceWith = ReplaceWith("bfAdd(args).await()"))
+@Deprecated(message = "Instead use bfAdd returning a future and chain with coAwait()", replaceWith = ReplaceWith("bfAdd(args).coAwait()"))
 suspend fun RedisAPI.bfAddAwait(args: List<String>): Response? {
   return awaitResult {
     this.bfAdd(args, it)
@@ -702,7 +702,7 @@ suspend fun RedisAPI.bfAddAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use bfCard returning a future and chain with await()", replaceWith = ReplaceWith("bfCard(args).await()"))
+@Deprecated(message = "Instead use bfCard returning a future and chain with coAwait()", replaceWith = ReplaceWith("bfCard(args).coAwait()"))
 suspend fun RedisAPI.bfCardAwait(args: List<String>): Response? {
   return awaitResult {
     this.bfCard(args, it)
@@ -717,7 +717,7 @@ suspend fun RedisAPI.bfCardAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use bfDebug returning a future and chain with await()", replaceWith = ReplaceWith("bfDebug(args).await()"))
+@Deprecated(message = "Instead use bfDebug returning a future and chain with coAwait()", replaceWith = ReplaceWith("bfDebug(args).coAwait()"))
 suspend fun RedisAPI.bfDebugAwait(args: List<String>): Response? {
   return awaitResult {
     this.bfDebug(args, it)
@@ -732,7 +732,7 @@ suspend fun RedisAPI.bfDebugAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use bfExists returning a future and chain with await()", replaceWith = ReplaceWith("bfExists(args).await()"))
+@Deprecated(message = "Instead use bfExists returning a future and chain with coAwait()", replaceWith = ReplaceWith("bfExists(args).coAwait()"))
 suspend fun RedisAPI.bfExistsAwait(args: List<String>): Response? {
   return awaitResult {
     this.bfExists(args, it)
@@ -747,7 +747,7 @@ suspend fun RedisAPI.bfExistsAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use bfInfo returning a future and chain with await()", replaceWith = ReplaceWith("bfInfo(args).await()"))
+@Deprecated(message = "Instead use bfInfo returning a future and chain with coAwait()", replaceWith = ReplaceWith("bfInfo(args).coAwait()"))
 suspend fun RedisAPI.bfInfoAwait(args: List<String>): Response? {
   return awaitResult {
     this.bfInfo(args, it)
@@ -762,7 +762,7 @@ suspend fun RedisAPI.bfInfoAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use bfInsert returning a future and chain with await()", replaceWith = ReplaceWith("bfInsert(args).await()"))
+@Deprecated(message = "Instead use bfInsert returning a future and chain with coAwait()", replaceWith = ReplaceWith("bfInsert(args).coAwait()"))
 suspend fun RedisAPI.bfInsertAwait(args: List<String>): Response? {
   return awaitResult {
     this.bfInsert(args, it)
@@ -777,7 +777,7 @@ suspend fun RedisAPI.bfInsertAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use bfLoadchunk returning a future and chain with await()", replaceWith = ReplaceWith("bfLoadchunk(args).await()"))
+@Deprecated(message = "Instead use bfLoadchunk returning a future and chain with coAwait()", replaceWith = ReplaceWith("bfLoadchunk(args).coAwait()"))
 suspend fun RedisAPI.bfLoadchunkAwait(args: List<String>): Response? {
   return awaitResult {
     this.bfLoadchunk(args, it)
@@ -792,7 +792,7 @@ suspend fun RedisAPI.bfLoadchunkAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use bfMadd returning a future and chain with await()", replaceWith = ReplaceWith("bfMadd(args).await()"))
+@Deprecated(message = "Instead use bfMadd returning a future and chain with coAwait()", replaceWith = ReplaceWith("bfMadd(args).coAwait()"))
 suspend fun RedisAPI.bfMaddAwait(args: List<String>): Response? {
   return awaitResult {
     this.bfMadd(args, it)
@@ -807,7 +807,7 @@ suspend fun RedisAPI.bfMaddAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use bfMexists returning a future and chain with await()", replaceWith = ReplaceWith("bfMexists(args).await()"))
+@Deprecated(message = "Instead use bfMexists returning a future and chain with coAwait()", replaceWith = ReplaceWith("bfMexists(args).coAwait()"))
 suspend fun RedisAPI.bfMexistsAwait(args: List<String>): Response? {
   return awaitResult {
     this.bfMexists(args, it)
@@ -822,7 +822,7 @@ suspend fun RedisAPI.bfMexistsAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use bfReserve returning a future and chain with await()", replaceWith = ReplaceWith("bfReserve(args).await()"))
+@Deprecated(message = "Instead use bfReserve returning a future and chain with coAwait()", replaceWith = ReplaceWith("bfReserve(args).coAwait()"))
 suspend fun RedisAPI.bfReserveAwait(args: List<String>): Response? {
   return awaitResult {
     this.bfReserve(args, it)
@@ -837,7 +837,7 @@ suspend fun RedisAPI.bfReserveAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use bfScandump returning a future and chain with await()", replaceWith = ReplaceWith("bfScandump(args).await()"))
+@Deprecated(message = "Instead use bfScandump returning a future and chain with coAwait()", replaceWith = ReplaceWith("bfScandump(args).coAwait()"))
 suspend fun RedisAPI.bfScandumpAwait(args: List<String>): Response? {
   return awaitResult {
     this.bfScandump(args, it)
@@ -851,7 +851,7 @@ suspend fun RedisAPI.bfScandumpAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use bgrewriteaof returning a future and chain with await()", replaceWith = ReplaceWith("bgrewriteaof().await()"))
+@Deprecated(message = "Instead use bgrewriteaof returning a future and chain with coAwait()", replaceWith = ReplaceWith("bgrewriteaof().coAwait()"))
 suspend fun RedisAPI.bgrewriteaofAwait(): Response? {
   return awaitResult {
     this.bgrewriteaof(it)
@@ -866,7 +866,7 @@ suspend fun RedisAPI.bgrewriteaofAwait(): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use bgsave returning a future and chain with await()", replaceWith = ReplaceWith("bgsave(args).await()"))
+@Deprecated(message = "Instead use bgsave returning a future and chain with coAwait()", replaceWith = ReplaceWith("bgsave(args).coAwait()"))
 suspend fun RedisAPI.bgsaveAwait(args: List<String>): Response? {
   return awaitResult {
     this.bgsave(args, it)
@@ -881,7 +881,7 @@ suspend fun RedisAPI.bgsaveAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use bitcount returning a future and chain with await()", replaceWith = ReplaceWith("bitcount(args).await()"))
+@Deprecated(message = "Instead use bitcount returning a future and chain with coAwait()", replaceWith = ReplaceWith("bitcount(args).coAwait()"))
 suspend fun RedisAPI.bitcountAwait(args: List<String>): Response? {
   return awaitResult {
     this.bitcount(args, it)
@@ -896,7 +896,7 @@ suspend fun RedisAPI.bitcountAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use bitfield returning a future and chain with await()", replaceWith = ReplaceWith("bitfield(args).await()"))
+@Deprecated(message = "Instead use bitfield returning a future and chain with coAwait()", replaceWith = ReplaceWith("bitfield(args).coAwait()"))
 suspend fun RedisAPI.bitfieldAwait(args: List<String>): Response? {
   return awaitResult {
     this.bitfield(args, it)
@@ -911,7 +911,7 @@ suspend fun RedisAPI.bitfieldAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use bitfieldRo returning a future and chain with await()", replaceWith = ReplaceWith("bitfieldRo(args).await()"))
+@Deprecated(message = "Instead use bitfieldRo returning a future and chain with coAwait()", replaceWith = ReplaceWith("bitfieldRo(args).coAwait()"))
 suspend fun RedisAPI.bitfieldRoAwait(args: List<String>): Response? {
   return awaitResult {
     this.bitfieldRo(args, it)
@@ -926,7 +926,7 @@ suspend fun RedisAPI.bitfieldRoAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use bitop returning a future and chain with await()", replaceWith = ReplaceWith("bitop(args).await()"))
+@Deprecated(message = "Instead use bitop returning a future and chain with coAwait()", replaceWith = ReplaceWith("bitop(args).coAwait()"))
 suspend fun RedisAPI.bitopAwait(args: List<String>): Response? {
   return awaitResult {
     this.bitop(args, it)
@@ -941,7 +941,7 @@ suspend fun RedisAPI.bitopAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use bitpos returning a future and chain with await()", replaceWith = ReplaceWith("bitpos(args).await()"))
+@Deprecated(message = "Instead use bitpos returning a future and chain with coAwait()", replaceWith = ReplaceWith("bitpos(args).coAwait()"))
 suspend fun RedisAPI.bitposAwait(args: List<String>): Response? {
   return awaitResult {
     this.bitpos(args, it)
@@ -960,7 +960,7 @@ suspend fun RedisAPI.bitposAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use blmove returning a future and chain with await()", replaceWith = ReplaceWith("blmove(arg0, arg1, arg2, arg3, arg4).await()"))
+@Deprecated(message = "Instead use blmove returning a future and chain with coAwait()", replaceWith = ReplaceWith("blmove(arg0, arg1, arg2, arg3, arg4).coAwait()"))
 suspend fun RedisAPI.blmoveAwait(arg0: String, arg1: String, arg2: String, arg3: String, arg4: String): Response? {
   return awaitResult {
     this.blmove(arg0, arg1, arg2, arg3, arg4, it)
@@ -975,7 +975,7 @@ suspend fun RedisAPI.blmoveAwait(arg0: String, arg1: String, arg2: String, arg3:
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use blmpop returning a future and chain with await()", replaceWith = ReplaceWith("blmpop(args).await()"))
+@Deprecated(message = "Instead use blmpop returning a future and chain with coAwait()", replaceWith = ReplaceWith("blmpop(args).coAwait()"))
 suspend fun RedisAPI.blmpopAwait(args: List<String>): Response? {
   return awaitResult {
     this.blmpop(args, it)
@@ -990,7 +990,7 @@ suspend fun RedisAPI.blmpopAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use blpop returning a future and chain with await()", replaceWith = ReplaceWith("blpop(args).await()"))
+@Deprecated(message = "Instead use blpop returning a future and chain with coAwait()", replaceWith = ReplaceWith("blpop(args).coAwait()"))
 suspend fun RedisAPI.blpopAwait(args: List<String>): Response? {
   return awaitResult {
     this.blpop(args, it)
@@ -1005,7 +1005,7 @@ suspend fun RedisAPI.blpopAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use brpop returning a future and chain with await()", replaceWith = ReplaceWith("brpop(args).await()"))
+@Deprecated(message = "Instead use brpop returning a future and chain with coAwait()", replaceWith = ReplaceWith("brpop(args).coAwait()"))
 suspend fun RedisAPI.brpopAwait(args: List<String>): Response? {
   return awaitResult {
     this.brpop(args, it)
@@ -1022,7 +1022,7 @@ suspend fun RedisAPI.brpopAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use brpoplpush returning a future and chain with await()", replaceWith = ReplaceWith("brpoplpush(arg0, arg1, arg2).await()"))
+@Deprecated(message = "Instead use brpoplpush returning a future and chain with coAwait()", replaceWith = ReplaceWith("brpoplpush(arg0, arg1, arg2).coAwait()"))
 suspend fun RedisAPI.brpoplpushAwait(arg0: String, arg1: String, arg2: String): Response? {
   return awaitResult {
     this.brpoplpush(arg0, arg1, arg2, it)
@@ -1037,7 +1037,7 @@ suspend fun RedisAPI.brpoplpushAwait(arg0: String, arg1: String, arg2: String): 
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use bzmpop returning a future and chain with await()", replaceWith = ReplaceWith("bzmpop(args).await()"))
+@Deprecated(message = "Instead use bzmpop returning a future and chain with coAwait()", replaceWith = ReplaceWith("bzmpop(args).coAwait()"))
 suspend fun RedisAPI.bzmpopAwait(args: List<String>): Response? {
   return awaitResult {
     this.bzmpop(args, it)
@@ -1052,7 +1052,7 @@ suspend fun RedisAPI.bzmpopAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use bzpopmax returning a future and chain with await()", replaceWith = ReplaceWith("bzpopmax(args).await()"))
+@Deprecated(message = "Instead use bzpopmax returning a future and chain with coAwait()", replaceWith = ReplaceWith("bzpopmax(args).coAwait()"))
 suspend fun RedisAPI.bzpopmaxAwait(args: List<String>): Response? {
   return awaitResult {
     this.bzpopmax(args, it)
@@ -1067,7 +1067,7 @@ suspend fun RedisAPI.bzpopmaxAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use bzpopmin returning a future and chain with await()", replaceWith = ReplaceWith("bzpopmin(args).await()"))
+@Deprecated(message = "Instead use bzpopmin returning a future and chain with coAwait()", replaceWith = ReplaceWith("bzpopmin(args).coAwait()"))
 suspend fun RedisAPI.bzpopminAwait(args: List<String>): Response? {
   return awaitResult {
     this.bzpopmin(args, it)
@@ -1082,7 +1082,7 @@ suspend fun RedisAPI.bzpopminAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use cfAdd returning a future and chain with await()", replaceWith = ReplaceWith("cfAdd(args).await()"))
+@Deprecated(message = "Instead use cfAdd returning a future and chain with coAwait()", replaceWith = ReplaceWith("cfAdd(args).coAwait()"))
 suspend fun RedisAPI.cfAddAwait(args: List<String>): Response? {
   return awaitResult {
     this.cfAdd(args, it)
@@ -1097,7 +1097,7 @@ suspend fun RedisAPI.cfAddAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use cfAddnx returning a future and chain with await()", replaceWith = ReplaceWith("cfAddnx(args).await()"))
+@Deprecated(message = "Instead use cfAddnx returning a future and chain with coAwait()", replaceWith = ReplaceWith("cfAddnx(args).coAwait()"))
 suspend fun RedisAPI.cfAddnxAwait(args: List<String>): Response? {
   return awaitResult {
     this.cfAddnx(args, it)
@@ -1112,7 +1112,7 @@ suspend fun RedisAPI.cfAddnxAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use cfCompact returning a future and chain with await()", replaceWith = ReplaceWith("cfCompact(args).await()"))
+@Deprecated(message = "Instead use cfCompact returning a future and chain with coAwait()", replaceWith = ReplaceWith("cfCompact(args).coAwait()"))
 suspend fun RedisAPI.cfCompactAwait(args: List<String>): Response? {
   return awaitResult {
     this.cfCompact(args, it)
@@ -1127,7 +1127,7 @@ suspend fun RedisAPI.cfCompactAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use cfCount returning a future and chain with await()", replaceWith = ReplaceWith("cfCount(args).await()"))
+@Deprecated(message = "Instead use cfCount returning a future and chain with coAwait()", replaceWith = ReplaceWith("cfCount(args).coAwait()"))
 suspend fun RedisAPI.cfCountAwait(args: List<String>): Response? {
   return awaitResult {
     this.cfCount(args, it)
@@ -1142,7 +1142,7 @@ suspend fun RedisAPI.cfCountAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use cfDebug returning a future and chain with await()", replaceWith = ReplaceWith("cfDebug(args).await()"))
+@Deprecated(message = "Instead use cfDebug returning a future and chain with coAwait()", replaceWith = ReplaceWith("cfDebug(args).coAwait()"))
 suspend fun RedisAPI.cfDebugAwait(args: List<String>): Response? {
   return awaitResult {
     this.cfDebug(args, it)
@@ -1157,7 +1157,7 @@ suspend fun RedisAPI.cfDebugAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use cfDel returning a future and chain with await()", replaceWith = ReplaceWith("cfDel(args).await()"))
+@Deprecated(message = "Instead use cfDel returning a future and chain with coAwait()", replaceWith = ReplaceWith("cfDel(args).coAwait()"))
 suspend fun RedisAPI.cfDelAwait(args: List<String>): Response? {
   return awaitResult {
     this.cfDel(args, it)
@@ -1172,7 +1172,7 @@ suspend fun RedisAPI.cfDelAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use cfExists returning a future and chain with await()", replaceWith = ReplaceWith("cfExists(args).await()"))
+@Deprecated(message = "Instead use cfExists returning a future and chain with coAwait()", replaceWith = ReplaceWith("cfExists(args).coAwait()"))
 suspend fun RedisAPI.cfExistsAwait(args: List<String>): Response? {
   return awaitResult {
     this.cfExists(args, it)
@@ -1187,7 +1187,7 @@ suspend fun RedisAPI.cfExistsAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use cfInfo returning a future and chain with await()", replaceWith = ReplaceWith("cfInfo(args).await()"))
+@Deprecated(message = "Instead use cfInfo returning a future and chain with coAwait()", replaceWith = ReplaceWith("cfInfo(args).coAwait()"))
 suspend fun RedisAPI.cfInfoAwait(args: List<String>): Response? {
   return awaitResult {
     this.cfInfo(args, it)
@@ -1202,7 +1202,7 @@ suspend fun RedisAPI.cfInfoAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use cfInsert returning a future and chain with await()", replaceWith = ReplaceWith("cfInsert(args).await()"))
+@Deprecated(message = "Instead use cfInsert returning a future and chain with coAwait()", replaceWith = ReplaceWith("cfInsert(args).coAwait()"))
 suspend fun RedisAPI.cfInsertAwait(args: List<String>): Response? {
   return awaitResult {
     this.cfInsert(args, it)
@@ -1217,7 +1217,7 @@ suspend fun RedisAPI.cfInsertAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use cfInsertnx returning a future and chain with await()", replaceWith = ReplaceWith("cfInsertnx(args).await()"))
+@Deprecated(message = "Instead use cfInsertnx returning a future and chain with coAwait()", replaceWith = ReplaceWith("cfInsertnx(args).coAwait()"))
 suspend fun RedisAPI.cfInsertnxAwait(args: List<String>): Response? {
   return awaitResult {
     this.cfInsertnx(args, it)
@@ -1232,7 +1232,7 @@ suspend fun RedisAPI.cfInsertnxAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use cfLoadchunk returning a future and chain with await()", replaceWith = ReplaceWith("cfLoadchunk(args).await()"))
+@Deprecated(message = "Instead use cfLoadchunk returning a future and chain with coAwait()", replaceWith = ReplaceWith("cfLoadchunk(args).coAwait()"))
 suspend fun RedisAPI.cfLoadchunkAwait(args: List<String>): Response? {
   return awaitResult {
     this.cfLoadchunk(args, it)
@@ -1247,7 +1247,7 @@ suspend fun RedisAPI.cfLoadchunkAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use cfMexists returning a future and chain with await()", replaceWith = ReplaceWith("cfMexists(args).await()"))
+@Deprecated(message = "Instead use cfMexists returning a future and chain with coAwait()", replaceWith = ReplaceWith("cfMexists(args).coAwait()"))
 suspend fun RedisAPI.cfMexistsAwait(args: List<String>): Response? {
   return awaitResult {
     this.cfMexists(args, it)
@@ -1262,7 +1262,7 @@ suspend fun RedisAPI.cfMexistsAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use cfReserve returning a future and chain with await()", replaceWith = ReplaceWith("cfReserve(args).await()"))
+@Deprecated(message = "Instead use cfReserve returning a future and chain with coAwait()", replaceWith = ReplaceWith("cfReserve(args).coAwait()"))
 suspend fun RedisAPI.cfReserveAwait(args: List<String>): Response? {
   return awaitResult {
     this.cfReserve(args, it)
@@ -1277,7 +1277,7 @@ suspend fun RedisAPI.cfReserveAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use cfScandump returning a future and chain with await()", replaceWith = ReplaceWith("cfScandump(args).await()"))
+@Deprecated(message = "Instead use cfScandump returning a future and chain with coAwait()", replaceWith = ReplaceWith("cfScandump(args).coAwait()"))
 suspend fun RedisAPI.cfScandumpAwait(args: List<String>): Response? {
   return awaitResult {
     this.cfScandump(args, it)
@@ -1292,7 +1292,7 @@ suspend fun RedisAPI.cfScandumpAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use client returning a future and chain with await()", replaceWith = ReplaceWith("client(args).await()"))
+@Deprecated(message = "Instead use client returning a future and chain with coAwait()", replaceWith = ReplaceWith("client(args).coAwait()"))
 suspend fun RedisAPI.clientAwait(args: List<String>): Response? {
   return awaitResult {
     this.client(args, it)
@@ -1307,7 +1307,7 @@ suspend fun RedisAPI.clientAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use cluster returning a future and chain with await()", replaceWith = ReplaceWith("cluster(args).await()"))
+@Deprecated(message = "Instead use cluster returning a future and chain with coAwait()", replaceWith = ReplaceWith("cluster(args).coAwait()"))
 suspend fun RedisAPI.clusterAwait(args: List<String>): Response? {
   return awaitResult {
     this.cluster(args, it)
@@ -1322,7 +1322,7 @@ suspend fun RedisAPI.clusterAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use cmsIncrby returning a future and chain with await()", replaceWith = ReplaceWith("cmsIncrby(args).await()"))
+@Deprecated(message = "Instead use cmsIncrby returning a future and chain with coAwait()", replaceWith = ReplaceWith("cmsIncrby(args).coAwait()"))
 suspend fun RedisAPI.cmsIncrbyAwait(args: List<String>): Response? {
   return awaitResult {
     this.cmsIncrby(args, it)
@@ -1337,7 +1337,7 @@ suspend fun RedisAPI.cmsIncrbyAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use cmsInfo returning a future and chain with await()", replaceWith = ReplaceWith("cmsInfo(args).await()"))
+@Deprecated(message = "Instead use cmsInfo returning a future and chain with coAwait()", replaceWith = ReplaceWith("cmsInfo(args).coAwait()"))
 suspend fun RedisAPI.cmsInfoAwait(args: List<String>): Response? {
   return awaitResult {
     this.cmsInfo(args, it)
@@ -1352,7 +1352,7 @@ suspend fun RedisAPI.cmsInfoAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use cmsInitbydim returning a future and chain with await()", replaceWith = ReplaceWith("cmsInitbydim(args).await()"))
+@Deprecated(message = "Instead use cmsInitbydim returning a future and chain with coAwait()", replaceWith = ReplaceWith("cmsInitbydim(args).coAwait()"))
 suspend fun RedisAPI.cmsInitbydimAwait(args: List<String>): Response? {
   return awaitResult {
     this.cmsInitbydim(args, it)
@@ -1367,7 +1367,7 @@ suspend fun RedisAPI.cmsInitbydimAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use cmsInitbyprob returning a future and chain with await()", replaceWith = ReplaceWith("cmsInitbyprob(args).await()"))
+@Deprecated(message = "Instead use cmsInitbyprob returning a future and chain with coAwait()", replaceWith = ReplaceWith("cmsInitbyprob(args).coAwait()"))
 suspend fun RedisAPI.cmsInitbyprobAwait(args: List<String>): Response? {
   return awaitResult {
     this.cmsInitbyprob(args, it)
@@ -1382,7 +1382,7 @@ suspend fun RedisAPI.cmsInitbyprobAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use cmsMerge returning a future and chain with await()", replaceWith = ReplaceWith("cmsMerge(args).await()"))
+@Deprecated(message = "Instead use cmsMerge returning a future and chain with coAwait()", replaceWith = ReplaceWith("cmsMerge(args).coAwait()"))
 suspend fun RedisAPI.cmsMergeAwait(args: List<String>): Response? {
   return awaitResult {
     this.cmsMerge(args, it)
@@ -1397,7 +1397,7 @@ suspend fun RedisAPI.cmsMergeAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use cmsQuery returning a future and chain with await()", replaceWith = ReplaceWith("cmsQuery(args).await()"))
+@Deprecated(message = "Instead use cmsQuery returning a future and chain with coAwait()", replaceWith = ReplaceWith("cmsQuery(args).coAwait()"))
 suspend fun RedisAPI.cmsQueryAwait(args: List<String>): Response? {
   return awaitResult {
     this.cmsQuery(args, it)
@@ -1412,7 +1412,7 @@ suspend fun RedisAPI.cmsQueryAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use command returning a future and chain with await()", replaceWith = ReplaceWith("command(args).await()"))
+@Deprecated(message = "Instead use command returning a future and chain with coAwait()", replaceWith = ReplaceWith("command(args).coAwait()"))
 suspend fun RedisAPI.commandAwait(args: List<String>): Response? {
   return awaitResult {
     this.command(args, it)
@@ -1427,7 +1427,7 @@ suspend fun RedisAPI.commandAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use config returning a future and chain with await()", replaceWith = ReplaceWith("config(args).await()"))
+@Deprecated(message = "Instead use config returning a future and chain with coAwait()", replaceWith = ReplaceWith("config(args).coAwait()"))
 suspend fun RedisAPI.configAwait(args: List<String>): Response? {
   return awaitResult {
     this.config(args, it)
@@ -1442,7 +1442,7 @@ suspend fun RedisAPI.configAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use copy returning a future and chain with await()", replaceWith = ReplaceWith("copy(args).await()"))
+@Deprecated(message = "Instead use copy returning a future and chain with coAwait()", replaceWith = ReplaceWith("copy(args).coAwait()"))
 suspend fun RedisAPI.copyAwait(args: List<String>): Response? {
   return awaitResult {
     this.copy(args, it)
@@ -1456,7 +1456,7 @@ suspend fun RedisAPI.copyAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use dbsize returning a future and chain with await()", replaceWith = ReplaceWith("dbsize().await()"))
+@Deprecated(message = "Instead use dbsize returning a future and chain with coAwait()", replaceWith = ReplaceWith("dbsize().coAwait()"))
 suspend fun RedisAPI.dbsizeAwait(): Response? {
   return awaitResult {
     this.dbsize(it)
@@ -1471,7 +1471,7 @@ suspend fun RedisAPI.dbsizeAwait(): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use debug returning a future and chain with await()", replaceWith = ReplaceWith("debug(args).await()"))
+@Deprecated(message = "Instead use debug returning a future and chain with coAwait()", replaceWith = ReplaceWith("debug(args).coAwait()"))
 suspend fun RedisAPI.debugAwait(args: List<String>): Response? {
   return awaitResult {
     this.debug(args, it)
@@ -1486,7 +1486,7 @@ suspend fun RedisAPI.debugAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use decr returning a future and chain with await()", replaceWith = ReplaceWith("decr(arg0).await()"))
+@Deprecated(message = "Instead use decr returning a future and chain with coAwait()", replaceWith = ReplaceWith("decr(arg0).coAwait()"))
 suspend fun RedisAPI.decrAwait(arg0: String): Response? {
   return awaitResult {
     this.decr(arg0, it)
@@ -1502,7 +1502,7 @@ suspend fun RedisAPI.decrAwait(arg0: String): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use decrby returning a future and chain with await()", replaceWith = ReplaceWith("decrby(arg0, arg1).await()"))
+@Deprecated(message = "Instead use decrby returning a future and chain with coAwait()", replaceWith = ReplaceWith("decrby(arg0, arg1).coAwait()"))
 suspend fun RedisAPI.decrbyAwait(arg0: String, arg1: String): Response? {
   return awaitResult {
     this.decrby(arg0, arg1, it)
@@ -1517,7 +1517,7 @@ suspend fun RedisAPI.decrbyAwait(arg0: String, arg1: String): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use del returning a future and chain with await()", replaceWith = ReplaceWith("del(args).await()"))
+@Deprecated(message = "Instead use del returning a future and chain with coAwait()", replaceWith = ReplaceWith("del(args).coAwait()"))
 suspend fun RedisAPI.delAwait(args: List<String>): Response? {
   return awaitResult {
     this.del(args, it)
@@ -1531,7 +1531,7 @@ suspend fun RedisAPI.delAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use discard returning a future and chain with await()", replaceWith = ReplaceWith("discard().await()"))
+@Deprecated(message = "Instead use discard returning a future and chain with coAwait()", replaceWith = ReplaceWith("discard().coAwait()"))
 suspend fun RedisAPI.discardAwait(): Response? {
   return awaitResult {
     this.discard(it)
@@ -1546,7 +1546,7 @@ suspend fun RedisAPI.discardAwait(): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use dump returning a future and chain with await()", replaceWith = ReplaceWith("dump(arg0).await()"))
+@Deprecated(message = "Instead use dump returning a future and chain with coAwait()", replaceWith = ReplaceWith("dump(arg0).coAwait()"))
 suspend fun RedisAPI.dumpAwait(arg0: String): Response? {
   return awaitResult {
     this.dump(arg0, it)
@@ -1561,7 +1561,7 @@ suspend fun RedisAPI.dumpAwait(arg0: String): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use echo returning a future and chain with await()", replaceWith = ReplaceWith("echo(arg0).await()"))
+@Deprecated(message = "Instead use echo returning a future and chain with coAwait()", replaceWith = ReplaceWith("echo(arg0).coAwait()"))
 suspend fun RedisAPI.echoAwait(arg0: String): Response? {
   return awaitResult {
     this.echo(arg0, it)
@@ -1576,7 +1576,7 @@ suspend fun RedisAPI.echoAwait(arg0: String): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use eval returning a future and chain with await()", replaceWith = ReplaceWith("eval(args).await()"))
+@Deprecated(message = "Instead use eval returning a future and chain with coAwait()", replaceWith = ReplaceWith("eval(args).coAwait()"))
 suspend fun RedisAPI.evalAwait(args: List<String>): Response? {
   return awaitResult {
     this.eval(args, it)
@@ -1591,7 +1591,7 @@ suspend fun RedisAPI.evalAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use evalRo returning a future and chain with await()", replaceWith = ReplaceWith("evalRo(args).await()"))
+@Deprecated(message = "Instead use evalRo returning a future and chain with coAwait()", replaceWith = ReplaceWith("evalRo(args).coAwait()"))
 suspend fun RedisAPI.evalRoAwait(args: List<String>): Response? {
   return awaitResult {
     this.evalRo(args, it)
@@ -1606,7 +1606,7 @@ suspend fun RedisAPI.evalRoAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use evalsha returning a future and chain with await()", replaceWith = ReplaceWith("evalsha(args).await()"))
+@Deprecated(message = "Instead use evalsha returning a future and chain with coAwait()", replaceWith = ReplaceWith("evalsha(args).coAwait()"))
 suspend fun RedisAPI.evalshaAwait(args: List<String>): Response? {
   return awaitResult {
     this.evalsha(args, it)
@@ -1621,7 +1621,7 @@ suspend fun RedisAPI.evalshaAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use evalshaRo returning a future and chain with await()", replaceWith = ReplaceWith("evalshaRo(args).await()"))
+@Deprecated(message = "Instead use evalshaRo returning a future and chain with coAwait()", replaceWith = ReplaceWith("evalshaRo(args).coAwait()"))
 suspend fun RedisAPI.evalshaRoAwait(args: List<String>): Response? {
   return awaitResult {
     this.evalshaRo(args, it)
@@ -1635,7 +1635,7 @@ suspend fun RedisAPI.evalshaRoAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use exec returning a future and chain with await()", replaceWith = ReplaceWith("exec().await()"))
+@Deprecated(message = "Instead use exec returning a future and chain with coAwait()", replaceWith = ReplaceWith("exec().coAwait()"))
 suspend fun RedisAPI.execAwait(): Response? {
   return awaitResult {
     this.exec(it)
@@ -1650,7 +1650,7 @@ suspend fun RedisAPI.execAwait(): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use exists returning a future and chain with await()", replaceWith = ReplaceWith("exists(args).await()"))
+@Deprecated(message = "Instead use exists returning a future and chain with coAwait()", replaceWith = ReplaceWith("exists(args).coAwait()"))
 suspend fun RedisAPI.existsAwait(args: List<String>): Response? {
   return awaitResult {
     this.exists(args, it)
@@ -1665,7 +1665,7 @@ suspend fun RedisAPI.existsAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use expire returning a future and chain with await()", replaceWith = ReplaceWith("expire(args).await()"))
+@Deprecated(message = "Instead use expire returning a future and chain with coAwait()", replaceWith = ReplaceWith("expire(args).coAwait()"))
 suspend fun RedisAPI.expireAwait(args: List<String>): Response? {
   return awaitResult {
     this.expire(args, it)
@@ -1680,7 +1680,7 @@ suspend fun RedisAPI.expireAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use expireat returning a future and chain with await()", replaceWith = ReplaceWith("expireat(args).await()"))
+@Deprecated(message = "Instead use expireat returning a future and chain with coAwait()", replaceWith = ReplaceWith("expireat(args).coAwait()"))
 suspend fun RedisAPI.expireatAwait(args: List<String>): Response? {
   return awaitResult {
     this.expireat(args, it)
@@ -1695,7 +1695,7 @@ suspend fun RedisAPI.expireatAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use expiretime returning a future and chain with await()", replaceWith = ReplaceWith("expiretime(arg0).await()"))
+@Deprecated(message = "Instead use expiretime returning a future and chain with coAwait()", replaceWith = ReplaceWith("expiretime(arg0).coAwait()"))
 suspend fun RedisAPI.expiretimeAwait(arg0: String): Response? {
   return awaitResult {
     this.expiretime(arg0, it)
@@ -1710,7 +1710,7 @@ suspend fun RedisAPI.expiretimeAwait(arg0: String): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use failover returning a future and chain with await()", replaceWith = ReplaceWith("failover(args).await()"))
+@Deprecated(message = "Instead use failover returning a future and chain with coAwait()", replaceWith = ReplaceWith("failover(args).coAwait()"))
 suspend fun RedisAPI.failoverAwait(args: List<String>): Response? {
   return awaitResult {
     this.failover(args, it)
@@ -1725,7 +1725,7 @@ suspend fun RedisAPI.failoverAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use fcall returning a future and chain with await()", replaceWith = ReplaceWith("fcall(args).await()"))
+@Deprecated(message = "Instead use fcall returning a future and chain with coAwait()", replaceWith = ReplaceWith("fcall(args).coAwait()"))
 suspend fun RedisAPI.fcallAwait(args: List<String>): Response? {
   return awaitResult {
     this.fcall(args, it)
@@ -1740,7 +1740,7 @@ suspend fun RedisAPI.fcallAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use fcallRo returning a future and chain with await()", replaceWith = ReplaceWith("fcallRo(args).await()"))
+@Deprecated(message = "Instead use fcallRo returning a future and chain with coAwait()", replaceWith = ReplaceWith("fcallRo(args).coAwait()"))
 suspend fun RedisAPI.fcallRoAwait(args: List<String>): Response? {
   return awaitResult {
     this.fcallRo(args, it)
@@ -1755,7 +1755,7 @@ suspend fun RedisAPI.fcallRoAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use flushall returning a future and chain with await()", replaceWith = ReplaceWith("flushall(args).await()"))
+@Deprecated(message = "Instead use flushall returning a future and chain with coAwait()", replaceWith = ReplaceWith("flushall(args).coAwait()"))
 suspend fun RedisAPI.flushallAwait(args: List<String>): Response? {
   return awaitResult {
     this.flushall(args, it)
@@ -1770,7 +1770,7 @@ suspend fun RedisAPI.flushallAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use flushdb returning a future and chain with await()", replaceWith = ReplaceWith("flushdb(args).await()"))
+@Deprecated(message = "Instead use flushdb returning a future and chain with coAwait()", replaceWith = ReplaceWith("flushdb(args).coAwait()"))
 suspend fun RedisAPI.flushdbAwait(args: List<String>): Response? {
   return awaitResult {
     this.flushdb(args, it)
@@ -1785,7 +1785,7 @@ suspend fun RedisAPI.flushdbAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use function returning a future and chain with await()", replaceWith = ReplaceWith("function(args).await()"))
+@Deprecated(message = "Instead use function returning a future and chain with coAwait()", replaceWith = ReplaceWith("function(args).coAwait()"))
 suspend fun RedisAPI.functionAwait(args: List<String>): Response? {
   return awaitResult {
     this.function(args, it)
@@ -1800,7 +1800,7 @@ suspend fun RedisAPI.functionAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use geoadd returning a future and chain with await()", replaceWith = ReplaceWith("geoadd(args).await()"))
+@Deprecated(message = "Instead use geoadd returning a future and chain with coAwait()", replaceWith = ReplaceWith("geoadd(args).coAwait()"))
 suspend fun RedisAPI.geoaddAwait(args: List<String>): Response? {
   return awaitResult {
     this.geoadd(args, it)
@@ -1815,7 +1815,7 @@ suspend fun RedisAPI.geoaddAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use geodist returning a future and chain with await()", replaceWith = ReplaceWith("geodist(args).await()"))
+@Deprecated(message = "Instead use geodist returning a future and chain with coAwait()", replaceWith = ReplaceWith("geodist(args).coAwait()"))
 suspend fun RedisAPI.geodistAwait(args: List<String>): Response? {
   return awaitResult {
     this.geodist(args, it)
@@ -1830,7 +1830,7 @@ suspend fun RedisAPI.geodistAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use geohash returning a future and chain with await()", replaceWith = ReplaceWith("geohash(args).await()"))
+@Deprecated(message = "Instead use geohash returning a future and chain with coAwait()", replaceWith = ReplaceWith("geohash(args).coAwait()"))
 suspend fun RedisAPI.geohashAwait(args: List<String>): Response? {
   return awaitResult {
     this.geohash(args, it)
@@ -1845,7 +1845,7 @@ suspend fun RedisAPI.geohashAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use geopos returning a future and chain with await()", replaceWith = ReplaceWith("geopos(args).await()"))
+@Deprecated(message = "Instead use geopos returning a future and chain with coAwait()", replaceWith = ReplaceWith("geopos(args).coAwait()"))
 suspend fun RedisAPI.geoposAwait(args: List<String>): Response? {
   return awaitResult {
     this.geopos(args, it)
@@ -1860,7 +1860,7 @@ suspend fun RedisAPI.geoposAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use georadius returning a future and chain with await()", replaceWith = ReplaceWith("georadius(args).await()"))
+@Deprecated(message = "Instead use georadius returning a future and chain with coAwait()", replaceWith = ReplaceWith("georadius(args).coAwait()"))
 suspend fun RedisAPI.georadiusAwait(args: List<String>): Response? {
   return awaitResult {
     this.georadius(args, it)
@@ -1875,7 +1875,7 @@ suspend fun RedisAPI.georadiusAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use georadiusRo returning a future and chain with await()", replaceWith = ReplaceWith("georadiusRo(args).await()"))
+@Deprecated(message = "Instead use georadiusRo returning a future and chain with coAwait()", replaceWith = ReplaceWith("georadiusRo(args).coAwait()"))
 suspend fun RedisAPI.georadiusRoAwait(args: List<String>): Response? {
   return awaitResult {
     this.georadiusRo(args, it)
@@ -1890,7 +1890,7 @@ suspend fun RedisAPI.georadiusRoAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use georadiusbymember returning a future and chain with await()", replaceWith = ReplaceWith("georadiusbymember(args).await()"))
+@Deprecated(message = "Instead use georadiusbymember returning a future and chain with coAwait()", replaceWith = ReplaceWith("georadiusbymember(args).coAwait()"))
 suspend fun RedisAPI.georadiusbymemberAwait(args: List<String>): Response? {
   return awaitResult {
     this.georadiusbymember(args, it)
@@ -1905,7 +1905,7 @@ suspend fun RedisAPI.georadiusbymemberAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use georadiusbymemberRo returning a future and chain with await()", replaceWith = ReplaceWith("georadiusbymemberRo(args).await()"))
+@Deprecated(message = "Instead use georadiusbymemberRo returning a future and chain with coAwait()", replaceWith = ReplaceWith("georadiusbymemberRo(args).coAwait()"))
 suspend fun RedisAPI.georadiusbymemberRoAwait(args: List<String>): Response? {
   return awaitResult {
     this.georadiusbymemberRo(args, it)
@@ -1920,7 +1920,7 @@ suspend fun RedisAPI.georadiusbymemberRoAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use geosearch returning a future and chain with await()", replaceWith = ReplaceWith("geosearch(args).await()"))
+@Deprecated(message = "Instead use geosearch returning a future and chain with coAwait()", replaceWith = ReplaceWith("geosearch(args).coAwait()"))
 suspend fun RedisAPI.geosearchAwait(args: List<String>): Response? {
   return awaitResult {
     this.geosearch(args, it)
@@ -1935,7 +1935,7 @@ suspend fun RedisAPI.geosearchAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use geosearchstore returning a future and chain with await()", replaceWith = ReplaceWith("geosearchstore(args).await()"))
+@Deprecated(message = "Instead use geosearchstore returning a future and chain with coAwait()", replaceWith = ReplaceWith("geosearchstore(args).coAwait()"))
 suspend fun RedisAPI.geosearchstoreAwait(args: List<String>): Response? {
   return awaitResult {
     this.geosearchstore(args, it)
@@ -1950,7 +1950,7 @@ suspend fun RedisAPI.geosearchstoreAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use get returning a future and chain with await()", replaceWith = ReplaceWith("get(arg0).await()"))
+@Deprecated(message = "Instead use get returning a future and chain with coAwait()", replaceWith = ReplaceWith("get(arg0).coAwait()"))
 suspend fun RedisAPI.getAwait(arg0: String): Response? {
   return awaitResult {
     this.get(arg0, it)
@@ -1966,7 +1966,7 @@ suspend fun RedisAPI.getAwait(arg0: String): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use getbit returning a future and chain with await()", replaceWith = ReplaceWith("getbit(arg0, arg1).await()"))
+@Deprecated(message = "Instead use getbit returning a future and chain with coAwait()", replaceWith = ReplaceWith("getbit(arg0, arg1).coAwait()"))
 suspend fun RedisAPI.getbitAwait(arg0: String, arg1: String): Response? {
   return awaitResult {
     this.getbit(arg0, arg1, it)
@@ -1981,7 +1981,7 @@ suspend fun RedisAPI.getbitAwait(arg0: String, arg1: String): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use getdel returning a future and chain with await()", replaceWith = ReplaceWith("getdel(arg0).await()"))
+@Deprecated(message = "Instead use getdel returning a future and chain with coAwait()", replaceWith = ReplaceWith("getdel(arg0).coAwait()"))
 suspend fun RedisAPI.getdelAwait(arg0: String): Response? {
   return awaitResult {
     this.getdel(arg0, it)
@@ -1996,7 +1996,7 @@ suspend fun RedisAPI.getdelAwait(arg0: String): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use getex returning a future and chain with await()", replaceWith = ReplaceWith("getex(args).await()"))
+@Deprecated(message = "Instead use getex returning a future and chain with coAwait()", replaceWith = ReplaceWith("getex(args).coAwait()"))
 suspend fun RedisAPI.getexAwait(args: List<String>): Response? {
   return awaitResult {
     this.getex(args, it)
@@ -2013,7 +2013,7 @@ suspend fun RedisAPI.getexAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use getrange returning a future and chain with await()", replaceWith = ReplaceWith("getrange(arg0, arg1, arg2).await()"))
+@Deprecated(message = "Instead use getrange returning a future and chain with coAwait()", replaceWith = ReplaceWith("getrange(arg0, arg1, arg2).coAwait()"))
 suspend fun RedisAPI.getrangeAwait(arg0: String, arg1: String, arg2: String): Response? {
   return awaitResult {
     this.getrange(arg0, arg1, arg2, it)
@@ -2029,7 +2029,7 @@ suspend fun RedisAPI.getrangeAwait(arg0: String, arg1: String, arg2: String): Re
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use getset returning a future and chain with await()", replaceWith = ReplaceWith("getset(arg0, arg1).await()"))
+@Deprecated(message = "Instead use getset returning a future and chain with coAwait()", replaceWith = ReplaceWith("getset(arg0, arg1).coAwait()"))
 suspend fun RedisAPI.getsetAwait(arg0: String, arg1: String): Response? {
   return awaitResult {
     this.getset(arg0, arg1, it)
@@ -2044,7 +2044,7 @@ suspend fun RedisAPI.getsetAwait(arg0: String, arg1: String): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use graphBulk returning a future and chain with await()", replaceWith = ReplaceWith("graphBulk(args).await()"))
+@Deprecated(message = "Instead use graphBulk returning a future and chain with coAwait()", replaceWith = ReplaceWith("graphBulk(args).coAwait()"))
 suspend fun RedisAPI.graphBulkAwait(args: List<String>): Response? {
   return awaitResult {
     this.graphBulk(args, it)
@@ -2059,7 +2059,7 @@ suspend fun RedisAPI.graphBulkAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use graphConfig returning a future and chain with await()", replaceWith = ReplaceWith("graphConfig(args).await()"))
+@Deprecated(message = "Instead use graphConfig returning a future and chain with coAwait()", replaceWith = ReplaceWith("graphConfig(args).coAwait()"))
 suspend fun RedisAPI.graphConfigAwait(args: List<String>): Response? {
   return awaitResult {
     this.graphConfig(args, it)
@@ -2074,7 +2074,7 @@ suspend fun RedisAPI.graphConfigAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use graphDebug returning a future and chain with await()", replaceWith = ReplaceWith("graphDebug(args).await()"))
+@Deprecated(message = "Instead use graphDebug returning a future and chain with coAwait()", replaceWith = ReplaceWith("graphDebug(args).coAwait()"))
 suspend fun RedisAPI.graphDebugAwait(args: List<String>): Response? {
   return awaitResult {
     this.graphDebug(args, it)
@@ -2089,7 +2089,7 @@ suspend fun RedisAPI.graphDebugAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use graphDelete returning a future and chain with await()", replaceWith = ReplaceWith("graphDelete(args).await()"))
+@Deprecated(message = "Instead use graphDelete returning a future and chain with coAwait()", replaceWith = ReplaceWith("graphDelete(args).coAwait()"))
 suspend fun RedisAPI.graphDeleteAwait(args: List<String>): Response? {
   return awaitResult {
     this.graphDelete(args, it)
@@ -2104,7 +2104,7 @@ suspend fun RedisAPI.graphDeleteAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use graphExplain returning a future and chain with await()", replaceWith = ReplaceWith("graphExplain(args).await()"))
+@Deprecated(message = "Instead use graphExplain returning a future and chain with coAwait()", replaceWith = ReplaceWith("graphExplain(args).coAwait()"))
 suspend fun RedisAPI.graphExplainAwait(args: List<String>): Response? {
   return awaitResult {
     this.graphExplain(args, it)
@@ -2119,7 +2119,7 @@ suspend fun RedisAPI.graphExplainAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use graphList returning a future and chain with await()", replaceWith = ReplaceWith("graphList(args).await()"))
+@Deprecated(message = "Instead use graphList returning a future and chain with coAwait()", replaceWith = ReplaceWith("graphList(args).coAwait()"))
 suspend fun RedisAPI.graphListAwait(args: List<String>): Response? {
   return awaitResult {
     this.graphList(args, it)
@@ -2134,7 +2134,7 @@ suspend fun RedisAPI.graphListAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use graphProfile returning a future and chain with await()", replaceWith = ReplaceWith("graphProfile(args).await()"))
+@Deprecated(message = "Instead use graphProfile returning a future and chain with coAwait()", replaceWith = ReplaceWith("graphProfile(args).coAwait()"))
 suspend fun RedisAPI.graphProfileAwait(args: List<String>): Response? {
   return awaitResult {
     this.graphProfile(args, it)
@@ -2149,7 +2149,7 @@ suspend fun RedisAPI.graphProfileAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use graphQuery returning a future and chain with await()", replaceWith = ReplaceWith("graphQuery(args).await()"))
+@Deprecated(message = "Instead use graphQuery returning a future and chain with coAwait()", replaceWith = ReplaceWith("graphQuery(args).coAwait()"))
 suspend fun RedisAPI.graphQueryAwait(args: List<String>): Response? {
   return awaitResult {
     this.graphQuery(args, it)
@@ -2164,7 +2164,7 @@ suspend fun RedisAPI.graphQueryAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use graphRoQuery returning a future and chain with await()", replaceWith = ReplaceWith("graphRoQuery(args).await()"))
+@Deprecated(message = "Instead use graphRoQuery returning a future and chain with coAwait()", replaceWith = ReplaceWith("graphRoQuery(args).coAwait()"))
 suspend fun RedisAPI.graphRoQueryAwait(args: List<String>): Response? {
   return awaitResult {
     this.graphRoQuery(args, it)
@@ -2179,7 +2179,7 @@ suspend fun RedisAPI.graphRoQueryAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use graphSlowlog returning a future and chain with await()", replaceWith = ReplaceWith("graphSlowlog(args).await()"))
+@Deprecated(message = "Instead use graphSlowlog returning a future and chain with coAwait()", replaceWith = ReplaceWith("graphSlowlog(args).coAwait()"))
 suspend fun RedisAPI.graphSlowlogAwait(args: List<String>): Response? {
   return awaitResult {
     this.graphSlowlog(args, it)
@@ -2194,7 +2194,7 @@ suspend fun RedisAPI.graphSlowlogAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use hdel returning a future and chain with await()", replaceWith = ReplaceWith("hdel(args).await()"))
+@Deprecated(message = "Instead use hdel returning a future and chain with coAwait()", replaceWith = ReplaceWith("hdel(args).coAwait()"))
 suspend fun RedisAPI.hdelAwait(args: List<String>): Response? {
   return awaitResult {
     this.hdel(args, it)
@@ -2209,7 +2209,7 @@ suspend fun RedisAPI.hdelAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use hello returning a future and chain with await()", replaceWith = ReplaceWith("hello(args).await()"))
+@Deprecated(message = "Instead use hello returning a future and chain with coAwait()", replaceWith = ReplaceWith("hello(args).coAwait()"))
 suspend fun RedisAPI.helloAwait(args: List<String>): Response? {
   return awaitResult {
     this.hello(args, it)
@@ -2225,7 +2225,7 @@ suspend fun RedisAPI.helloAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use hexists returning a future and chain with await()", replaceWith = ReplaceWith("hexists(arg0, arg1).await()"))
+@Deprecated(message = "Instead use hexists returning a future and chain with coAwait()", replaceWith = ReplaceWith("hexists(arg0, arg1).coAwait()"))
 suspend fun RedisAPI.hexistsAwait(arg0: String, arg1: String): Response? {
   return awaitResult {
     this.hexists(arg0, arg1, it)
@@ -2241,7 +2241,7 @@ suspend fun RedisAPI.hexistsAwait(arg0: String, arg1: String): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use hget returning a future and chain with await()", replaceWith = ReplaceWith("hget(arg0, arg1).await()"))
+@Deprecated(message = "Instead use hget returning a future and chain with coAwait()", replaceWith = ReplaceWith("hget(arg0, arg1).coAwait()"))
 suspend fun RedisAPI.hgetAwait(arg0: String, arg1: String): Response? {
   return awaitResult {
     this.hget(arg0, arg1, it)
@@ -2256,7 +2256,7 @@ suspend fun RedisAPI.hgetAwait(arg0: String, arg1: String): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use hgetall returning a future and chain with await()", replaceWith = ReplaceWith("hgetall(arg0).await()"))
+@Deprecated(message = "Instead use hgetall returning a future and chain with coAwait()", replaceWith = ReplaceWith("hgetall(arg0).coAwait()"))
 suspend fun RedisAPI.hgetallAwait(arg0: String): Response? {
   return awaitResult {
     this.hgetall(arg0, it)
@@ -2273,7 +2273,7 @@ suspend fun RedisAPI.hgetallAwait(arg0: String): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use hincrby returning a future and chain with await()", replaceWith = ReplaceWith("hincrby(arg0, arg1, arg2).await()"))
+@Deprecated(message = "Instead use hincrby returning a future and chain with coAwait()", replaceWith = ReplaceWith("hincrby(arg0, arg1, arg2).coAwait()"))
 suspend fun RedisAPI.hincrbyAwait(arg0: String, arg1: String, arg2: String): Response? {
   return awaitResult {
     this.hincrby(arg0, arg1, arg2, it)
@@ -2290,7 +2290,7 @@ suspend fun RedisAPI.hincrbyAwait(arg0: String, arg1: String, arg2: String): Res
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use hincrbyfloat returning a future and chain with await()", replaceWith = ReplaceWith("hincrbyfloat(arg0, arg1, arg2).await()"))
+@Deprecated(message = "Instead use hincrbyfloat returning a future and chain with coAwait()", replaceWith = ReplaceWith("hincrbyfloat(arg0, arg1, arg2).coAwait()"))
 suspend fun RedisAPI.hincrbyfloatAwait(arg0: String, arg1: String, arg2: String): Response? {
   return awaitResult {
     this.hincrbyfloat(arg0, arg1, arg2, it)
@@ -2305,7 +2305,7 @@ suspend fun RedisAPI.hincrbyfloatAwait(arg0: String, arg1: String, arg2: String)
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use hkeys returning a future and chain with await()", replaceWith = ReplaceWith("hkeys(arg0).await()"))
+@Deprecated(message = "Instead use hkeys returning a future and chain with coAwait()", replaceWith = ReplaceWith("hkeys(arg0).coAwait()"))
 suspend fun RedisAPI.hkeysAwait(arg0: String): Response? {
   return awaitResult {
     this.hkeys(arg0, it)
@@ -2320,7 +2320,7 @@ suspend fun RedisAPI.hkeysAwait(arg0: String): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use hlen returning a future and chain with await()", replaceWith = ReplaceWith("hlen(arg0).await()"))
+@Deprecated(message = "Instead use hlen returning a future and chain with coAwait()", replaceWith = ReplaceWith("hlen(arg0).coAwait()"))
 suspend fun RedisAPI.hlenAwait(arg0: String): Response? {
   return awaitResult {
     this.hlen(arg0, it)
@@ -2335,7 +2335,7 @@ suspend fun RedisAPI.hlenAwait(arg0: String): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use hmget returning a future and chain with await()", replaceWith = ReplaceWith("hmget(args).await()"))
+@Deprecated(message = "Instead use hmget returning a future and chain with coAwait()", replaceWith = ReplaceWith("hmget(args).coAwait()"))
 suspend fun RedisAPI.hmgetAwait(args: List<String>): Response? {
   return awaitResult {
     this.hmget(args, it)
@@ -2350,7 +2350,7 @@ suspend fun RedisAPI.hmgetAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use hmset returning a future and chain with await()", replaceWith = ReplaceWith("hmset(args).await()"))
+@Deprecated(message = "Instead use hmset returning a future and chain with coAwait()", replaceWith = ReplaceWith("hmset(args).coAwait()"))
 suspend fun RedisAPI.hmsetAwait(args: List<String>): Response? {
   return awaitResult {
     this.hmset(args, it)
@@ -2365,7 +2365,7 @@ suspend fun RedisAPI.hmsetAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use hrandfield returning a future and chain with await()", replaceWith = ReplaceWith("hrandfield(args).await()"))
+@Deprecated(message = "Instead use hrandfield returning a future and chain with coAwait()", replaceWith = ReplaceWith("hrandfield(args).coAwait()"))
 suspend fun RedisAPI.hrandfieldAwait(args: List<String>): Response? {
   return awaitResult {
     this.hrandfield(args, it)
@@ -2380,7 +2380,7 @@ suspend fun RedisAPI.hrandfieldAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use hscan returning a future and chain with await()", replaceWith = ReplaceWith("hscan(args).await()"))
+@Deprecated(message = "Instead use hscan returning a future and chain with coAwait()", replaceWith = ReplaceWith("hscan(args).coAwait()"))
 suspend fun RedisAPI.hscanAwait(args: List<String>): Response? {
   return awaitResult {
     this.hscan(args, it)
@@ -2395,7 +2395,7 @@ suspend fun RedisAPI.hscanAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use hset returning a future and chain with await()", replaceWith = ReplaceWith("hset(args).await()"))
+@Deprecated(message = "Instead use hset returning a future and chain with coAwait()", replaceWith = ReplaceWith("hset(args).coAwait()"))
 suspend fun RedisAPI.hsetAwait(args: List<String>): Response? {
   return awaitResult {
     this.hset(args, it)
@@ -2412,7 +2412,7 @@ suspend fun RedisAPI.hsetAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use hsetnx returning a future and chain with await()", replaceWith = ReplaceWith("hsetnx(arg0, arg1, arg2).await()"))
+@Deprecated(message = "Instead use hsetnx returning a future and chain with coAwait()", replaceWith = ReplaceWith("hsetnx(arg0, arg1, arg2).coAwait()"))
 suspend fun RedisAPI.hsetnxAwait(arg0: String, arg1: String, arg2: String): Response? {
   return awaitResult {
     this.hsetnx(arg0, arg1, arg2, it)
@@ -2428,7 +2428,7 @@ suspend fun RedisAPI.hsetnxAwait(arg0: String, arg1: String, arg2: String): Resp
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use hstrlen returning a future and chain with await()", replaceWith = ReplaceWith("hstrlen(arg0, arg1).await()"))
+@Deprecated(message = "Instead use hstrlen returning a future and chain with coAwait()", replaceWith = ReplaceWith("hstrlen(arg0, arg1).coAwait()"))
 suspend fun RedisAPI.hstrlenAwait(arg0: String, arg1: String): Response? {
   return awaitResult {
     this.hstrlen(arg0, arg1, it)
@@ -2443,7 +2443,7 @@ suspend fun RedisAPI.hstrlenAwait(arg0: String, arg1: String): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use hvals returning a future and chain with await()", replaceWith = ReplaceWith("hvals(arg0).await()"))
+@Deprecated(message = "Instead use hvals returning a future and chain with coAwait()", replaceWith = ReplaceWith("hvals(arg0).coAwait()"))
 suspend fun RedisAPI.hvalsAwait(arg0: String): Response? {
   return awaitResult {
     this.hvals(arg0, it)
@@ -2458,7 +2458,7 @@ suspend fun RedisAPI.hvalsAwait(arg0: String): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use incr returning a future and chain with await()", replaceWith = ReplaceWith("incr(arg0).await()"))
+@Deprecated(message = "Instead use incr returning a future and chain with coAwait()", replaceWith = ReplaceWith("incr(arg0).coAwait()"))
 suspend fun RedisAPI.incrAwait(arg0: String): Response? {
   return awaitResult {
     this.incr(arg0, it)
@@ -2474,7 +2474,7 @@ suspend fun RedisAPI.incrAwait(arg0: String): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use incrby returning a future and chain with await()", replaceWith = ReplaceWith("incrby(arg0, arg1).await()"))
+@Deprecated(message = "Instead use incrby returning a future and chain with coAwait()", replaceWith = ReplaceWith("incrby(arg0, arg1).coAwait()"))
 suspend fun RedisAPI.incrbyAwait(arg0: String, arg1: String): Response? {
   return awaitResult {
     this.incrby(arg0, arg1, it)
@@ -2490,7 +2490,7 @@ suspend fun RedisAPI.incrbyAwait(arg0: String, arg1: String): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use incrbyfloat returning a future and chain with await()", replaceWith = ReplaceWith("incrbyfloat(arg0, arg1).await()"))
+@Deprecated(message = "Instead use incrbyfloat returning a future and chain with coAwait()", replaceWith = ReplaceWith("incrbyfloat(arg0, arg1).coAwait()"))
 suspend fun RedisAPI.incrbyfloatAwait(arg0: String, arg1: String): Response? {
   return awaitResult {
     this.incrbyfloat(arg0, arg1, it)
@@ -2505,7 +2505,7 @@ suspend fun RedisAPI.incrbyfloatAwait(arg0: String, arg1: String): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use info returning a future and chain with await()", replaceWith = ReplaceWith("info(args).await()"))
+@Deprecated(message = "Instead use info returning a future and chain with coAwait()", replaceWith = ReplaceWith("info(args).coAwait()"))
 suspend fun RedisAPI.infoAwait(args: List<String>): Response? {
   return awaitResult {
     this.info(args, it)
@@ -2520,7 +2520,7 @@ suspend fun RedisAPI.infoAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use jsonArrappend returning a future and chain with await()", replaceWith = ReplaceWith("jsonArrappend(args).await()"))
+@Deprecated(message = "Instead use jsonArrappend returning a future and chain with coAwait()", replaceWith = ReplaceWith("jsonArrappend(args).coAwait()"))
 suspend fun RedisAPI.jsonArrappendAwait(args: List<String>): Response? {
   return awaitResult {
     this.jsonArrappend(args, it)
@@ -2535,7 +2535,7 @@ suspend fun RedisAPI.jsonArrappendAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use jsonArrindex returning a future and chain with await()", replaceWith = ReplaceWith("jsonArrindex(args).await()"))
+@Deprecated(message = "Instead use jsonArrindex returning a future and chain with coAwait()", replaceWith = ReplaceWith("jsonArrindex(args).coAwait()"))
 suspend fun RedisAPI.jsonArrindexAwait(args: List<String>): Response? {
   return awaitResult {
     this.jsonArrindex(args, it)
@@ -2550,7 +2550,7 @@ suspend fun RedisAPI.jsonArrindexAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use jsonArrinsert returning a future and chain with await()", replaceWith = ReplaceWith("jsonArrinsert(args).await()"))
+@Deprecated(message = "Instead use jsonArrinsert returning a future and chain with coAwait()", replaceWith = ReplaceWith("jsonArrinsert(args).coAwait()"))
 suspend fun RedisAPI.jsonArrinsertAwait(args: List<String>): Response? {
   return awaitResult {
     this.jsonArrinsert(args, it)
@@ -2565,7 +2565,7 @@ suspend fun RedisAPI.jsonArrinsertAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use jsonArrlen returning a future and chain with await()", replaceWith = ReplaceWith("jsonArrlen(args).await()"))
+@Deprecated(message = "Instead use jsonArrlen returning a future and chain with coAwait()", replaceWith = ReplaceWith("jsonArrlen(args).coAwait()"))
 suspend fun RedisAPI.jsonArrlenAwait(args: List<String>): Response? {
   return awaitResult {
     this.jsonArrlen(args, it)
@@ -2580,7 +2580,7 @@ suspend fun RedisAPI.jsonArrlenAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use jsonArrpop returning a future and chain with await()", replaceWith = ReplaceWith("jsonArrpop(args).await()"))
+@Deprecated(message = "Instead use jsonArrpop returning a future and chain with coAwait()", replaceWith = ReplaceWith("jsonArrpop(args).coAwait()"))
 suspend fun RedisAPI.jsonArrpopAwait(args: List<String>): Response? {
   return awaitResult {
     this.jsonArrpop(args, it)
@@ -2595,7 +2595,7 @@ suspend fun RedisAPI.jsonArrpopAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use jsonArrtrim returning a future and chain with await()", replaceWith = ReplaceWith("jsonArrtrim(args).await()"))
+@Deprecated(message = "Instead use jsonArrtrim returning a future and chain with coAwait()", replaceWith = ReplaceWith("jsonArrtrim(args).coAwait()"))
 suspend fun RedisAPI.jsonArrtrimAwait(args: List<String>): Response? {
   return awaitResult {
     this.jsonArrtrim(args, it)
@@ -2610,7 +2610,7 @@ suspend fun RedisAPI.jsonArrtrimAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use jsonClear returning a future and chain with await()", replaceWith = ReplaceWith("jsonClear(args).await()"))
+@Deprecated(message = "Instead use jsonClear returning a future and chain with coAwait()", replaceWith = ReplaceWith("jsonClear(args).coAwait()"))
 suspend fun RedisAPI.jsonClearAwait(args: List<String>): Response? {
   return awaitResult {
     this.jsonClear(args, it)
@@ -2625,7 +2625,7 @@ suspend fun RedisAPI.jsonClearAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use jsonDebug returning a future and chain with await()", replaceWith = ReplaceWith("jsonDebug(args).await()"))
+@Deprecated(message = "Instead use jsonDebug returning a future and chain with coAwait()", replaceWith = ReplaceWith("jsonDebug(args).coAwait()"))
 suspend fun RedisAPI.jsonDebugAwait(args: List<String>): Response? {
   return awaitResult {
     this.jsonDebug(args, it)
@@ -2640,7 +2640,7 @@ suspend fun RedisAPI.jsonDebugAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use jsonDel returning a future and chain with await()", replaceWith = ReplaceWith("jsonDel(args).await()"))
+@Deprecated(message = "Instead use jsonDel returning a future and chain with coAwait()", replaceWith = ReplaceWith("jsonDel(args).coAwait()"))
 suspend fun RedisAPI.jsonDelAwait(args: List<String>): Response? {
   return awaitResult {
     this.jsonDel(args, it)
@@ -2655,7 +2655,7 @@ suspend fun RedisAPI.jsonDelAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use jsonForget returning a future and chain with await()", replaceWith = ReplaceWith("jsonForget(args).await()"))
+@Deprecated(message = "Instead use jsonForget returning a future and chain with coAwait()", replaceWith = ReplaceWith("jsonForget(args).coAwait()"))
 suspend fun RedisAPI.jsonForgetAwait(args: List<String>): Response? {
   return awaitResult {
     this.jsonForget(args, it)
@@ -2670,7 +2670,7 @@ suspend fun RedisAPI.jsonForgetAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use jsonGet returning a future and chain with await()", replaceWith = ReplaceWith("jsonGet(args).await()"))
+@Deprecated(message = "Instead use jsonGet returning a future and chain with coAwait()", replaceWith = ReplaceWith("jsonGet(args).coAwait()"))
 suspend fun RedisAPI.jsonGetAwait(args: List<String>): Response? {
   return awaitResult {
     this.jsonGet(args, it)
@@ -2685,7 +2685,7 @@ suspend fun RedisAPI.jsonGetAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use jsonMget returning a future and chain with await()", replaceWith = ReplaceWith("jsonMget(args).await()"))
+@Deprecated(message = "Instead use jsonMget returning a future and chain with coAwait()", replaceWith = ReplaceWith("jsonMget(args).coAwait()"))
 suspend fun RedisAPI.jsonMgetAwait(args: List<String>): Response? {
   return awaitResult {
     this.jsonMget(args, it)
@@ -2700,7 +2700,7 @@ suspend fun RedisAPI.jsonMgetAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use jsonNumincrby returning a future and chain with await()", replaceWith = ReplaceWith("jsonNumincrby(args).await()"))
+@Deprecated(message = "Instead use jsonNumincrby returning a future and chain with coAwait()", replaceWith = ReplaceWith("jsonNumincrby(args).coAwait()"))
 suspend fun RedisAPI.jsonNumincrbyAwait(args: List<String>): Response? {
   return awaitResult {
     this.jsonNumincrby(args, it)
@@ -2715,7 +2715,7 @@ suspend fun RedisAPI.jsonNumincrbyAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use jsonNummultby returning a future and chain with await()", replaceWith = ReplaceWith("jsonNummultby(args).await()"))
+@Deprecated(message = "Instead use jsonNummultby returning a future and chain with coAwait()", replaceWith = ReplaceWith("jsonNummultby(args).coAwait()"))
 suspend fun RedisAPI.jsonNummultbyAwait(args: List<String>): Response? {
   return awaitResult {
     this.jsonNummultby(args, it)
@@ -2730,7 +2730,7 @@ suspend fun RedisAPI.jsonNummultbyAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use jsonNumpowby returning a future and chain with await()", replaceWith = ReplaceWith("jsonNumpowby(args).await()"))
+@Deprecated(message = "Instead use jsonNumpowby returning a future and chain with coAwait()", replaceWith = ReplaceWith("jsonNumpowby(args).coAwait()"))
 suspend fun RedisAPI.jsonNumpowbyAwait(args: List<String>): Response? {
   return awaitResult {
     this.jsonNumpowby(args, it)
@@ -2745,7 +2745,7 @@ suspend fun RedisAPI.jsonNumpowbyAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use jsonObjkeys returning a future and chain with await()", replaceWith = ReplaceWith("jsonObjkeys(args).await()"))
+@Deprecated(message = "Instead use jsonObjkeys returning a future and chain with coAwait()", replaceWith = ReplaceWith("jsonObjkeys(args).coAwait()"))
 suspend fun RedisAPI.jsonObjkeysAwait(args: List<String>): Response? {
   return awaitResult {
     this.jsonObjkeys(args, it)
@@ -2760,7 +2760,7 @@ suspend fun RedisAPI.jsonObjkeysAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use jsonObjlen returning a future and chain with await()", replaceWith = ReplaceWith("jsonObjlen(args).await()"))
+@Deprecated(message = "Instead use jsonObjlen returning a future and chain with coAwait()", replaceWith = ReplaceWith("jsonObjlen(args).coAwait()"))
 suspend fun RedisAPI.jsonObjlenAwait(args: List<String>): Response? {
   return awaitResult {
     this.jsonObjlen(args, it)
@@ -2775,7 +2775,7 @@ suspend fun RedisAPI.jsonObjlenAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use jsonResp returning a future and chain with await()", replaceWith = ReplaceWith("jsonResp(args).await()"))
+@Deprecated(message = "Instead use jsonResp returning a future and chain with coAwait()", replaceWith = ReplaceWith("jsonResp(args).coAwait()"))
 suspend fun RedisAPI.jsonRespAwait(args: List<String>): Response? {
   return awaitResult {
     this.jsonResp(args, it)
@@ -2790,7 +2790,7 @@ suspend fun RedisAPI.jsonRespAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use jsonSet returning a future and chain with await()", replaceWith = ReplaceWith("jsonSet(args).await()"))
+@Deprecated(message = "Instead use jsonSet returning a future and chain with coAwait()", replaceWith = ReplaceWith("jsonSet(args).coAwait()"))
 suspend fun RedisAPI.jsonSetAwait(args: List<String>): Response? {
   return awaitResult {
     this.jsonSet(args, it)
@@ -2805,7 +2805,7 @@ suspend fun RedisAPI.jsonSetAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use jsonStrappend returning a future and chain with await()", replaceWith = ReplaceWith("jsonStrappend(args).await()"))
+@Deprecated(message = "Instead use jsonStrappend returning a future and chain with coAwait()", replaceWith = ReplaceWith("jsonStrappend(args).coAwait()"))
 suspend fun RedisAPI.jsonStrappendAwait(args: List<String>): Response? {
   return awaitResult {
     this.jsonStrappend(args, it)
@@ -2820,7 +2820,7 @@ suspend fun RedisAPI.jsonStrappendAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use jsonStrlen returning a future and chain with await()", replaceWith = ReplaceWith("jsonStrlen(args).await()"))
+@Deprecated(message = "Instead use jsonStrlen returning a future and chain with coAwait()", replaceWith = ReplaceWith("jsonStrlen(args).coAwait()"))
 suspend fun RedisAPI.jsonStrlenAwait(args: List<String>): Response? {
   return awaitResult {
     this.jsonStrlen(args, it)
@@ -2835,7 +2835,7 @@ suspend fun RedisAPI.jsonStrlenAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use jsonToggle returning a future and chain with await()", replaceWith = ReplaceWith("jsonToggle(args).await()"))
+@Deprecated(message = "Instead use jsonToggle returning a future and chain with coAwait()", replaceWith = ReplaceWith("jsonToggle(args).coAwait()"))
 suspend fun RedisAPI.jsonToggleAwait(args: List<String>): Response? {
   return awaitResult {
     this.jsonToggle(args, it)
@@ -2850,7 +2850,7 @@ suspend fun RedisAPI.jsonToggleAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use jsonType returning a future and chain with await()", replaceWith = ReplaceWith("jsonType(args).await()"))
+@Deprecated(message = "Instead use jsonType returning a future and chain with coAwait()", replaceWith = ReplaceWith("jsonType(args).coAwait()"))
 suspend fun RedisAPI.jsonTypeAwait(args: List<String>): Response? {
   return awaitResult {
     this.jsonType(args, it)
@@ -2865,7 +2865,7 @@ suspend fun RedisAPI.jsonTypeAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use keys returning a future and chain with await()", replaceWith = ReplaceWith("keys(arg0).await()"))
+@Deprecated(message = "Instead use keys returning a future and chain with coAwait()", replaceWith = ReplaceWith("keys(arg0).coAwait()"))
 suspend fun RedisAPI.keysAwait(arg0: String): Response? {
   return awaitResult {
     this.keys(arg0, it)
@@ -2879,7 +2879,7 @@ suspend fun RedisAPI.keysAwait(arg0: String): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use lastsave returning a future and chain with await()", replaceWith = ReplaceWith("lastsave().await()"))
+@Deprecated(message = "Instead use lastsave returning a future and chain with coAwait()", replaceWith = ReplaceWith("lastsave().coAwait()"))
 suspend fun RedisAPI.lastsaveAwait(): Response? {
   return awaitResult {
     this.lastsave(it)
@@ -2894,7 +2894,7 @@ suspend fun RedisAPI.lastsaveAwait(): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use latency returning a future and chain with await()", replaceWith = ReplaceWith("latency(args).await()"))
+@Deprecated(message = "Instead use latency returning a future and chain with coAwait()", replaceWith = ReplaceWith("latency(args).coAwait()"))
 suspend fun RedisAPI.latencyAwait(args: List<String>): Response? {
   return awaitResult {
     this.latency(args, it)
@@ -2909,7 +2909,7 @@ suspend fun RedisAPI.latencyAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use lcs returning a future and chain with await()", replaceWith = ReplaceWith("lcs(args).await()"))
+@Deprecated(message = "Instead use lcs returning a future and chain with coAwait()", replaceWith = ReplaceWith("lcs(args).coAwait()"))
 suspend fun RedisAPI.lcsAwait(args: List<String>): Response? {
   return awaitResult {
     this.lcs(args, it)
@@ -2925,7 +2925,7 @@ suspend fun RedisAPI.lcsAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use lindex returning a future and chain with await()", replaceWith = ReplaceWith("lindex(arg0, arg1).await()"))
+@Deprecated(message = "Instead use lindex returning a future and chain with coAwait()", replaceWith = ReplaceWith("lindex(arg0, arg1).coAwait()"))
 suspend fun RedisAPI.lindexAwait(arg0: String, arg1: String): Response? {
   return awaitResult {
     this.lindex(arg0, arg1, it)
@@ -2943,7 +2943,7 @@ suspend fun RedisAPI.lindexAwait(arg0: String, arg1: String): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use linsert returning a future and chain with await()", replaceWith = ReplaceWith("linsert(arg0, arg1, arg2, arg3).await()"))
+@Deprecated(message = "Instead use linsert returning a future and chain with coAwait()", replaceWith = ReplaceWith("linsert(arg0, arg1, arg2, arg3).coAwait()"))
 suspend fun RedisAPI.linsertAwait(arg0: String, arg1: String, arg2: String, arg3: String): Response? {
   return awaitResult {
     this.linsert(arg0, arg1, arg2, arg3, it)
@@ -2958,7 +2958,7 @@ suspend fun RedisAPI.linsertAwait(arg0: String, arg1: String, arg2: String, arg3
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use llen returning a future and chain with await()", replaceWith = ReplaceWith("llen(arg0).await()"))
+@Deprecated(message = "Instead use llen returning a future and chain with coAwait()", replaceWith = ReplaceWith("llen(arg0).coAwait()"))
 suspend fun RedisAPI.llenAwait(arg0: String): Response? {
   return awaitResult {
     this.llen(arg0, it)
@@ -2976,7 +2976,7 @@ suspend fun RedisAPI.llenAwait(arg0: String): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use lmove returning a future and chain with await()", replaceWith = ReplaceWith("lmove(arg0, arg1, arg2, arg3).await()"))
+@Deprecated(message = "Instead use lmove returning a future and chain with coAwait()", replaceWith = ReplaceWith("lmove(arg0, arg1, arg2, arg3).coAwait()"))
 suspend fun RedisAPI.lmoveAwait(arg0: String, arg1: String, arg2: String, arg3: String): Response? {
   return awaitResult {
     this.lmove(arg0, arg1, arg2, arg3, it)
@@ -2991,7 +2991,7 @@ suspend fun RedisAPI.lmoveAwait(arg0: String, arg1: String, arg2: String, arg3: 
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use lmpop returning a future and chain with await()", replaceWith = ReplaceWith("lmpop(args).await()"))
+@Deprecated(message = "Instead use lmpop returning a future and chain with coAwait()", replaceWith = ReplaceWith("lmpop(args).coAwait()"))
 suspend fun RedisAPI.lmpopAwait(args: List<String>): Response? {
   return awaitResult {
     this.lmpop(args, it)
@@ -3006,7 +3006,7 @@ suspend fun RedisAPI.lmpopAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use lolwut returning a future and chain with await()", replaceWith = ReplaceWith("lolwut(args).await()"))
+@Deprecated(message = "Instead use lolwut returning a future and chain with coAwait()", replaceWith = ReplaceWith("lolwut(args).coAwait()"))
 suspend fun RedisAPI.lolwutAwait(args: List<String>): Response? {
   return awaitResult {
     this.lolwut(args, it)
@@ -3021,7 +3021,7 @@ suspend fun RedisAPI.lolwutAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use lpop returning a future and chain with await()", replaceWith = ReplaceWith("lpop(args).await()"))
+@Deprecated(message = "Instead use lpop returning a future and chain with coAwait()", replaceWith = ReplaceWith("lpop(args).coAwait()"))
 suspend fun RedisAPI.lpopAwait(args: List<String>): Response? {
   return awaitResult {
     this.lpop(args, it)
@@ -3036,7 +3036,7 @@ suspend fun RedisAPI.lpopAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use lpos returning a future and chain with await()", replaceWith = ReplaceWith("lpos(args).await()"))
+@Deprecated(message = "Instead use lpos returning a future and chain with coAwait()", replaceWith = ReplaceWith("lpos(args).coAwait()"))
 suspend fun RedisAPI.lposAwait(args: List<String>): Response? {
   return awaitResult {
     this.lpos(args, it)
@@ -3051,7 +3051,7 @@ suspend fun RedisAPI.lposAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use lpush returning a future and chain with await()", replaceWith = ReplaceWith("lpush(args).await()"))
+@Deprecated(message = "Instead use lpush returning a future and chain with coAwait()", replaceWith = ReplaceWith("lpush(args).coAwait()"))
 suspend fun RedisAPI.lpushAwait(args: List<String>): Response? {
   return awaitResult {
     this.lpush(args, it)
@@ -3066,7 +3066,7 @@ suspend fun RedisAPI.lpushAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use lpushx returning a future and chain with await()", replaceWith = ReplaceWith("lpushx(args).await()"))
+@Deprecated(message = "Instead use lpushx returning a future and chain with coAwait()", replaceWith = ReplaceWith("lpushx(args).coAwait()"))
 suspend fun RedisAPI.lpushxAwait(args: List<String>): Response? {
   return awaitResult {
     this.lpushx(args, it)
@@ -3083,7 +3083,7 @@ suspend fun RedisAPI.lpushxAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use lrange returning a future and chain with await()", replaceWith = ReplaceWith("lrange(arg0, arg1, arg2).await()"))
+@Deprecated(message = "Instead use lrange returning a future and chain with coAwait()", replaceWith = ReplaceWith("lrange(arg0, arg1, arg2).coAwait()"))
 suspend fun RedisAPI.lrangeAwait(arg0: String, arg1: String, arg2: String): Response? {
   return awaitResult {
     this.lrange(arg0, arg1, arg2, it)
@@ -3100,7 +3100,7 @@ suspend fun RedisAPI.lrangeAwait(arg0: String, arg1: String, arg2: String): Resp
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use lrem returning a future and chain with await()", replaceWith = ReplaceWith("lrem(arg0, arg1, arg2).await()"))
+@Deprecated(message = "Instead use lrem returning a future and chain with coAwait()", replaceWith = ReplaceWith("lrem(arg0, arg1, arg2).coAwait()"))
 suspend fun RedisAPI.lremAwait(arg0: String, arg1: String, arg2: String): Response? {
   return awaitResult {
     this.lrem(arg0, arg1, arg2, it)
@@ -3117,7 +3117,7 @@ suspend fun RedisAPI.lremAwait(arg0: String, arg1: String, arg2: String): Respon
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use lset returning a future and chain with await()", replaceWith = ReplaceWith("lset(arg0, arg1, arg2).await()"))
+@Deprecated(message = "Instead use lset returning a future and chain with coAwait()", replaceWith = ReplaceWith("lset(arg0, arg1, arg2).coAwait()"))
 suspend fun RedisAPI.lsetAwait(arg0: String, arg1: String, arg2: String): Response? {
   return awaitResult {
     this.lset(arg0, arg1, arg2, it)
@@ -3134,7 +3134,7 @@ suspend fun RedisAPI.lsetAwait(arg0: String, arg1: String, arg2: String): Respon
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use ltrim returning a future and chain with await()", replaceWith = ReplaceWith("ltrim(arg0, arg1, arg2).await()"))
+@Deprecated(message = "Instead use ltrim returning a future and chain with coAwait()", replaceWith = ReplaceWith("ltrim(arg0, arg1, arg2).coAwait()"))
 suspend fun RedisAPI.ltrimAwait(arg0: String, arg1: String, arg2: String): Response? {
   return awaitResult {
     this.ltrim(arg0, arg1, arg2, it)
@@ -3149,7 +3149,7 @@ suspend fun RedisAPI.ltrimAwait(arg0: String, arg1: String, arg2: String): Respo
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use memory returning a future and chain with await()", replaceWith = ReplaceWith("memory(args).await()"))
+@Deprecated(message = "Instead use memory returning a future and chain with coAwait()", replaceWith = ReplaceWith("memory(args).coAwait()"))
 suspend fun RedisAPI.memoryAwait(args: List<String>): Response? {
   return awaitResult {
     this.memory(args, it)
@@ -3164,7 +3164,7 @@ suspend fun RedisAPI.memoryAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use mget returning a future and chain with await()", replaceWith = ReplaceWith("mget(args).await()"))
+@Deprecated(message = "Instead use mget returning a future and chain with coAwait()", replaceWith = ReplaceWith("mget(args).coAwait()"))
 suspend fun RedisAPI.mgetAwait(args: List<String>): Response? {
   return awaitResult {
     this.mget(args, it)
@@ -3179,7 +3179,7 @@ suspend fun RedisAPI.mgetAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use migrate returning a future and chain with await()", replaceWith = ReplaceWith("migrate(args).await()"))
+@Deprecated(message = "Instead use migrate returning a future and chain with coAwait()", replaceWith = ReplaceWith("migrate(args).coAwait()"))
 suspend fun RedisAPI.migrateAwait(args: List<String>): Response? {
   return awaitResult {
     this.migrate(args, it)
@@ -3194,7 +3194,7 @@ suspend fun RedisAPI.migrateAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use module returning a future and chain with await()", replaceWith = ReplaceWith("module(args).await()"))
+@Deprecated(message = "Instead use module returning a future and chain with coAwait()", replaceWith = ReplaceWith("module(args).coAwait()"))
 suspend fun RedisAPI.moduleAwait(args: List<String>): Response? {
   return awaitResult {
     this.module(args, it)
@@ -3208,7 +3208,7 @@ suspend fun RedisAPI.moduleAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use monitor returning a future and chain with await()", replaceWith = ReplaceWith("monitor().await()"))
+@Deprecated(message = "Instead use monitor returning a future and chain with coAwait()", replaceWith = ReplaceWith("monitor().coAwait()"))
 suspend fun RedisAPI.monitorAwait(): Response? {
   return awaitResult {
     this.monitor(it)
@@ -3224,7 +3224,7 @@ suspend fun RedisAPI.monitorAwait(): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use move returning a future and chain with await()", replaceWith = ReplaceWith("move(arg0, arg1).await()"))
+@Deprecated(message = "Instead use move returning a future and chain with coAwait()", replaceWith = ReplaceWith("move(arg0, arg1).coAwait()"))
 suspend fun RedisAPI.moveAwait(arg0: String, arg1: String): Response? {
   return awaitResult {
     this.move(arg0, arg1, it)
@@ -3239,7 +3239,7 @@ suspend fun RedisAPI.moveAwait(arg0: String, arg1: String): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use mset returning a future and chain with await()", replaceWith = ReplaceWith("mset(args).await()"))
+@Deprecated(message = "Instead use mset returning a future and chain with coAwait()", replaceWith = ReplaceWith("mset(args).coAwait()"))
 suspend fun RedisAPI.msetAwait(args: List<String>): Response? {
   return awaitResult {
     this.mset(args, it)
@@ -3254,7 +3254,7 @@ suspend fun RedisAPI.msetAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use msetnx returning a future and chain with await()", replaceWith = ReplaceWith("msetnx(args).await()"))
+@Deprecated(message = "Instead use msetnx returning a future and chain with coAwait()", replaceWith = ReplaceWith("msetnx(args).coAwait()"))
 suspend fun RedisAPI.msetnxAwait(args: List<String>): Response? {
   return awaitResult {
     this.msetnx(args, it)
@@ -3268,7 +3268,7 @@ suspend fun RedisAPI.msetnxAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use multi returning a future and chain with await()", replaceWith = ReplaceWith("multi().await()"))
+@Deprecated(message = "Instead use multi returning a future and chain with coAwait()", replaceWith = ReplaceWith("multi().coAwait()"))
 suspend fun RedisAPI.multiAwait(): Response? {
   return awaitResult {
     this.multi(it)
@@ -3283,7 +3283,7 @@ suspend fun RedisAPI.multiAwait(): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use object returning a future and chain with await()", replaceWith = ReplaceWith("object(args).await()"))
+@Deprecated(message = "Instead use object returning a future and chain with coAwait()", replaceWith = ReplaceWith("object(args).coAwait()"))
 suspend fun RedisAPI.objectAwait(args: List<String>): Response? {
   return awaitResult {
     this.`object`(args, it)
@@ -3298,7 +3298,7 @@ suspend fun RedisAPI.objectAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use persist returning a future and chain with await()", replaceWith = ReplaceWith("persist(arg0).await()"))
+@Deprecated(message = "Instead use persist returning a future and chain with coAwait()", replaceWith = ReplaceWith("persist(arg0).coAwait()"))
 suspend fun RedisAPI.persistAwait(arg0: String): Response? {
   return awaitResult {
     this.persist(arg0, it)
@@ -3313,7 +3313,7 @@ suspend fun RedisAPI.persistAwait(arg0: String): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use pexpire returning a future and chain with await()", replaceWith = ReplaceWith("pexpire(args).await()"))
+@Deprecated(message = "Instead use pexpire returning a future and chain with coAwait()", replaceWith = ReplaceWith("pexpire(args).coAwait()"))
 suspend fun RedisAPI.pexpireAwait(args: List<String>): Response? {
   return awaitResult {
     this.pexpire(args, it)
@@ -3328,7 +3328,7 @@ suspend fun RedisAPI.pexpireAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use pexpireat returning a future and chain with await()", replaceWith = ReplaceWith("pexpireat(args).await()"))
+@Deprecated(message = "Instead use pexpireat returning a future and chain with coAwait()", replaceWith = ReplaceWith("pexpireat(args).coAwait()"))
 suspend fun RedisAPI.pexpireatAwait(args: List<String>): Response? {
   return awaitResult {
     this.pexpireat(args, it)
@@ -3343,7 +3343,7 @@ suspend fun RedisAPI.pexpireatAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use pexpiretime returning a future and chain with await()", replaceWith = ReplaceWith("pexpiretime(arg0).await()"))
+@Deprecated(message = "Instead use pexpiretime returning a future and chain with coAwait()", replaceWith = ReplaceWith("pexpiretime(arg0).coAwait()"))
 suspend fun RedisAPI.pexpiretimeAwait(arg0: String): Response? {
   return awaitResult {
     this.pexpiretime(arg0, it)
@@ -3358,7 +3358,7 @@ suspend fun RedisAPI.pexpiretimeAwait(arg0: String): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use pfadd returning a future and chain with await()", replaceWith = ReplaceWith("pfadd(args).await()"))
+@Deprecated(message = "Instead use pfadd returning a future and chain with coAwait()", replaceWith = ReplaceWith("pfadd(args).coAwait()"))
 suspend fun RedisAPI.pfaddAwait(args: List<String>): Response? {
   return awaitResult {
     this.pfadd(args, it)
@@ -3373,7 +3373,7 @@ suspend fun RedisAPI.pfaddAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use pfcount returning a future and chain with await()", replaceWith = ReplaceWith("pfcount(args).await()"))
+@Deprecated(message = "Instead use pfcount returning a future and chain with coAwait()", replaceWith = ReplaceWith("pfcount(args).coAwait()"))
 suspend fun RedisAPI.pfcountAwait(args: List<String>): Response? {
   return awaitResult {
     this.pfcount(args, it)
@@ -3389,7 +3389,7 @@ suspend fun RedisAPI.pfcountAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use pfdebug returning a future and chain with await()", replaceWith = ReplaceWith("pfdebug(arg0, arg1).await()"))
+@Deprecated(message = "Instead use pfdebug returning a future and chain with coAwait()", replaceWith = ReplaceWith("pfdebug(arg0, arg1).coAwait()"))
 suspend fun RedisAPI.pfdebugAwait(arg0: String, arg1: String): Response? {
   return awaitResult {
     this.pfdebug(arg0, arg1, it)
@@ -3404,7 +3404,7 @@ suspend fun RedisAPI.pfdebugAwait(arg0: String, arg1: String): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use pfmerge returning a future and chain with await()", replaceWith = ReplaceWith("pfmerge(args).await()"))
+@Deprecated(message = "Instead use pfmerge returning a future and chain with coAwait()", replaceWith = ReplaceWith("pfmerge(args).coAwait()"))
 suspend fun RedisAPI.pfmergeAwait(args: List<String>): Response? {
   return awaitResult {
     this.pfmerge(args, it)
@@ -3418,7 +3418,7 @@ suspend fun RedisAPI.pfmergeAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use pfselftest returning a future and chain with await()", replaceWith = ReplaceWith("pfselftest().await()"))
+@Deprecated(message = "Instead use pfselftest returning a future and chain with coAwait()", replaceWith = ReplaceWith("pfselftest().coAwait()"))
 suspend fun RedisAPI.pfselftestAwait(): Response? {
   return awaitResult {
     this.pfselftest(it)
@@ -3433,7 +3433,7 @@ suspend fun RedisAPI.pfselftestAwait(): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use ping returning a future and chain with await()", replaceWith = ReplaceWith("ping(args).await()"))
+@Deprecated(message = "Instead use ping returning a future and chain with coAwait()", replaceWith = ReplaceWith("ping(args).coAwait()"))
 suspend fun RedisAPI.pingAwait(args: List<String>): Response? {
   return awaitResult {
     this.ping(args, it)
@@ -3450,7 +3450,7 @@ suspend fun RedisAPI.pingAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use psetex returning a future and chain with await()", replaceWith = ReplaceWith("psetex(arg0, arg1, arg2).await()"))
+@Deprecated(message = "Instead use psetex returning a future and chain with coAwait()", replaceWith = ReplaceWith("psetex(arg0, arg1, arg2).coAwait()"))
 suspend fun RedisAPI.psetexAwait(arg0: String, arg1: String, arg2: String): Response? {
   return awaitResult {
     this.psetex(arg0, arg1, arg2, it)
@@ -3465,7 +3465,7 @@ suspend fun RedisAPI.psetexAwait(arg0: String, arg1: String, arg2: String): Resp
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use psubscribe returning a future and chain with await()", replaceWith = ReplaceWith("psubscribe(args).await()"))
+@Deprecated(message = "Instead use psubscribe returning a future and chain with coAwait()", replaceWith = ReplaceWith("psubscribe(args).coAwait()"))
 suspend fun RedisAPI.psubscribeAwait(args: List<String>): Response? {
   return awaitResult {
     this.psubscribe(args, it)
@@ -3480,7 +3480,7 @@ suspend fun RedisAPI.psubscribeAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use psync returning a future and chain with await()", replaceWith = ReplaceWith("psync(args).await()"))
+@Deprecated(message = "Instead use psync returning a future and chain with coAwait()", replaceWith = ReplaceWith("psync(args).coAwait()"))
 suspend fun RedisAPI.psyncAwait(args: List<String>): Response? {
   return awaitResult {
     this.psync(args, it)
@@ -3495,7 +3495,7 @@ suspend fun RedisAPI.psyncAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use pttl returning a future and chain with await()", replaceWith = ReplaceWith("pttl(arg0).await()"))
+@Deprecated(message = "Instead use pttl returning a future and chain with coAwait()", replaceWith = ReplaceWith("pttl(arg0).coAwait()"))
 suspend fun RedisAPI.pttlAwait(arg0: String): Response? {
   return awaitResult {
     this.pttl(arg0, it)
@@ -3511,7 +3511,7 @@ suspend fun RedisAPI.pttlAwait(arg0: String): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use publish returning a future and chain with await()", replaceWith = ReplaceWith("publish(arg0, arg1).await()"))
+@Deprecated(message = "Instead use publish returning a future and chain with coAwait()", replaceWith = ReplaceWith("publish(arg0, arg1).coAwait()"))
 suspend fun RedisAPI.publishAwait(arg0: String, arg1: String): Response? {
   return awaitResult {
     this.publish(arg0, arg1, it)
@@ -3526,7 +3526,7 @@ suspend fun RedisAPI.publishAwait(arg0: String, arg1: String): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use pubsub returning a future and chain with await()", replaceWith = ReplaceWith("pubsub(args).await()"))
+@Deprecated(message = "Instead use pubsub returning a future and chain with coAwait()", replaceWith = ReplaceWith("pubsub(args).coAwait()"))
 suspend fun RedisAPI.pubsubAwait(args: List<String>): Response? {
   return awaitResult {
     this.pubsub(args, it)
@@ -3541,7 +3541,7 @@ suspend fun RedisAPI.pubsubAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use punsubscribe returning a future and chain with await()", replaceWith = ReplaceWith("punsubscribe(args).await()"))
+@Deprecated(message = "Instead use punsubscribe returning a future and chain with coAwait()", replaceWith = ReplaceWith("punsubscribe(args).coAwait()"))
 suspend fun RedisAPI.punsubscribeAwait(args: List<String>): Response? {
   return awaitResult {
     this.punsubscribe(args, it)
@@ -3556,7 +3556,7 @@ suspend fun RedisAPI.punsubscribeAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use quit returning a future and chain with await()", replaceWith = ReplaceWith("quit(args).await()"))
+@Deprecated(message = "Instead use quit returning a future and chain with coAwait()", replaceWith = ReplaceWith("quit(args).coAwait()"))
 suspend fun RedisAPI.quitAwait(args: List<String>): Response? {
   return awaitResult {
     this.quit(args, it)
@@ -3570,7 +3570,7 @@ suspend fun RedisAPI.quitAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use randomkey returning a future and chain with await()", replaceWith = ReplaceWith("randomkey().await()"))
+@Deprecated(message = "Instead use randomkey returning a future and chain with coAwait()", replaceWith = ReplaceWith("randomkey().coAwait()"))
 suspend fun RedisAPI.randomkeyAwait(): Response? {
   return awaitResult {
     this.randomkey(it)
@@ -3584,7 +3584,7 @@ suspend fun RedisAPI.randomkeyAwait(): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use readonly returning a future and chain with await()", replaceWith = ReplaceWith("readonly().await()"))
+@Deprecated(message = "Instead use readonly returning a future and chain with coAwait()", replaceWith = ReplaceWith("readonly().coAwait()"))
 suspend fun RedisAPI.readonlyAwait(): Response? {
   return awaitResult {
     this.readonly(it)
@@ -3598,7 +3598,7 @@ suspend fun RedisAPI.readonlyAwait(): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use readwrite returning a future and chain with await()", replaceWith = ReplaceWith("readwrite().await()"))
+@Deprecated(message = "Instead use readwrite returning a future and chain with coAwait()", replaceWith = ReplaceWith("readwrite().coAwait()"))
 suspend fun RedisAPI.readwriteAwait(): Response? {
   return awaitResult {
     this.readwrite(it)
@@ -3614,7 +3614,7 @@ suspend fun RedisAPI.readwriteAwait(): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use rename returning a future and chain with await()", replaceWith = ReplaceWith("rename(arg0, arg1).await()"))
+@Deprecated(message = "Instead use rename returning a future and chain with coAwait()", replaceWith = ReplaceWith("rename(arg0, arg1).coAwait()"))
 suspend fun RedisAPI.renameAwait(arg0: String, arg1: String): Response? {
   return awaitResult {
     this.rename(arg0, arg1, it)
@@ -3630,7 +3630,7 @@ suspend fun RedisAPI.renameAwait(arg0: String, arg1: String): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use renamenx returning a future and chain with await()", replaceWith = ReplaceWith("renamenx(arg0, arg1).await()"))
+@Deprecated(message = "Instead use renamenx returning a future and chain with coAwait()", replaceWith = ReplaceWith("renamenx(arg0, arg1).coAwait()"))
 suspend fun RedisAPI.renamenxAwait(arg0: String, arg1: String): Response? {
   return awaitResult {
     this.renamenx(arg0, arg1, it)
@@ -3645,7 +3645,7 @@ suspend fun RedisAPI.renamenxAwait(arg0: String, arg1: String): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use replconf returning a future and chain with await()", replaceWith = ReplaceWith("replconf(args).await()"))
+@Deprecated(message = "Instead use replconf returning a future and chain with coAwait()", replaceWith = ReplaceWith("replconf(args).coAwait()"))
 suspend fun RedisAPI.replconfAwait(args: List<String>): Response? {
   return awaitResult {
     this.replconf(args, it)
@@ -3661,7 +3661,7 @@ suspend fun RedisAPI.replconfAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use replicaof returning a future and chain with await()", replaceWith = ReplaceWith("replicaof(arg0, arg1).await()"))
+@Deprecated(message = "Instead use replicaof returning a future and chain with coAwait()", replaceWith = ReplaceWith("replicaof(arg0, arg1).coAwait()"))
 suspend fun RedisAPI.replicaofAwait(arg0: String, arg1: String): Response? {
   return awaitResult {
     this.replicaof(arg0, arg1, it)
@@ -3675,7 +3675,7 @@ suspend fun RedisAPI.replicaofAwait(arg0: String, arg1: String): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use reset returning a future and chain with await()", replaceWith = ReplaceWith("reset().await()"))
+@Deprecated(message = "Instead use reset returning a future and chain with coAwait()", replaceWith = ReplaceWith("reset().coAwait()"))
 suspend fun RedisAPI.resetAwait(): Response? {
   return awaitResult {
     this.reset(it)
@@ -3690,7 +3690,7 @@ suspend fun RedisAPI.resetAwait(): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use restore returning a future and chain with await()", replaceWith = ReplaceWith("restore(args).await()"))
+@Deprecated(message = "Instead use restore returning a future and chain with coAwait()", replaceWith = ReplaceWith("restore(args).coAwait()"))
 suspend fun RedisAPI.restoreAwait(args: List<String>): Response? {
   return awaitResult {
     this.restore(args, it)
@@ -3705,7 +3705,7 @@ suspend fun RedisAPI.restoreAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use restoreAsking returning a future and chain with await()", replaceWith = ReplaceWith("restoreAsking(args).await()"))
+@Deprecated(message = "Instead use restoreAsking returning a future and chain with coAwait()", replaceWith = ReplaceWith("restoreAsking(args).coAwait()"))
 suspend fun RedisAPI.restoreAskingAwait(args: List<String>): Response? {
   return awaitResult {
     this.restoreAsking(args, it)
@@ -3719,7 +3719,7 @@ suspend fun RedisAPI.restoreAskingAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use role returning a future and chain with await()", replaceWith = ReplaceWith("role().await()"))
+@Deprecated(message = "Instead use role returning a future and chain with coAwait()", replaceWith = ReplaceWith("role().coAwait()"))
 suspend fun RedisAPI.roleAwait(): Response? {
   return awaitResult {
     this.role(it)
@@ -3734,7 +3734,7 @@ suspend fun RedisAPI.roleAwait(): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use rpop returning a future and chain with await()", replaceWith = ReplaceWith("rpop(args).await()"))
+@Deprecated(message = "Instead use rpop returning a future and chain with coAwait()", replaceWith = ReplaceWith("rpop(args).coAwait()"))
 suspend fun RedisAPI.rpopAwait(args: List<String>): Response? {
   return awaitResult {
     this.rpop(args, it)
@@ -3750,7 +3750,7 @@ suspend fun RedisAPI.rpopAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use rpoplpush returning a future and chain with await()", replaceWith = ReplaceWith("rpoplpush(arg0, arg1).await()"))
+@Deprecated(message = "Instead use rpoplpush returning a future and chain with coAwait()", replaceWith = ReplaceWith("rpoplpush(arg0, arg1).coAwait()"))
 suspend fun RedisAPI.rpoplpushAwait(arg0: String, arg1: String): Response? {
   return awaitResult {
     this.rpoplpush(arg0, arg1, it)
@@ -3765,7 +3765,7 @@ suspend fun RedisAPI.rpoplpushAwait(arg0: String, arg1: String): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use rpush returning a future and chain with await()", replaceWith = ReplaceWith("rpush(args).await()"))
+@Deprecated(message = "Instead use rpush returning a future and chain with coAwait()", replaceWith = ReplaceWith("rpush(args).coAwait()"))
 suspend fun RedisAPI.rpushAwait(args: List<String>): Response? {
   return awaitResult {
     this.rpush(args, it)
@@ -3780,7 +3780,7 @@ suspend fun RedisAPI.rpushAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use rpushx returning a future and chain with await()", replaceWith = ReplaceWith("rpushx(args).await()"))
+@Deprecated(message = "Instead use rpushx returning a future and chain with coAwait()", replaceWith = ReplaceWith("rpushx(args).coAwait()"))
 suspend fun RedisAPI.rpushxAwait(args: List<String>): Response? {
   return awaitResult {
     this.rpushx(args, it)
@@ -3795,7 +3795,7 @@ suspend fun RedisAPI.rpushxAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use sadd returning a future and chain with await()", replaceWith = ReplaceWith("sadd(args).await()"))
+@Deprecated(message = "Instead use sadd returning a future and chain with coAwait()", replaceWith = ReplaceWith("sadd(args).coAwait()"))
 suspend fun RedisAPI.saddAwait(args: List<String>): Response? {
   return awaitResult {
     this.sadd(args, it)
@@ -3809,7 +3809,7 @@ suspend fun RedisAPI.saddAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use save returning a future and chain with await()", replaceWith = ReplaceWith("save().await()"))
+@Deprecated(message = "Instead use save returning a future and chain with coAwait()", replaceWith = ReplaceWith("save().coAwait()"))
 suspend fun RedisAPI.saveAwait(): Response? {
   return awaitResult {
     this.save(it)
@@ -3824,7 +3824,7 @@ suspend fun RedisAPI.saveAwait(): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use scan returning a future and chain with await()", replaceWith = ReplaceWith("scan(args).await()"))
+@Deprecated(message = "Instead use scan returning a future and chain with coAwait()", replaceWith = ReplaceWith("scan(args).coAwait()"))
 suspend fun RedisAPI.scanAwait(args: List<String>): Response? {
   return awaitResult {
     this.scan(args, it)
@@ -3839,7 +3839,7 @@ suspend fun RedisAPI.scanAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use scard returning a future and chain with await()", replaceWith = ReplaceWith("scard(arg0).await()"))
+@Deprecated(message = "Instead use scard returning a future and chain with coAwait()", replaceWith = ReplaceWith("scard(arg0).coAwait()"))
 suspend fun RedisAPI.scardAwait(arg0: String): Response? {
   return awaitResult {
     this.scard(arg0, it)
@@ -3854,7 +3854,7 @@ suspend fun RedisAPI.scardAwait(arg0: String): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use script returning a future and chain with await()", replaceWith = ReplaceWith("script(args).await()"))
+@Deprecated(message = "Instead use script returning a future and chain with coAwait()", replaceWith = ReplaceWith("script(args).coAwait()"))
 suspend fun RedisAPI.scriptAwait(args: List<String>): Response? {
   return awaitResult {
     this.script(args, it)
@@ -3869,7 +3869,7 @@ suspend fun RedisAPI.scriptAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use sdiff returning a future and chain with await()", replaceWith = ReplaceWith("sdiff(args).await()"))
+@Deprecated(message = "Instead use sdiff returning a future and chain with coAwait()", replaceWith = ReplaceWith("sdiff(args).coAwait()"))
 suspend fun RedisAPI.sdiffAwait(args: List<String>): Response? {
   return awaitResult {
     this.sdiff(args, it)
@@ -3884,7 +3884,7 @@ suspend fun RedisAPI.sdiffAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use sdiffstore returning a future and chain with await()", replaceWith = ReplaceWith("sdiffstore(args).await()"))
+@Deprecated(message = "Instead use sdiffstore returning a future and chain with coAwait()", replaceWith = ReplaceWith("sdiffstore(args).coAwait()"))
 suspend fun RedisAPI.sdiffstoreAwait(args: List<String>): Response? {
   return awaitResult {
     this.sdiffstore(args, it)
@@ -3899,7 +3899,7 @@ suspend fun RedisAPI.sdiffstoreAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use select returning a future and chain with await()", replaceWith = ReplaceWith("select(arg0).await()"))
+@Deprecated(message = "Instead use select returning a future and chain with coAwait()", replaceWith = ReplaceWith("select(arg0).coAwait()"))
 suspend fun RedisAPI.selectAwait(arg0: String): Response? {
   return awaitResult {
     this.select(arg0, it)
@@ -3914,7 +3914,7 @@ suspend fun RedisAPI.selectAwait(arg0: String): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use set returning a future and chain with await()", replaceWith = ReplaceWith("set(args).await()"))
+@Deprecated(message = "Instead use set returning a future and chain with coAwait()", replaceWith = ReplaceWith("set(args).coAwait()"))
 suspend fun RedisAPI.setAwait(args: List<String>): Response? {
   return awaitResult {
     this.set(args, it)
@@ -3931,7 +3931,7 @@ suspend fun RedisAPI.setAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use setbit returning a future and chain with await()", replaceWith = ReplaceWith("setbit(arg0, arg1, arg2).await()"))
+@Deprecated(message = "Instead use setbit returning a future and chain with coAwait()", replaceWith = ReplaceWith("setbit(arg0, arg1, arg2).coAwait()"))
 suspend fun RedisAPI.setbitAwait(arg0: String, arg1: String, arg2: String): Response? {
   return awaitResult {
     this.setbit(arg0, arg1, arg2, it)
@@ -3948,7 +3948,7 @@ suspend fun RedisAPI.setbitAwait(arg0: String, arg1: String, arg2: String): Resp
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use setex returning a future and chain with await()", replaceWith = ReplaceWith("setex(arg0, arg1, arg2).await()"))
+@Deprecated(message = "Instead use setex returning a future and chain with coAwait()", replaceWith = ReplaceWith("setex(arg0, arg1, arg2).coAwait()"))
 suspend fun RedisAPI.setexAwait(arg0: String, arg1: String, arg2: String): Response? {
   return awaitResult {
     this.setex(arg0, arg1, arg2, it)
@@ -3964,7 +3964,7 @@ suspend fun RedisAPI.setexAwait(arg0: String, arg1: String, arg2: String): Respo
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use setnx returning a future and chain with await()", replaceWith = ReplaceWith("setnx(arg0, arg1).await()"))
+@Deprecated(message = "Instead use setnx returning a future and chain with coAwait()", replaceWith = ReplaceWith("setnx(arg0, arg1).coAwait()"))
 suspend fun RedisAPI.setnxAwait(arg0: String, arg1: String): Response? {
   return awaitResult {
     this.setnx(arg0, arg1, it)
@@ -3981,7 +3981,7 @@ suspend fun RedisAPI.setnxAwait(arg0: String, arg1: String): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use setrange returning a future and chain with await()", replaceWith = ReplaceWith("setrange(arg0, arg1, arg2).await()"))
+@Deprecated(message = "Instead use setrange returning a future and chain with coAwait()", replaceWith = ReplaceWith("setrange(arg0, arg1, arg2).coAwait()"))
 suspend fun RedisAPI.setrangeAwait(arg0: String, arg1: String, arg2: String): Response? {
   return awaitResult {
     this.setrange(arg0, arg1, arg2, it)
@@ -3996,7 +3996,7 @@ suspend fun RedisAPI.setrangeAwait(arg0: String, arg1: String, arg2: String): Re
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use shutdown returning a future and chain with await()", replaceWith = ReplaceWith("shutdown(args).await()"))
+@Deprecated(message = "Instead use shutdown returning a future and chain with coAwait()", replaceWith = ReplaceWith("shutdown(args).coAwait()"))
 suspend fun RedisAPI.shutdownAwait(args: List<String>): Response? {
   return awaitResult {
     this.shutdown(args, it)
@@ -4011,7 +4011,7 @@ suspend fun RedisAPI.shutdownAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use sinter returning a future and chain with await()", replaceWith = ReplaceWith("sinter(args).await()"))
+@Deprecated(message = "Instead use sinter returning a future and chain with coAwait()", replaceWith = ReplaceWith("sinter(args).coAwait()"))
 suspend fun RedisAPI.sinterAwait(args: List<String>): Response? {
   return awaitResult {
     this.sinter(args, it)
@@ -4026,7 +4026,7 @@ suspend fun RedisAPI.sinterAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use sintercard returning a future and chain with await()", replaceWith = ReplaceWith("sintercard(args).await()"))
+@Deprecated(message = "Instead use sintercard returning a future and chain with coAwait()", replaceWith = ReplaceWith("sintercard(args).coAwait()"))
 suspend fun RedisAPI.sintercardAwait(args: List<String>): Response? {
   return awaitResult {
     this.sintercard(args, it)
@@ -4041,7 +4041,7 @@ suspend fun RedisAPI.sintercardAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use sinterstore returning a future and chain with await()", replaceWith = ReplaceWith("sinterstore(args).await()"))
+@Deprecated(message = "Instead use sinterstore returning a future and chain with coAwait()", replaceWith = ReplaceWith("sinterstore(args).coAwait()"))
 suspend fun RedisAPI.sinterstoreAwait(args: List<String>): Response? {
   return awaitResult {
     this.sinterstore(args, it)
@@ -4057,7 +4057,7 @@ suspend fun RedisAPI.sinterstoreAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use sismember returning a future and chain with await()", replaceWith = ReplaceWith("sismember(arg0, arg1).await()"))
+@Deprecated(message = "Instead use sismember returning a future and chain with coAwait()", replaceWith = ReplaceWith("sismember(arg0, arg1).coAwait()"))
 suspend fun RedisAPI.sismemberAwait(arg0: String, arg1: String): Response? {
   return awaitResult {
     this.sismember(arg0, arg1, it)
@@ -4073,7 +4073,7 @@ suspend fun RedisAPI.sismemberAwait(arg0: String, arg1: String): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use slaveof returning a future and chain with await()", replaceWith = ReplaceWith("slaveof(arg0, arg1).await()"))
+@Deprecated(message = "Instead use slaveof returning a future and chain with coAwait()", replaceWith = ReplaceWith("slaveof(arg0, arg1).coAwait()"))
 suspend fun RedisAPI.slaveofAwait(arg0: String, arg1: String): Response? {
   return awaitResult {
     this.slaveof(arg0, arg1, it)
@@ -4088,7 +4088,7 @@ suspend fun RedisAPI.slaveofAwait(arg0: String, arg1: String): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use slowlog returning a future and chain with await()", replaceWith = ReplaceWith("slowlog(args).await()"))
+@Deprecated(message = "Instead use slowlog returning a future and chain with coAwait()", replaceWith = ReplaceWith("slowlog(args).coAwait()"))
 suspend fun RedisAPI.slowlogAwait(args: List<String>): Response? {
   return awaitResult {
     this.slowlog(args, it)
@@ -4103,7 +4103,7 @@ suspend fun RedisAPI.slowlogAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use smembers returning a future and chain with await()", replaceWith = ReplaceWith("smembers(arg0).await()"))
+@Deprecated(message = "Instead use smembers returning a future and chain with coAwait()", replaceWith = ReplaceWith("smembers(arg0).coAwait()"))
 suspend fun RedisAPI.smembersAwait(arg0: String): Response? {
   return awaitResult {
     this.smembers(arg0, it)
@@ -4118,7 +4118,7 @@ suspend fun RedisAPI.smembersAwait(arg0: String): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use smismember returning a future and chain with await()", replaceWith = ReplaceWith("smismember(args).await()"))
+@Deprecated(message = "Instead use smismember returning a future and chain with coAwait()", replaceWith = ReplaceWith("smismember(args).coAwait()"))
 suspend fun RedisAPI.smismemberAwait(args: List<String>): Response? {
   return awaitResult {
     this.smismember(args, it)
@@ -4135,7 +4135,7 @@ suspend fun RedisAPI.smismemberAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use smove returning a future and chain with await()", replaceWith = ReplaceWith("smove(arg0, arg1, arg2).await()"))
+@Deprecated(message = "Instead use smove returning a future and chain with coAwait()", replaceWith = ReplaceWith("smove(arg0, arg1, arg2).coAwait()"))
 suspend fun RedisAPI.smoveAwait(arg0: String, arg1: String, arg2: String): Response? {
   return awaitResult {
     this.smove(arg0, arg1, arg2, it)
@@ -4150,7 +4150,7 @@ suspend fun RedisAPI.smoveAwait(arg0: String, arg1: String, arg2: String): Respo
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use sort returning a future and chain with await()", replaceWith = ReplaceWith("sort(args).await()"))
+@Deprecated(message = "Instead use sort returning a future and chain with coAwait()", replaceWith = ReplaceWith("sort(args).coAwait()"))
 suspend fun RedisAPI.sortAwait(args: List<String>): Response? {
   return awaitResult {
     this.sort(args, it)
@@ -4165,7 +4165,7 @@ suspend fun RedisAPI.sortAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use sortRo returning a future and chain with await()", replaceWith = ReplaceWith("sortRo(args).await()"))
+@Deprecated(message = "Instead use sortRo returning a future and chain with coAwait()", replaceWith = ReplaceWith("sortRo(args).coAwait()"))
 suspend fun RedisAPI.sortRoAwait(args: List<String>): Response? {
   return awaitResult {
     this.sortRo(args, it)
@@ -4180,7 +4180,7 @@ suspend fun RedisAPI.sortRoAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use spop returning a future and chain with await()", replaceWith = ReplaceWith("spop(args).await()"))
+@Deprecated(message = "Instead use spop returning a future and chain with coAwait()", replaceWith = ReplaceWith("spop(args).coAwait()"))
 suspend fun RedisAPI.spopAwait(args: List<String>): Response? {
   return awaitResult {
     this.spop(args, it)
@@ -4196,7 +4196,7 @@ suspend fun RedisAPI.spopAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use spublish returning a future and chain with await()", replaceWith = ReplaceWith("spublish(arg0, arg1).await()"))
+@Deprecated(message = "Instead use spublish returning a future and chain with coAwait()", replaceWith = ReplaceWith("spublish(arg0, arg1).coAwait()"))
 suspend fun RedisAPI.spublishAwait(arg0: String, arg1: String): Response? {
   return awaitResult {
     this.spublish(arg0, arg1, it)
@@ -4211,7 +4211,7 @@ suspend fun RedisAPI.spublishAwait(arg0: String, arg1: String): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use srandmember returning a future and chain with await()", replaceWith = ReplaceWith("srandmember(args).await()"))
+@Deprecated(message = "Instead use srandmember returning a future and chain with coAwait()", replaceWith = ReplaceWith("srandmember(args).coAwait()"))
 suspend fun RedisAPI.srandmemberAwait(args: List<String>): Response? {
   return awaitResult {
     this.srandmember(args, it)
@@ -4226,7 +4226,7 @@ suspend fun RedisAPI.srandmemberAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use srem returning a future and chain with await()", replaceWith = ReplaceWith("srem(args).await()"))
+@Deprecated(message = "Instead use srem returning a future and chain with coAwait()", replaceWith = ReplaceWith("srem(args).coAwait()"))
 suspend fun RedisAPI.sremAwait(args: List<String>): Response? {
   return awaitResult {
     this.srem(args, it)
@@ -4241,7 +4241,7 @@ suspend fun RedisAPI.sremAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use sscan returning a future and chain with await()", replaceWith = ReplaceWith("sscan(args).await()"))
+@Deprecated(message = "Instead use sscan returning a future and chain with coAwait()", replaceWith = ReplaceWith("sscan(args).coAwait()"))
 suspend fun RedisAPI.sscanAwait(args: List<String>): Response? {
   return awaitResult {
     this.sscan(args, it)
@@ -4256,7 +4256,7 @@ suspend fun RedisAPI.sscanAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use ssubscribe returning a future and chain with await()", replaceWith = ReplaceWith("ssubscribe(args).await()"))
+@Deprecated(message = "Instead use ssubscribe returning a future and chain with coAwait()", replaceWith = ReplaceWith("ssubscribe(args).coAwait()"))
 suspend fun RedisAPI.ssubscribeAwait(args: List<String>): Response? {
   return awaitResult {
     this.ssubscribe(args, it)
@@ -4271,7 +4271,7 @@ suspend fun RedisAPI.ssubscribeAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use strlen returning a future and chain with await()", replaceWith = ReplaceWith("strlen(arg0).await()"))
+@Deprecated(message = "Instead use strlen returning a future and chain with coAwait()", replaceWith = ReplaceWith("strlen(arg0).coAwait()"))
 suspend fun RedisAPI.strlenAwait(arg0: String): Response? {
   return awaitResult {
     this.strlen(arg0, it)
@@ -4286,7 +4286,7 @@ suspend fun RedisAPI.strlenAwait(arg0: String): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use subscribe returning a future and chain with await()", replaceWith = ReplaceWith("subscribe(args).await()"))
+@Deprecated(message = "Instead use subscribe returning a future and chain with coAwait()", replaceWith = ReplaceWith("subscribe(args).coAwait()"))
 suspend fun RedisAPI.subscribeAwait(args: List<String>): Response? {
   return awaitResult {
     this.subscribe(args, it)
@@ -4303,7 +4303,7 @@ suspend fun RedisAPI.subscribeAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use substr returning a future and chain with await()", replaceWith = ReplaceWith("substr(arg0, arg1, arg2).await()"))
+@Deprecated(message = "Instead use substr returning a future and chain with coAwait()", replaceWith = ReplaceWith("substr(arg0, arg1, arg2).coAwait()"))
 suspend fun RedisAPI.substrAwait(arg0: String, arg1: String, arg2: String): Response? {
   return awaitResult {
     this.substr(arg0, arg1, arg2, it)
@@ -4318,7 +4318,7 @@ suspend fun RedisAPI.substrAwait(arg0: String, arg1: String, arg2: String): Resp
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use sunion returning a future and chain with await()", replaceWith = ReplaceWith("sunion(args).await()"))
+@Deprecated(message = "Instead use sunion returning a future and chain with coAwait()", replaceWith = ReplaceWith("sunion(args).coAwait()"))
 suspend fun RedisAPI.sunionAwait(args: List<String>): Response? {
   return awaitResult {
     this.sunion(args, it)
@@ -4333,7 +4333,7 @@ suspend fun RedisAPI.sunionAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use sunionstore returning a future and chain with await()", replaceWith = ReplaceWith("sunionstore(args).await()"))
+@Deprecated(message = "Instead use sunionstore returning a future and chain with coAwait()", replaceWith = ReplaceWith("sunionstore(args).coAwait()"))
 suspend fun RedisAPI.sunionstoreAwait(args: List<String>): Response? {
   return awaitResult {
     this.sunionstore(args, it)
@@ -4348,7 +4348,7 @@ suspend fun RedisAPI.sunionstoreAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use sunsubscribe returning a future and chain with await()", replaceWith = ReplaceWith("sunsubscribe(args).await()"))
+@Deprecated(message = "Instead use sunsubscribe returning a future and chain with coAwait()", replaceWith = ReplaceWith("sunsubscribe(args).coAwait()"))
 suspend fun RedisAPI.sunsubscribeAwait(args: List<String>): Response? {
   return awaitResult {
     this.sunsubscribe(args, it)
@@ -4364,7 +4364,7 @@ suspend fun RedisAPI.sunsubscribeAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use swapdb returning a future and chain with await()", replaceWith = ReplaceWith("swapdb(arg0, arg1).await()"))
+@Deprecated(message = "Instead use swapdb returning a future and chain with coAwait()", replaceWith = ReplaceWith("swapdb(arg0, arg1).coAwait()"))
 suspend fun RedisAPI.swapdbAwait(arg0: String, arg1: String): Response? {
   return awaitResult {
     this.swapdb(arg0, arg1, it)
@@ -4378,7 +4378,7 @@ suspend fun RedisAPI.swapdbAwait(arg0: String, arg1: String): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use sync returning a future and chain with await()", replaceWith = ReplaceWith("sync().await()"))
+@Deprecated(message = "Instead use sync returning a future and chain with coAwait()", replaceWith = ReplaceWith("sync().coAwait()"))
 suspend fun RedisAPI.syncAwait(): Response? {
   return awaitResult {
     this.sync(it)
@@ -4393,7 +4393,7 @@ suspend fun RedisAPI.syncAwait(): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use tdigestAdd returning a future and chain with await()", replaceWith = ReplaceWith("tdigestAdd(args).await()"))
+@Deprecated(message = "Instead use tdigestAdd returning a future and chain with coAwait()", replaceWith = ReplaceWith("tdigestAdd(args).coAwait()"))
 suspend fun RedisAPI.tdigestAddAwait(args: List<String>): Response? {
   return awaitResult {
     this.tdigestAdd(args, it)
@@ -4408,7 +4408,7 @@ suspend fun RedisAPI.tdigestAddAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use tdigestByrank returning a future and chain with await()", replaceWith = ReplaceWith("tdigestByrank(args).await()"))
+@Deprecated(message = "Instead use tdigestByrank returning a future and chain with coAwait()", replaceWith = ReplaceWith("tdigestByrank(args).coAwait()"))
 suspend fun RedisAPI.tdigestByrankAwait(args: List<String>): Response? {
   return awaitResult {
     this.tdigestByrank(args, it)
@@ -4423,7 +4423,7 @@ suspend fun RedisAPI.tdigestByrankAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use tdigestByrevrank returning a future and chain with await()", replaceWith = ReplaceWith("tdigestByrevrank(args).await()"))
+@Deprecated(message = "Instead use tdigestByrevrank returning a future and chain with coAwait()", replaceWith = ReplaceWith("tdigestByrevrank(args).coAwait()"))
 suspend fun RedisAPI.tdigestByrevrankAwait(args: List<String>): Response? {
   return awaitResult {
     this.tdigestByrevrank(args, it)
@@ -4438,7 +4438,7 @@ suspend fun RedisAPI.tdigestByrevrankAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use tdigestCdf returning a future and chain with await()", replaceWith = ReplaceWith("tdigestCdf(args).await()"))
+@Deprecated(message = "Instead use tdigestCdf returning a future and chain with coAwait()", replaceWith = ReplaceWith("tdigestCdf(args).coAwait()"))
 suspend fun RedisAPI.tdigestCdfAwait(args: List<String>): Response? {
   return awaitResult {
     this.tdigestCdf(args, it)
@@ -4453,7 +4453,7 @@ suspend fun RedisAPI.tdigestCdfAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use tdigestCreate returning a future and chain with await()", replaceWith = ReplaceWith("tdigestCreate(args).await()"))
+@Deprecated(message = "Instead use tdigestCreate returning a future and chain with coAwait()", replaceWith = ReplaceWith("tdigestCreate(args).coAwait()"))
 suspend fun RedisAPI.tdigestCreateAwait(args: List<String>): Response? {
   return awaitResult {
     this.tdigestCreate(args, it)
@@ -4468,7 +4468,7 @@ suspend fun RedisAPI.tdigestCreateAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use tdigestInfo returning a future and chain with await()", replaceWith = ReplaceWith("tdigestInfo(args).await()"))
+@Deprecated(message = "Instead use tdigestInfo returning a future and chain with coAwait()", replaceWith = ReplaceWith("tdigestInfo(args).coAwait()"))
 suspend fun RedisAPI.tdigestInfoAwait(args: List<String>): Response? {
   return awaitResult {
     this.tdigestInfo(args, it)
@@ -4483,7 +4483,7 @@ suspend fun RedisAPI.tdigestInfoAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use tdigestMax returning a future and chain with await()", replaceWith = ReplaceWith("tdigestMax(args).await()"))
+@Deprecated(message = "Instead use tdigestMax returning a future and chain with coAwait()", replaceWith = ReplaceWith("tdigestMax(args).coAwait()"))
 suspend fun RedisAPI.tdigestMaxAwait(args: List<String>): Response? {
   return awaitResult {
     this.tdigestMax(args, it)
@@ -4498,7 +4498,7 @@ suspend fun RedisAPI.tdigestMaxAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use tdigestMerge returning a future and chain with await()", replaceWith = ReplaceWith("tdigestMerge(args).await()"))
+@Deprecated(message = "Instead use tdigestMerge returning a future and chain with coAwait()", replaceWith = ReplaceWith("tdigestMerge(args).coAwait()"))
 suspend fun RedisAPI.tdigestMergeAwait(args: List<String>): Response? {
   return awaitResult {
     this.tdigestMerge(args, it)
@@ -4513,7 +4513,7 @@ suspend fun RedisAPI.tdigestMergeAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use tdigestMin returning a future and chain with await()", replaceWith = ReplaceWith("tdigestMin(args).await()"))
+@Deprecated(message = "Instead use tdigestMin returning a future and chain with coAwait()", replaceWith = ReplaceWith("tdigestMin(args).coAwait()"))
 suspend fun RedisAPI.tdigestMinAwait(args: List<String>): Response? {
   return awaitResult {
     this.tdigestMin(args, it)
@@ -4528,7 +4528,7 @@ suspend fun RedisAPI.tdigestMinAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use tdigestQuantile returning a future and chain with await()", replaceWith = ReplaceWith("tdigestQuantile(args).await()"))
+@Deprecated(message = "Instead use tdigestQuantile returning a future and chain with coAwait()", replaceWith = ReplaceWith("tdigestQuantile(args).coAwait()"))
 suspend fun RedisAPI.tdigestQuantileAwait(args: List<String>): Response? {
   return awaitResult {
     this.tdigestQuantile(args, it)
@@ -4543,7 +4543,7 @@ suspend fun RedisAPI.tdigestQuantileAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use tdigestRank returning a future and chain with await()", replaceWith = ReplaceWith("tdigestRank(args).await()"))
+@Deprecated(message = "Instead use tdigestRank returning a future and chain with coAwait()", replaceWith = ReplaceWith("tdigestRank(args).coAwait()"))
 suspend fun RedisAPI.tdigestRankAwait(args: List<String>): Response? {
   return awaitResult {
     this.tdigestRank(args, it)
@@ -4558,7 +4558,7 @@ suspend fun RedisAPI.tdigestRankAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use tdigestReset returning a future and chain with await()", replaceWith = ReplaceWith("tdigestReset(args).await()"))
+@Deprecated(message = "Instead use tdigestReset returning a future and chain with coAwait()", replaceWith = ReplaceWith("tdigestReset(args).coAwait()"))
 suspend fun RedisAPI.tdigestResetAwait(args: List<String>): Response? {
   return awaitResult {
     this.tdigestReset(args, it)
@@ -4573,7 +4573,7 @@ suspend fun RedisAPI.tdigestResetAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use tdigestRevrank returning a future and chain with await()", replaceWith = ReplaceWith("tdigestRevrank(args).await()"))
+@Deprecated(message = "Instead use tdigestRevrank returning a future and chain with coAwait()", replaceWith = ReplaceWith("tdigestRevrank(args).coAwait()"))
 suspend fun RedisAPI.tdigestRevrankAwait(args: List<String>): Response? {
   return awaitResult {
     this.tdigestRevrank(args, it)
@@ -4588,7 +4588,7 @@ suspend fun RedisAPI.tdigestRevrankAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use tdigestTrimmedMean returning a future and chain with await()", replaceWith = ReplaceWith("tdigestTrimmedMean(args).await()"))
+@Deprecated(message = "Instead use tdigestTrimmedMean returning a future and chain with coAwait()", replaceWith = ReplaceWith("tdigestTrimmedMean(args).coAwait()"))
 suspend fun RedisAPI.tdigestTrimmedMeanAwait(args: List<String>): Response? {
   return awaitResult {
     this.tdigestTrimmedMean(args, it)
@@ -4602,7 +4602,7 @@ suspend fun RedisAPI.tdigestTrimmedMeanAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use time returning a future and chain with await()", replaceWith = ReplaceWith("time().await()"))
+@Deprecated(message = "Instead use time returning a future and chain with coAwait()", replaceWith = ReplaceWith("time().coAwait()"))
 suspend fun RedisAPI.timeAwait(): Response? {
   return awaitResult {
     this.time(it)
@@ -4617,7 +4617,7 @@ suspend fun RedisAPI.timeAwait(): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use timeseriesClusterset returning a future and chain with await()", replaceWith = ReplaceWith("timeseriesClusterset(args).await()"))
+@Deprecated(message = "Instead use timeseriesClusterset returning a future and chain with coAwait()", replaceWith = ReplaceWith("timeseriesClusterset(args).coAwait()"))
 suspend fun RedisAPI.timeseriesClustersetAwait(args: List<String>): Response? {
   return awaitResult {
     this.timeseriesClusterset(args, it)
@@ -4632,7 +4632,7 @@ suspend fun RedisAPI.timeseriesClustersetAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use timeseriesClustersetfromshard returning a future and chain with await()", replaceWith = ReplaceWith("timeseriesClustersetfromshard(args).await()"))
+@Deprecated(message = "Instead use timeseriesClustersetfromshard returning a future and chain with coAwait()", replaceWith = ReplaceWith("timeseriesClustersetfromshard(args).coAwait()"))
 suspend fun RedisAPI.timeseriesClustersetfromshardAwait(args: List<String>): Response? {
   return awaitResult {
     this.timeseriesClustersetfromshard(args, it)
@@ -4647,7 +4647,7 @@ suspend fun RedisAPI.timeseriesClustersetfromshardAwait(args: List<String>): Res
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use timeseriesHello returning a future and chain with await()", replaceWith = ReplaceWith("timeseriesHello(args).await()"))
+@Deprecated(message = "Instead use timeseriesHello returning a future and chain with coAwait()", replaceWith = ReplaceWith("timeseriesHello(args).coAwait()"))
 suspend fun RedisAPI.timeseriesHelloAwait(args: List<String>): Response? {
   return awaitResult {
     this.timeseriesHello(args, it)
@@ -4662,7 +4662,7 @@ suspend fun RedisAPI.timeseriesHelloAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use timeseriesInfocluster returning a future and chain with await()", replaceWith = ReplaceWith("timeseriesInfocluster(args).await()"))
+@Deprecated(message = "Instead use timeseriesInfocluster returning a future and chain with coAwait()", replaceWith = ReplaceWith("timeseriesInfocluster(args).coAwait()"))
 suspend fun RedisAPI.timeseriesInfoclusterAwait(args: List<String>): Response? {
   return awaitResult {
     this.timeseriesInfocluster(args, it)
@@ -4677,7 +4677,7 @@ suspend fun RedisAPI.timeseriesInfoclusterAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use timeseriesInnercommunication returning a future and chain with await()", replaceWith = ReplaceWith("timeseriesInnercommunication(args).await()"))
+@Deprecated(message = "Instead use timeseriesInnercommunication returning a future and chain with coAwait()", replaceWith = ReplaceWith("timeseriesInnercommunication(args).coAwait()"))
 suspend fun RedisAPI.timeseriesInnercommunicationAwait(args: List<String>): Response? {
   return awaitResult {
     this.timeseriesInnercommunication(args, it)
@@ -4692,7 +4692,7 @@ suspend fun RedisAPI.timeseriesInnercommunicationAwait(args: List<String>): Resp
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use timeseriesNetworktest returning a future and chain with await()", replaceWith = ReplaceWith("timeseriesNetworktest(args).await()"))
+@Deprecated(message = "Instead use timeseriesNetworktest returning a future and chain with coAwait()", replaceWith = ReplaceWith("timeseriesNetworktest(args).coAwait()"))
 suspend fun RedisAPI.timeseriesNetworktestAwait(args: List<String>): Response? {
   return awaitResult {
     this.timeseriesNetworktest(args, it)
@@ -4707,7 +4707,7 @@ suspend fun RedisAPI.timeseriesNetworktestAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use timeseriesRefreshcluster returning a future and chain with await()", replaceWith = ReplaceWith("timeseriesRefreshcluster(args).await()"))
+@Deprecated(message = "Instead use timeseriesRefreshcluster returning a future and chain with coAwait()", replaceWith = ReplaceWith("timeseriesRefreshcluster(args).coAwait()"))
 suspend fun RedisAPI.timeseriesRefreshclusterAwait(args: List<String>): Response? {
   return awaitResult {
     this.timeseriesRefreshcluster(args, it)
@@ -4722,7 +4722,7 @@ suspend fun RedisAPI.timeseriesRefreshclusterAwait(args: List<String>): Response
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use topkAdd returning a future and chain with await()", replaceWith = ReplaceWith("topkAdd(args).await()"))
+@Deprecated(message = "Instead use topkAdd returning a future and chain with coAwait()", replaceWith = ReplaceWith("topkAdd(args).coAwait()"))
 suspend fun RedisAPI.topkAddAwait(args: List<String>): Response? {
   return awaitResult {
     this.topkAdd(args, it)
@@ -4737,7 +4737,7 @@ suspend fun RedisAPI.topkAddAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use topkCount returning a future and chain with await()", replaceWith = ReplaceWith("topkCount(args).await()"))
+@Deprecated(message = "Instead use topkCount returning a future and chain with coAwait()", replaceWith = ReplaceWith("topkCount(args).coAwait()"))
 suspend fun RedisAPI.topkCountAwait(args: List<String>): Response? {
   return awaitResult {
     this.topkCount(args, it)
@@ -4752,7 +4752,7 @@ suspend fun RedisAPI.topkCountAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use topkIncrby returning a future and chain with await()", replaceWith = ReplaceWith("topkIncrby(args).await()"))
+@Deprecated(message = "Instead use topkIncrby returning a future and chain with coAwait()", replaceWith = ReplaceWith("topkIncrby(args).coAwait()"))
 suspend fun RedisAPI.topkIncrbyAwait(args: List<String>): Response? {
   return awaitResult {
     this.topkIncrby(args, it)
@@ -4767,7 +4767,7 @@ suspend fun RedisAPI.topkIncrbyAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use topkInfo returning a future and chain with await()", replaceWith = ReplaceWith("topkInfo(args).await()"))
+@Deprecated(message = "Instead use topkInfo returning a future and chain with coAwait()", replaceWith = ReplaceWith("topkInfo(args).coAwait()"))
 suspend fun RedisAPI.topkInfoAwait(args: List<String>): Response? {
   return awaitResult {
     this.topkInfo(args, it)
@@ -4782,7 +4782,7 @@ suspend fun RedisAPI.topkInfoAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use topkList returning a future and chain with await()", replaceWith = ReplaceWith("topkList(args).await()"))
+@Deprecated(message = "Instead use topkList returning a future and chain with coAwait()", replaceWith = ReplaceWith("topkList(args).coAwait()"))
 suspend fun RedisAPI.topkListAwait(args: List<String>): Response? {
   return awaitResult {
     this.topkList(args, it)
@@ -4797,7 +4797,7 @@ suspend fun RedisAPI.topkListAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use topkQuery returning a future and chain with await()", replaceWith = ReplaceWith("topkQuery(args).await()"))
+@Deprecated(message = "Instead use topkQuery returning a future and chain with coAwait()", replaceWith = ReplaceWith("topkQuery(args).coAwait()"))
 suspend fun RedisAPI.topkQueryAwait(args: List<String>): Response? {
   return awaitResult {
     this.topkQuery(args, it)
@@ -4812,7 +4812,7 @@ suspend fun RedisAPI.topkQueryAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use topkReserve returning a future and chain with await()", replaceWith = ReplaceWith("topkReserve(args).await()"))
+@Deprecated(message = "Instead use topkReserve returning a future and chain with coAwait()", replaceWith = ReplaceWith("topkReserve(args).coAwait()"))
 suspend fun RedisAPI.topkReserveAwait(args: List<String>): Response? {
   return awaitResult {
     this.topkReserve(args, it)
@@ -4827,7 +4827,7 @@ suspend fun RedisAPI.topkReserveAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use touch returning a future and chain with await()", replaceWith = ReplaceWith("touch(args).await()"))
+@Deprecated(message = "Instead use touch returning a future and chain with coAwait()", replaceWith = ReplaceWith("touch(args).coAwait()"))
 suspend fun RedisAPI.touchAwait(args: List<String>): Response? {
   return awaitResult {
     this.touch(args, it)
@@ -4842,7 +4842,7 @@ suspend fun RedisAPI.touchAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use tsAdd returning a future and chain with await()", replaceWith = ReplaceWith("tsAdd(args).await()"))
+@Deprecated(message = "Instead use tsAdd returning a future and chain with coAwait()", replaceWith = ReplaceWith("tsAdd(args).coAwait()"))
 suspend fun RedisAPI.tsAddAwait(args: List<String>): Response? {
   return awaitResult {
     this.tsAdd(args, it)
@@ -4857,7 +4857,7 @@ suspend fun RedisAPI.tsAddAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use tsAlter returning a future and chain with await()", replaceWith = ReplaceWith("tsAlter(args).await()"))
+@Deprecated(message = "Instead use tsAlter returning a future and chain with coAwait()", replaceWith = ReplaceWith("tsAlter(args).coAwait()"))
 suspend fun RedisAPI.tsAlterAwait(args: List<String>): Response? {
   return awaitResult {
     this.tsAlter(args, it)
@@ -4872,7 +4872,7 @@ suspend fun RedisAPI.tsAlterAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use tsCreate returning a future and chain with await()", replaceWith = ReplaceWith("tsCreate(args).await()"))
+@Deprecated(message = "Instead use tsCreate returning a future and chain with coAwait()", replaceWith = ReplaceWith("tsCreate(args).coAwait()"))
 suspend fun RedisAPI.tsCreateAwait(args: List<String>): Response? {
   return awaitResult {
     this.tsCreate(args, it)
@@ -4887,7 +4887,7 @@ suspend fun RedisAPI.tsCreateAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use tsCreaterule returning a future and chain with await()", replaceWith = ReplaceWith("tsCreaterule(args).await()"))
+@Deprecated(message = "Instead use tsCreaterule returning a future and chain with coAwait()", replaceWith = ReplaceWith("tsCreaterule(args).coAwait()"))
 suspend fun RedisAPI.tsCreateruleAwait(args: List<String>): Response? {
   return awaitResult {
     this.tsCreaterule(args, it)
@@ -4902,7 +4902,7 @@ suspend fun RedisAPI.tsCreateruleAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use tsDecrby returning a future and chain with await()", replaceWith = ReplaceWith("tsDecrby(args).await()"))
+@Deprecated(message = "Instead use tsDecrby returning a future and chain with coAwait()", replaceWith = ReplaceWith("tsDecrby(args).coAwait()"))
 suspend fun RedisAPI.tsDecrbyAwait(args: List<String>): Response? {
   return awaitResult {
     this.tsDecrby(args, it)
@@ -4917,7 +4917,7 @@ suspend fun RedisAPI.tsDecrbyAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use tsDel returning a future and chain with await()", replaceWith = ReplaceWith("tsDel(args).await()"))
+@Deprecated(message = "Instead use tsDel returning a future and chain with coAwait()", replaceWith = ReplaceWith("tsDel(args).coAwait()"))
 suspend fun RedisAPI.tsDelAwait(args: List<String>): Response? {
   return awaitResult {
     this.tsDel(args, it)
@@ -4932,7 +4932,7 @@ suspend fun RedisAPI.tsDelAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use tsDeleterule returning a future and chain with await()", replaceWith = ReplaceWith("tsDeleterule(args).await()"))
+@Deprecated(message = "Instead use tsDeleterule returning a future and chain with coAwait()", replaceWith = ReplaceWith("tsDeleterule(args).coAwait()"))
 suspend fun RedisAPI.tsDeleteruleAwait(args: List<String>): Response? {
   return awaitResult {
     this.tsDeleterule(args, it)
@@ -4947,7 +4947,7 @@ suspend fun RedisAPI.tsDeleteruleAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use tsGet returning a future and chain with await()", replaceWith = ReplaceWith("tsGet(args).await()"))
+@Deprecated(message = "Instead use tsGet returning a future and chain with coAwait()", replaceWith = ReplaceWith("tsGet(args).coAwait()"))
 suspend fun RedisAPI.tsGetAwait(args: List<String>): Response? {
   return awaitResult {
     this.tsGet(args, it)
@@ -4962,7 +4962,7 @@ suspend fun RedisAPI.tsGetAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use tsIncrby returning a future and chain with await()", replaceWith = ReplaceWith("tsIncrby(args).await()"))
+@Deprecated(message = "Instead use tsIncrby returning a future and chain with coAwait()", replaceWith = ReplaceWith("tsIncrby(args).coAwait()"))
 suspend fun RedisAPI.tsIncrbyAwait(args: List<String>): Response? {
   return awaitResult {
     this.tsIncrby(args, it)
@@ -4977,7 +4977,7 @@ suspend fun RedisAPI.tsIncrbyAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use tsInfo returning a future and chain with await()", replaceWith = ReplaceWith("tsInfo(args).await()"))
+@Deprecated(message = "Instead use tsInfo returning a future and chain with coAwait()", replaceWith = ReplaceWith("tsInfo(args).coAwait()"))
 suspend fun RedisAPI.tsInfoAwait(args: List<String>): Response? {
   return awaitResult {
     this.tsInfo(args, it)
@@ -4992,7 +4992,7 @@ suspend fun RedisAPI.tsInfoAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use tsMadd returning a future and chain with await()", replaceWith = ReplaceWith("tsMadd(args).await()"))
+@Deprecated(message = "Instead use tsMadd returning a future and chain with coAwait()", replaceWith = ReplaceWith("tsMadd(args).coAwait()"))
 suspend fun RedisAPI.tsMaddAwait(args: List<String>): Response? {
   return awaitResult {
     this.tsMadd(args, it)
@@ -5007,7 +5007,7 @@ suspend fun RedisAPI.tsMaddAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use tsMget returning a future and chain with await()", replaceWith = ReplaceWith("tsMget(args).await()"))
+@Deprecated(message = "Instead use tsMget returning a future and chain with coAwait()", replaceWith = ReplaceWith("tsMget(args).coAwait()"))
 suspend fun RedisAPI.tsMgetAwait(args: List<String>): Response? {
   return awaitResult {
     this.tsMget(args, it)
@@ -5022,7 +5022,7 @@ suspend fun RedisAPI.tsMgetAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use tsMrange returning a future and chain with await()", replaceWith = ReplaceWith("tsMrange(args).await()"))
+@Deprecated(message = "Instead use tsMrange returning a future and chain with coAwait()", replaceWith = ReplaceWith("tsMrange(args).coAwait()"))
 suspend fun RedisAPI.tsMrangeAwait(args: List<String>): Response? {
   return awaitResult {
     this.tsMrange(args, it)
@@ -5037,7 +5037,7 @@ suspend fun RedisAPI.tsMrangeAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use tsMrevrange returning a future and chain with await()", replaceWith = ReplaceWith("tsMrevrange(args).await()"))
+@Deprecated(message = "Instead use tsMrevrange returning a future and chain with coAwait()", replaceWith = ReplaceWith("tsMrevrange(args).coAwait()"))
 suspend fun RedisAPI.tsMrevrangeAwait(args: List<String>): Response? {
   return awaitResult {
     this.tsMrevrange(args, it)
@@ -5052,7 +5052,7 @@ suspend fun RedisAPI.tsMrevrangeAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use tsQueryindex returning a future and chain with await()", replaceWith = ReplaceWith("tsQueryindex(args).await()"))
+@Deprecated(message = "Instead use tsQueryindex returning a future and chain with coAwait()", replaceWith = ReplaceWith("tsQueryindex(args).coAwait()"))
 suspend fun RedisAPI.tsQueryindexAwait(args: List<String>): Response? {
   return awaitResult {
     this.tsQueryindex(args, it)
@@ -5067,7 +5067,7 @@ suspend fun RedisAPI.tsQueryindexAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use tsRange returning a future and chain with await()", replaceWith = ReplaceWith("tsRange(args).await()"))
+@Deprecated(message = "Instead use tsRange returning a future and chain with coAwait()", replaceWith = ReplaceWith("tsRange(args).coAwait()"))
 suspend fun RedisAPI.tsRangeAwait(args: List<String>): Response? {
   return awaitResult {
     this.tsRange(args, it)
@@ -5082,7 +5082,7 @@ suspend fun RedisAPI.tsRangeAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use tsRevrange returning a future and chain with await()", replaceWith = ReplaceWith("tsRevrange(args).await()"))
+@Deprecated(message = "Instead use tsRevrange returning a future and chain with coAwait()", replaceWith = ReplaceWith("tsRevrange(args).coAwait()"))
 suspend fun RedisAPI.tsRevrangeAwait(args: List<String>): Response? {
   return awaitResult {
     this.tsRevrange(args, it)
@@ -5097,7 +5097,7 @@ suspend fun RedisAPI.tsRevrangeAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use ttl returning a future and chain with await()", replaceWith = ReplaceWith("ttl(arg0).await()"))
+@Deprecated(message = "Instead use ttl returning a future and chain with coAwait()", replaceWith = ReplaceWith("ttl(arg0).coAwait()"))
 suspend fun RedisAPI.ttlAwait(arg0: String): Response? {
   return awaitResult {
     this.ttl(arg0, it)
@@ -5112,7 +5112,7 @@ suspend fun RedisAPI.ttlAwait(arg0: String): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use type returning a future and chain with await()", replaceWith = ReplaceWith("type(arg0).await()"))
+@Deprecated(message = "Instead use type returning a future and chain with coAwait()", replaceWith = ReplaceWith("type(arg0).coAwait()"))
 suspend fun RedisAPI.typeAwait(arg0: String): Response? {
   return awaitResult {
     this.type(arg0, it)
@@ -5127,7 +5127,7 @@ suspend fun RedisAPI.typeAwait(arg0: String): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use unlink returning a future and chain with await()", replaceWith = ReplaceWith("unlink(args).await()"))
+@Deprecated(message = "Instead use unlink returning a future and chain with coAwait()", replaceWith = ReplaceWith("unlink(args).coAwait()"))
 suspend fun RedisAPI.unlinkAwait(args: List<String>): Response? {
   return awaitResult {
     this.unlink(args, it)
@@ -5142,7 +5142,7 @@ suspend fun RedisAPI.unlinkAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use unsubscribe returning a future and chain with await()", replaceWith = ReplaceWith("unsubscribe(args).await()"))
+@Deprecated(message = "Instead use unsubscribe returning a future and chain with coAwait()", replaceWith = ReplaceWith("unsubscribe(args).coAwait()"))
 suspend fun RedisAPI.unsubscribeAwait(args: List<String>): Response? {
   return awaitResult {
     this.unsubscribe(args, it)
@@ -5156,7 +5156,7 @@ suspend fun RedisAPI.unsubscribeAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use unwatch returning a future and chain with await()", replaceWith = ReplaceWith("unwatch().await()"))
+@Deprecated(message = "Instead use unwatch returning a future and chain with coAwait()", replaceWith = ReplaceWith("unwatch().coAwait()"))
 suspend fun RedisAPI.unwatchAwait(): Response? {
   return awaitResult {
     this.unwatch(it)
@@ -5172,7 +5172,7 @@ suspend fun RedisAPI.unwatchAwait(): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use wait returning a future and chain with await()", replaceWith = ReplaceWith("wait(arg0, arg1).await()"))
+@Deprecated(message = "Instead use wait returning a future and chain with coAwait()", replaceWith = ReplaceWith("wait(arg0, arg1).coAwait()"))
 suspend fun RedisAPI.waitAwait(arg0: String, arg1: String): Response? {
   return awaitResult {
     this.wait(arg0, arg1, it)
@@ -5187,7 +5187,7 @@ suspend fun RedisAPI.waitAwait(arg0: String, arg1: String): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use watch returning a future and chain with await()", replaceWith = ReplaceWith("watch(args).await()"))
+@Deprecated(message = "Instead use watch returning a future and chain with coAwait()", replaceWith = ReplaceWith("watch(args).coAwait()"))
 suspend fun RedisAPI.watchAwait(args: List<String>): Response? {
   return awaitResult {
     this.watch(args, it)
@@ -5202,7 +5202,7 @@ suspend fun RedisAPI.watchAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use xack returning a future and chain with await()", replaceWith = ReplaceWith("xack(args).await()"))
+@Deprecated(message = "Instead use xack returning a future and chain with coAwait()", replaceWith = ReplaceWith("xack(args).coAwait()"))
 suspend fun RedisAPI.xackAwait(args: List<String>): Response? {
   return awaitResult {
     this.xack(args, it)
@@ -5217,7 +5217,7 @@ suspend fun RedisAPI.xackAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use xadd returning a future and chain with await()", replaceWith = ReplaceWith("xadd(args).await()"))
+@Deprecated(message = "Instead use xadd returning a future and chain with coAwait()", replaceWith = ReplaceWith("xadd(args).coAwait()"))
 suspend fun RedisAPI.xaddAwait(args: List<String>): Response? {
   return awaitResult {
     this.xadd(args, it)
@@ -5232,7 +5232,7 @@ suspend fun RedisAPI.xaddAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use xautoclaim returning a future and chain with await()", replaceWith = ReplaceWith("xautoclaim(args).await()"))
+@Deprecated(message = "Instead use xautoclaim returning a future and chain with coAwait()", replaceWith = ReplaceWith("xautoclaim(args).coAwait()"))
 suspend fun RedisAPI.xautoclaimAwait(args: List<String>): Response? {
   return awaitResult {
     this.xautoclaim(args, it)
@@ -5247,7 +5247,7 @@ suspend fun RedisAPI.xautoclaimAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use xclaim returning a future and chain with await()", replaceWith = ReplaceWith("xclaim(args).await()"))
+@Deprecated(message = "Instead use xclaim returning a future and chain with coAwait()", replaceWith = ReplaceWith("xclaim(args).coAwait()"))
 suspend fun RedisAPI.xclaimAwait(args: List<String>): Response? {
   return awaitResult {
     this.xclaim(args, it)
@@ -5262,7 +5262,7 @@ suspend fun RedisAPI.xclaimAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use xdel returning a future and chain with await()", replaceWith = ReplaceWith("xdel(args).await()"))
+@Deprecated(message = "Instead use xdel returning a future and chain with coAwait()", replaceWith = ReplaceWith("xdel(args).coAwait()"))
 suspend fun RedisAPI.xdelAwait(args: List<String>): Response? {
   return awaitResult {
     this.xdel(args, it)
@@ -5277,7 +5277,7 @@ suspend fun RedisAPI.xdelAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use xgroup returning a future and chain with await()", replaceWith = ReplaceWith("xgroup(args).await()"))
+@Deprecated(message = "Instead use xgroup returning a future and chain with coAwait()", replaceWith = ReplaceWith("xgroup(args).coAwait()"))
 suspend fun RedisAPI.xgroupAwait(args: List<String>): Response? {
   return awaitResult {
     this.xgroup(args, it)
@@ -5292,7 +5292,7 @@ suspend fun RedisAPI.xgroupAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use xinfo returning a future and chain with await()", replaceWith = ReplaceWith("xinfo(args).await()"))
+@Deprecated(message = "Instead use xinfo returning a future and chain with coAwait()", replaceWith = ReplaceWith("xinfo(args).coAwait()"))
 suspend fun RedisAPI.xinfoAwait(args: List<String>): Response? {
   return awaitResult {
     this.xinfo(args, it)
@@ -5307,7 +5307,7 @@ suspend fun RedisAPI.xinfoAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use xlen returning a future and chain with await()", replaceWith = ReplaceWith("xlen(arg0).await()"))
+@Deprecated(message = "Instead use xlen returning a future and chain with coAwait()", replaceWith = ReplaceWith("xlen(arg0).coAwait()"))
 suspend fun RedisAPI.xlenAwait(arg0: String): Response? {
   return awaitResult {
     this.xlen(arg0, it)
@@ -5322,7 +5322,7 @@ suspend fun RedisAPI.xlenAwait(arg0: String): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use xpending returning a future and chain with await()", replaceWith = ReplaceWith("xpending(args).await()"))
+@Deprecated(message = "Instead use xpending returning a future and chain with coAwait()", replaceWith = ReplaceWith("xpending(args).coAwait()"))
 suspend fun RedisAPI.xpendingAwait(args: List<String>): Response? {
   return awaitResult {
     this.xpending(args, it)
@@ -5337,7 +5337,7 @@ suspend fun RedisAPI.xpendingAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use xrange returning a future and chain with await()", replaceWith = ReplaceWith("xrange(args).await()"))
+@Deprecated(message = "Instead use xrange returning a future and chain with coAwait()", replaceWith = ReplaceWith("xrange(args).coAwait()"))
 suspend fun RedisAPI.xrangeAwait(args: List<String>): Response? {
   return awaitResult {
     this.xrange(args, it)
@@ -5352,7 +5352,7 @@ suspend fun RedisAPI.xrangeAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use xread returning a future and chain with await()", replaceWith = ReplaceWith("xread(args).await()"))
+@Deprecated(message = "Instead use xread returning a future and chain with coAwait()", replaceWith = ReplaceWith("xread(args).coAwait()"))
 suspend fun RedisAPI.xreadAwait(args: List<String>): Response? {
   return awaitResult {
     this.xread(args, it)
@@ -5367,7 +5367,7 @@ suspend fun RedisAPI.xreadAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use xreadgroup returning a future and chain with await()", replaceWith = ReplaceWith("xreadgroup(args).await()"))
+@Deprecated(message = "Instead use xreadgroup returning a future and chain with coAwait()", replaceWith = ReplaceWith("xreadgroup(args).coAwait()"))
 suspend fun RedisAPI.xreadgroupAwait(args: List<String>): Response? {
   return awaitResult {
     this.xreadgroup(args, it)
@@ -5382,7 +5382,7 @@ suspend fun RedisAPI.xreadgroupAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use xrevrange returning a future and chain with await()", replaceWith = ReplaceWith("xrevrange(args).await()"))
+@Deprecated(message = "Instead use xrevrange returning a future and chain with coAwait()", replaceWith = ReplaceWith("xrevrange(args).coAwait()"))
 suspend fun RedisAPI.xrevrangeAwait(args: List<String>): Response? {
   return awaitResult {
     this.xrevrange(args, it)
@@ -5397,7 +5397,7 @@ suspend fun RedisAPI.xrevrangeAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use xsetid returning a future and chain with await()", replaceWith = ReplaceWith("xsetid(args).await()"))
+@Deprecated(message = "Instead use xsetid returning a future and chain with coAwait()", replaceWith = ReplaceWith("xsetid(args).coAwait()"))
 suspend fun RedisAPI.xsetidAwait(args: List<String>): Response? {
   return awaitResult {
     this.xsetid(args, it)
@@ -5412,7 +5412,7 @@ suspend fun RedisAPI.xsetidAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use xtrim returning a future and chain with await()", replaceWith = ReplaceWith("xtrim(args).await()"))
+@Deprecated(message = "Instead use xtrim returning a future and chain with coAwait()", replaceWith = ReplaceWith("xtrim(args).coAwait()"))
 suspend fun RedisAPI.xtrimAwait(args: List<String>): Response? {
   return awaitResult {
     this.xtrim(args, it)
@@ -5427,7 +5427,7 @@ suspend fun RedisAPI.xtrimAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use zadd returning a future and chain with await()", replaceWith = ReplaceWith("zadd(args).await()"))
+@Deprecated(message = "Instead use zadd returning a future and chain with coAwait()", replaceWith = ReplaceWith("zadd(args).coAwait()"))
 suspend fun RedisAPI.zaddAwait(args: List<String>): Response? {
   return awaitResult {
     this.zadd(args, it)
@@ -5442,7 +5442,7 @@ suspend fun RedisAPI.zaddAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use zcard returning a future and chain with await()", replaceWith = ReplaceWith("zcard(arg0).await()"))
+@Deprecated(message = "Instead use zcard returning a future and chain with coAwait()", replaceWith = ReplaceWith("zcard(arg0).coAwait()"))
 suspend fun RedisAPI.zcardAwait(arg0: String): Response? {
   return awaitResult {
     this.zcard(arg0, it)
@@ -5459,7 +5459,7 @@ suspend fun RedisAPI.zcardAwait(arg0: String): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use zcount returning a future and chain with await()", replaceWith = ReplaceWith("zcount(arg0, arg1, arg2).await()"))
+@Deprecated(message = "Instead use zcount returning a future and chain with coAwait()", replaceWith = ReplaceWith("zcount(arg0, arg1, arg2).coAwait()"))
 suspend fun RedisAPI.zcountAwait(arg0: String, arg1: String, arg2: String): Response? {
   return awaitResult {
     this.zcount(arg0, arg1, arg2, it)
@@ -5474,7 +5474,7 @@ suspend fun RedisAPI.zcountAwait(arg0: String, arg1: String, arg2: String): Resp
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use zdiff returning a future and chain with await()", replaceWith = ReplaceWith("zdiff(args).await()"))
+@Deprecated(message = "Instead use zdiff returning a future and chain with coAwait()", replaceWith = ReplaceWith("zdiff(args).coAwait()"))
 suspend fun RedisAPI.zdiffAwait(args: List<String>): Response? {
   return awaitResult {
     this.zdiff(args, it)
@@ -5489,7 +5489,7 @@ suspend fun RedisAPI.zdiffAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use zdiffstore returning a future and chain with await()", replaceWith = ReplaceWith("zdiffstore(args).await()"))
+@Deprecated(message = "Instead use zdiffstore returning a future and chain with coAwait()", replaceWith = ReplaceWith("zdiffstore(args).coAwait()"))
 suspend fun RedisAPI.zdiffstoreAwait(args: List<String>): Response? {
   return awaitResult {
     this.zdiffstore(args, it)
@@ -5506,7 +5506,7 @@ suspend fun RedisAPI.zdiffstoreAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use zincrby returning a future and chain with await()", replaceWith = ReplaceWith("zincrby(arg0, arg1, arg2).await()"))
+@Deprecated(message = "Instead use zincrby returning a future and chain with coAwait()", replaceWith = ReplaceWith("zincrby(arg0, arg1, arg2).coAwait()"))
 suspend fun RedisAPI.zincrbyAwait(arg0: String, arg1: String, arg2: String): Response? {
   return awaitResult {
     this.zincrby(arg0, arg1, arg2, it)
@@ -5521,7 +5521,7 @@ suspend fun RedisAPI.zincrbyAwait(arg0: String, arg1: String, arg2: String): Res
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use zinter returning a future and chain with await()", replaceWith = ReplaceWith("zinter(args).await()"))
+@Deprecated(message = "Instead use zinter returning a future and chain with coAwait()", replaceWith = ReplaceWith("zinter(args).coAwait()"))
 suspend fun RedisAPI.zinterAwait(args: List<String>): Response? {
   return awaitResult {
     this.zinter(args, it)
@@ -5536,7 +5536,7 @@ suspend fun RedisAPI.zinterAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use zintercard returning a future and chain with await()", replaceWith = ReplaceWith("zintercard(args).await()"))
+@Deprecated(message = "Instead use zintercard returning a future and chain with coAwait()", replaceWith = ReplaceWith("zintercard(args).coAwait()"))
 suspend fun RedisAPI.zintercardAwait(args: List<String>): Response? {
   return awaitResult {
     this.zintercard(args, it)
@@ -5551,7 +5551,7 @@ suspend fun RedisAPI.zintercardAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use zinterstore returning a future and chain with await()", replaceWith = ReplaceWith("zinterstore(args).await()"))
+@Deprecated(message = "Instead use zinterstore returning a future and chain with coAwait()", replaceWith = ReplaceWith("zinterstore(args).coAwait()"))
 suspend fun RedisAPI.zinterstoreAwait(args: List<String>): Response? {
   return awaitResult {
     this.zinterstore(args, it)
@@ -5568,7 +5568,7 @@ suspend fun RedisAPI.zinterstoreAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use zlexcount returning a future and chain with await()", replaceWith = ReplaceWith("zlexcount(arg0, arg1, arg2).await()"))
+@Deprecated(message = "Instead use zlexcount returning a future and chain with coAwait()", replaceWith = ReplaceWith("zlexcount(arg0, arg1, arg2).coAwait()"))
 suspend fun RedisAPI.zlexcountAwait(arg0: String, arg1: String, arg2: String): Response? {
   return awaitResult {
     this.zlexcount(arg0, arg1, arg2, it)
@@ -5583,7 +5583,7 @@ suspend fun RedisAPI.zlexcountAwait(arg0: String, arg1: String, arg2: String): R
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use zmpop returning a future and chain with await()", replaceWith = ReplaceWith("zmpop(args).await()"))
+@Deprecated(message = "Instead use zmpop returning a future and chain with coAwait()", replaceWith = ReplaceWith("zmpop(args).coAwait()"))
 suspend fun RedisAPI.zmpopAwait(args: List<String>): Response? {
   return awaitResult {
     this.zmpop(args, it)
@@ -5598,7 +5598,7 @@ suspend fun RedisAPI.zmpopAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use zmscore returning a future and chain with await()", replaceWith = ReplaceWith("zmscore(args).await()"))
+@Deprecated(message = "Instead use zmscore returning a future and chain with coAwait()", replaceWith = ReplaceWith("zmscore(args).coAwait()"))
 suspend fun RedisAPI.zmscoreAwait(args: List<String>): Response? {
   return awaitResult {
     this.zmscore(args, it)
@@ -5613,7 +5613,7 @@ suspend fun RedisAPI.zmscoreAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use zpopmax returning a future and chain with await()", replaceWith = ReplaceWith("zpopmax(args).await()"))
+@Deprecated(message = "Instead use zpopmax returning a future and chain with coAwait()", replaceWith = ReplaceWith("zpopmax(args).coAwait()"))
 suspend fun RedisAPI.zpopmaxAwait(args: List<String>): Response? {
   return awaitResult {
     this.zpopmax(args, it)
@@ -5628,7 +5628,7 @@ suspend fun RedisAPI.zpopmaxAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use zpopmin returning a future and chain with await()", replaceWith = ReplaceWith("zpopmin(args).await()"))
+@Deprecated(message = "Instead use zpopmin returning a future and chain with coAwait()", replaceWith = ReplaceWith("zpopmin(args).coAwait()"))
 suspend fun RedisAPI.zpopminAwait(args: List<String>): Response? {
   return awaitResult {
     this.zpopmin(args, it)
@@ -5643,7 +5643,7 @@ suspend fun RedisAPI.zpopminAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use zrandmember returning a future and chain with await()", replaceWith = ReplaceWith("zrandmember(args).await()"))
+@Deprecated(message = "Instead use zrandmember returning a future and chain with coAwait()", replaceWith = ReplaceWith("zrandmember(args).coAwait()"))
 suspend fun RedisAPI.zrandmemberAwait(args: List<String>): Response? {
   return awaitResult {
     this.zrandmember(args, it)
@@ -5658,7 +5658,7 @@ suspend fun RedisAPI.zrandmemberAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use zrange returning a future and chain with await()", replaceWith = ReplaceWith("zrange(args).await()"))
+@Deprecated(message = "Instead use zrange returning a future and chain with coAwait()", replaceWith = ReplaceWith("zrange(args).coAwait()"))
 suspend fun RedisAPI.zrangeAwait(args: List<String>): Response? {
   return awaitResult {
     this.zrange(args, it)
@@ -5673,7 +5673,7 @@ suspend fun RedisAPI.zrangeAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use zrangebylex returning a future and chain with await()", replaceWith = ReplaceWith("zrangebylex(args).await()"))
+@Deprecated(message = "Instead use zrangebylex returning a future and chain with coAwait()", replaceWith = ReplaceWith("zrangebylex(args).coAwait()"))
 suspend fun RedisAPI.zrangebylexAwait(args: List<String>): Response? {
   return awaitResult {
     this.zrangebylex(args, it)
@@ -5688,7 +5688,7 @@ suspend fun RedisAPI.zrangebylexAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use zrangebyscore returning a future and chain with await()", replaceWith = ReplaceWith("zrangebyscore(args).await()"))
+@Deprecated(message = "Instead use zrangebyscore returning a future and chain with coAwait()", replaceWith = ReplaceWith("zrangebyscore(args).coAwait()"))
 suspend fun RedisAPI.zrangebyscoreAwait(args: List<String>): Response? {
   return awaitResult {
     this.zrangebyscore(args, it)
@@ -5703,7 +5703,7 @@ suspend fun RedisAPI.zrangebyscoreAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use zrangestore returning a future and chain with await()", replaceWith = ReplaceWith("zrangestore(args).await()"))
+@Deprecated(message = "Instead use zrangestore returning a future and chain with coAwait()", replaceWith = ReplaceWith("zrangestore(args).coAwait()"))
 suspend fun RedisAPI.zrangestoreAwait(args: List<String>): Response? {
   return awaitResult {
     this.zrangestore(args, it)
@@ -5719,7 +5719,7 @@ suspend fun RedisAPI.zrangestoreAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use zrank returning a future and chain with await()", replaceWith = ReplaceWith("zrank(arg0, arg1).await()"))
+@Deprecated(message = "Instead use zrank returning a future and chain with coAwait()", replaceWith = ReplaceWith("zrank(arg0, arg1).coAwait()"))
 suspend fun RedisAPI.zrankAwait(arg0: String, arg1: String): Response? {
   return awaitResult {
     this.zrank(arg0, arg1, it)
@@ -5734,7 +5734,7 @@ suspend fun RedisAPI.zrankAwait(arg0: String, arg1: String): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use zrem returning a future and chain with await()", replaceWith = ReplaceWith("zrem(args).await()"))
+@Deprecated(message = "Instead use zrem returning a future and chain with coAwait()", replaceWith = ReplaceWith("zrem(args).coAwait()"))
 suspend fun RedisAPI.zremAwait(args: List<String>): Response? {
   return awaitResult {
     this.zrem(args, it)
@@ -5751,7 +5751,7 @@ suspend fun RedisAPI.zremAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use zremrangebylex returning a future and chain with await()", replaceWith = ReplaceWith("zremrangebylex(arg0, arg1, arg2).await()"))
+@Deprecated(message = "Instead use zremrangebylex returning a future and chain with coAwait()", replaceWith = ReplaceWith("zremrangebylex(arg0, arg1, arg2).coAwait()"))
 suspend fun RedisAPI.zremrangebylexAwait(arg0: String, arg1: String, arg2: String): Response? {
   return awaitResult {
     this.zremrangebylex(arg0, arg1, arg2, it)
@@ -5768,7 +5768,7 @@ suspend fun RedisAPI.zremrangebylexAwait(arg0: String, arg1: String, arg2: Strin
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use zremrangebyrank returning a future and chain with await()", replaceWith = ReplaceWith("zremrangebyrank(arg0, arg1, arg2).await()"))
+@Deprecated(message = "Instead use zremrangebyrank returning a future and chain with coAwait()", replaceWith = ReplaceWith("zremrangebyrank(arg0, arg1, arg2).coAwait()"))
 suspend fun RedisAPI.zremrangebyrankAwait(arg0: String, arg1: String, arg2: String): Response? {
   return awaitResult {
     this.zremrangebyrank(arg0, arg1, arg2, it)
@@ -5785,7 +5785,7 @@ suspend fun RedisAPI.zremrangebyrankAwait(arg0: String, arg1: String, arg2: Stri
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use zremrangebyscore returning a future and chain with await()", replaceWith = ReplaceWith("zremrangebyscore(arg0, arg1, arg2).await()"))
+@Deprecated(message = "Instead use zremrangebyscore returning a future and chain with coAwait()", replaceWith = ReplaceWith("zremrangebyscore(arg0, arg1, arg2).coAwait()"))
 suspend fun RedisAPI.zremrangebyscoreAwait(arg0: String, arg1: String, arg2: String): Response? {
   return awaitResult {
     this.zremrangebyscore(arg0, arg1, arg2, it)
@@ -5800,7 +5800,7 @@ suspend fun RedisAPI.zremrangebyscoreAwait(arg0: String, arg1: String, arg2: Str
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use zrevrange returning a future and chain with await()", replaceWith = ReplaceWith("zrevrange(args).await()"))
+@Deprecated(message = "Instead use zrevrange returning a future and chain with coAwait()", replaceWith = ReplaceWith("zrevrange(args).coAwait()"))
 suspend fun RedisAPI.zrevrangeAwait(args: List<String>): Response? {
   return awaitResult {
     this.zrevrange(args, it)
@@ -5815,7 +5815,7 @@ suspend fun RedisAPI.zrevrangeAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use zrevrangebylex returning a future and chain with await()", replaceWith = ReplaceWith("zrevrangebylex(args).await()"))
+@Deprecated(message = "Instead use zrevrangebylex returning a future and chain with coAwait()", replaceWith = ReplaceWith("zrevrangebylex(args).coAwait()"))
 suspend fun RedisAPI.zrevrangebylexAwait(args: List<String>): Response? {
   return awaitResult {
     this.zrevrangebylex(args, it)
@@ -5830,7 +5830,7 @@ suspend fun RedisAPI.zrevrangebylexAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use zrevrangebyscore returning a future and chain with await()", replaceWith = ReplaceWith("zrevrangebyscore(args).await()"))
+@Deprecated(message = "Instead use zrevrangebyscore returning a future and chain with coAwait()", replaceWith = ReplaceWith("zrevrangebyscore(args).coAwait()"))
 suspend fun RedisAPI.zrevrangebyscoreAwait(args: List<String>): Response? {
   return awaitResult {
     this.zrevrangebyscore(args, it)
@@ -5846,7 +5846,7 @@ suspend fun RedisAPI.zrevrangebyscoreAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use zrevrank returning a future and chain with await()", replaceWith = ReplaceWith("zrevrank(arg0, arg1).await()"))
+@Deprecated(message = "Instead use zrevrank returning a future and chain with coAwait()", replaceWith = ReplaceWith("zrevrank(arg0, arg1).coAwait()"))
 suspend fun RedisAPI.zrevrankAwait(arg0: String, arg1: String): Response? {
   return awaitResult {
     this.zrevrank(arg0, arg1, it)
@@ -5861,7 +5861,7 @@ suspend fun RedisAPI.zrevrankAwait(arg0: String, arg1: String): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use zscan returning a future and chain with await()", replaceWith = ReplaceWith("zscan(args).await()"))
+@Deprecated(message = "Instead use zscan returning a future and chain with coAwait()", replaceWith = ReplaceWith("zscan(args).coAwait()"))
 suspend fun RedisAPI.zscanAwait(args: List<String>): Response? {
   return awaitResult {
     this.zscan(args, it)
@@ -5877,7 +5877,7 @@ suspend fun RedisAPI.zscanAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use zscore returning a future and chain with await()", replaceWith = ReplaceWith("zscore(arg0, arg1).await()"))
+@Deprecated(message = "Instead use zscore returning a future and chain with coAwait()", replaceWith = ReplaceWith("zscore(arg0, arg1).coAwait()"))
 suspend fun RedisAPI.zscoreAwait(arg0: String, arg1: String): Response? {
   return awaitResult {
     this.zscore(arg0, arg1, it)
@@ -5892,7 +5892,7 @@ suspend fun RedisAPI.zscoreAwait(arg0: String, arg1: String): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use zunion returning a future and chain with await()", replaceWith = ReplaceWith("zunion(args).await()"))
+@Deprecated(message = "Instead use zunion returning a future and chain with coAwait()", replaceWith = ReplaceWith("zunion(args).coAwait()"))
 suspend fun RedisAPI.zunionAwait(args: List<String>): Response? {
   return awaitResult {
     this.zunion(args, it)
@@ -5907,7 +5907,7 @@ suspend fun RedisAPI.zunionAwait(args: List<String>): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisAPI] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use zunionstore returning a future and chain with await()", replaceWith = ReplaceWith("zunionstore(args).await()"))
+@Deprecated(message = "Instead use zunionstore returning a future and chain with coAwait()", replaceWith = ReplaceWith("zunionstore(args).coAwait()"))
 suspend fun RedisAPI.zunionstoreAwait(args: List<String>): Response? {
   return awaitResult {
     this.zunionstore(args, it)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/redis/client/RedisConnection.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/redis/client/RedisConnection.kt
@@ -28,7 +28,7 @@ import io.vertx.redis.client.Response
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use pipeTo returning a future and chain with await()", replaceWith = ReplaceWith("pipeTo(dst).await()"))
+@Deprecated(message = "Instead use pipeTo returning a future and chain with coAwait()", replaceWith = ReplaceWith("pipeTo(dst).coAwait()"))
 suspend fun RedisConnection.pipeToAwait(dst: WriteStream<Response>): Unit {
   return awaitResult {
     this.pipeTo(dst, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -43,7 +43,7 @@ suspend fun RedisConnection.pipeToAwait(dst: WriteStream<Response>): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use send returning a future and chain with await()", replaceWith = ReplaceWith("send(command).await()"))
+@Deprecated(message = "Instead use send returning a future and chain with coAwait()", replaceWith = ReplaceWith("send(command).coAwait()"))
 suspend fun RedisConnection.sendAwait(command: Request): Response? {
   return awaitResult {
     this.send(command, it)
@@ -58,7 +58,7 @@ suspend fun RedisConnection.sendAwait(command: Request): Response? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use batch returning a future and chain with await()", replaceWith = ReplaceWith("batch(commands).await()"))
+@Deprecated(message = "Instead use batch returning a future and chain with coAwait()", replaceWith = ReplaceWith("batch(commands).coAwait()"))
 suspend fun RedisConnection.batchAwait(commands: List<Request>): List<Response?> {
   return awaitResult {
     this.batch(commands, it)
@@ -71,7 +71,7 @@ suspend fun RedisConnection.batchAwait(commands: List<Request>): List<Response?>
  *
  * NOTE: This function has been automatically generated from [io.vertx.redis.client.RedisConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use close returning a future and chain with await()", replaceWith = ReplaceWith("close().await()"))
+@Deprecated(message = "Instead use close returning a future and chain with coAwait()", replaceWith = ReplaceWith("close().coAwait()"))
 suspend fun RedisConnection.closeAwait(): Unit {
   return awaitResult {
     this.close(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/redis/client/RedisReplicationConnectOptions.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/redis/client/RedisReplicationConnectOptions.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package io.vertx.kotlin.redis.client
+
+import io.vertx.redis.client.RedisReplicationConnectOptions
+import io.vertx.redis.client.ProtocolVersion
+import io.vertx.redis.client.RedisReplicas
+import io.vertx.redis.client.RedisTopology
+
+fun redisReplicationConnectOptionsOf(
+  connectionString: String? = null,
+  connectionStrings: Iterable<String>? = null,
+  endpoints: Iterable<String>? = null,
+  maxNestedArrays: Int? = null,
+  maxWaitingHandlers: Int? = null,
+  password: String? = null,
+  preferredProtocolVersion: ProtocolVersion? = null,
+  protocolNegotiation: Boolean? = null,
+  topology: RedisTopology? = null,
+  useReplicas: RedisReplicas? = null): RedisReplicationConnectOptions = io.vertx.redis.client.RedisReplicationConnectOptions().apply {
+
+  if (connectionString != null) {
+    this.setConnectionString(connectionString)
+  }
+  if (connectionStrings != null) {
+    for (item in connectionStrings) {
+      this.addConnectionString(item)
+    }
+  }
+  if (endpoints != null) {
+    this.setEndpoints(endpoints.toList())
+  }
+  if (maxNestedArrays != null) {
+    this.setMaxNestedArrays(maxNestedArrays)
+  }
+  if (maxWaitingHandlers != null) {
+    this.setMaxWaitingHandlers(maxWaitingHandlers)
+  }
+  if (password != null) {
+    this.setPassword(password)
+  }
+  if (preferredProtocolVersion != null) {
+    this.setPreferredProtocolVersion(preferredProtocolVersion)
+  }
+  if (protocolNegotiation != null) {
+    this.setProtocolNegotiation(protocolNegotiation)
+  }
+  if (topology != null) {
+    this.setTopology(topology)
+  }
+  if (useReplicas != null) {
+    this.setUseReplicas(useReplicas)
+  }
+}
+

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/servicediscovery/ServiceDiscovery.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/servicediscovery/ServiceDiscovery.kt
@@ -31,7 +31,7 @@ import java.util.function.Function
  *
  * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.ServiceDiscovery] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use registerServiceImporter returning a future and chain with await()", replaceWith = ReplaceWith("registerServiceImporter(importer, configuration).await()"))
+@Deprecated(message = "Instead use registerServiceImporter returning a future and chain with coAwait()", replaceWith = ReplaceWith("registerServiceImporter(importer, configuration).coAwait()"))
 suspend fun ServiceDiscovery.registerServiceImporterAwait(importer: ServiceImporter, configuration: JsonObject): Unit {
   return awaitResult {
     this.registerServiceImporter(importer, configuration, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -46,7 +46,7 @@ suspend fun ServiceDiscovery.registerServiceImporterAwait(importer: ServiceImpor
  *
  * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.ServiceDiscovery] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use registerServiceExporter returning a future and chain with await()", replaceWith = ReplaceWith("registerServiceExporter(exporter, configuration).await()"))
+@Deprecated(message = "Instead use registerServiceExporter returning a future and chain with coAwait()", replaceWith = ReplaceWith("registerServiceExporter(exporter, configuration).coAwait()"))
 suspend fun ServiceDiscovery.registerServiceExporterAwait(exporter: ServiceExporter, configuration: JsonObject): Unit {
   return awaitResult {
     this.registerServiceExporter(exporter, configuration, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -61,7 +61,7 @@ suspend fun ServiceDiscovery.registerServiceExporterAwait(exporter: ServiceExpor
  *
  * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.ServiceDiscovery] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use publish returning a future and chain with await()", replaceWith = ReplaceWith("publish(record).await()"))
+@Deprecated(message = "Instead use publish returning a future and chain with coAwait()", replaceWith = ReplaceWith("publish(record).coAwait()"))
 suspend fun ServiceDiscovery.publishAwait(record: Record): Record {
   return awaitResult {
     this.publish(record, it)
@@ -75,7 +75,7 @@ suspend fun ServiceDiscovery.publishAwait(record: Record): Record {
  *
  * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.ServiceDiscovery] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use unpublish returning a future and chain with await()", replaceWith = ReplaceWith("unpublish(id).await()"))
+@Deprecated(message = "Instead use unpublish returning a future and chain with coAwait()", replaceWith = ReplaceWith("unpublish(id).coAwait()"))
 suspend fun ServiceDiscovery.unpublishAwait(id: String): Unit {
   return awaitResult {
     this.unpublish(id, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -90,7 +90,7 @@ suspend fun ServiceDiscovery.unpublishAwait(id: String): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.ServiceDiscovery] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use getRecord returning a future and chain with await()", replaceWith = ReplaceWith("getRecord(filter).await()"))
+@Deprecated(message = "Instead use getRecord returning a future and chain with coAwait()", replaceWith = ReplaceWith("getRecord(filter).coAwait()"))
 suspend fun ServiceDiscovery.getRecordAwait(filter: JsonObject): Record? {
   return awaitResult {
     this.getRecord(filter, it)
@@ -105,7 +105,7 @@ suspend fun ServiceDiscovery.getRecordAwait(filter: JsonObject): Record? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.ServiceDiscovery] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use getRecord returning a future and chain with await()", replaceWith = ReplaceWith("getRecord(id).await()"))
+@Deprecated(message = "Instead use getRecord returning a future and chain with coAwait()", replaceWith = ReplaceWith("getRecord(id).coAwait()"))
 suspend fun ServiceDiscovery.getRecordAwait(id: String): Record? {
   return awaitResult {
     this.getRecord(id, it)
@@ -120,7 +120,7 @@ suspend fun ServiceDiscovery.getRecordAwait(id: String): Record? {
  *
  * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.ServiceDiscovery] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use getRecord returning a future and chain with await()", replaceWith = ReplaceWith("getRecord(filter).await()"))
+@Deprecated(message = "Instead use getRecord returning a future and chain with coAwait()", replaceWith = ReplaceWith("getRecord(filter).coAwait()"))
 suspend fun ServiceDiscovery.getRecordAwait(filter: (Record) -> Boolean): Record? {
   return awaitResult {
     this.getRecord(filter, it::handle)
@@ -136,7 +136,7 @@ suspend fun ServiceDiscovery.getRecordAwait(filter: (Record) -> Boolean): Record
  *
  * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.ServiceDiscovery] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use getRecord returning a future and chain with await()", replaceWith = ReplaceWith("getRecord(filter, includeOutOfService).await()"))
+@Deprecated(message = "Instead use getRecord returning a future and chain with coAwait()", replaceWith = ReplaceWith("getRecord(filter, includeOutOfService).coAwait()"))
 suspend fun ServiceDiscovery.getRecordAwait(filter: (Record) -> Boolean, includeOutOfService: Boolean): Record? {
   return awaitResult {
     this.getRecord(filter, includeOutOfService, it::handle)
@@ -151,7 +151,7 @@ suspend fun ServiceDiscovery.getRecordAwait(filter: (Record) -> Boolean, include
  *
  * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.ServiceDiscovery] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use getRecords returning a future and chain with await()", replaceWith = ReplaceWith("getRecords(filter).await()"))
+@Deprecated(message = "Instead use getRecords returning a future and chain with coAwait()", replaceWith = ReplaceWith("getRecords(filter).coAwait()"))
 suspend fun ServiceDiscovery.getRecordsAwait(filter: JsonObject): List<Record> {
   return awaitResult {
     this.getRecords(filter, it)
@@ -166,7 +166,7 @@ suspend fun ServiceDiscovery.getRecordsAwait(filter: JsonObject): List<Record> {
  *
  * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.ServiceDiscovery] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use getRecords returning a future and chain with await()", replaceWith = ReplaceWith("getRecords(filter).await()"))
+@Deprecated(message = "Instead use getRecords returning a future and chain with coAwait()", replaceWith = ReplaceWith("getRecords(filter).coAwait()"))
 suspend fun ServiceDiscovery.getRecordsAwait(filter: (Record) -> Boolean): List<Record> {
   return awaitResult {
     this.getRecords(filter, it::handle)
@@ -182,7 +182,7 @@ suspend fun ServiceDiscovery.getRecordsAwait(filter: (Record) -> Boolean): List<
  *
  * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.ServiceDiscovery] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use getRecords returning a future and chain with await()", replaceWith = ReplaceWith("getRecords(filter, includeOutOfService).await()"))
+@Deprecated(message = "Instead use getRecords returning a future and chain with coAwait()", replaceWith = ReplaceWith("getRecords(filter, includeOutOfService).coAwait()"))
 suspend fun ServiceDiscovery.getRecordsAwait(filter: (Record) -> Boolean, includeOutOfService: Boolean): List<Record> {
   return awaitResult {
     this.getRecords(filter, includeOutOfService, it::handle)
@@ -197,7 +197,7 @@ suspend fun ServiceDiscovery.getRecordsAwait(filter: (Record) -> Boolean, includ
  *
  * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.ServiceDiscovery] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use update returning a future and chain with await()", replaceWith = ReplaceWith("update(record).await()"))
+@Deprecated(message = "Instead use update returning a future and chain with coAwait()", replaceWith = ReplaceWith("update(record).coAwait()"))
 suspend fun ServiceDiscovery.updateAwait(record: Record): Record {
   return awaitResult {
     this.update(record, it)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/servicediscovery/spi/ServicePublisher.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/servicediscovery/spi/ServicePublisher.kt
@@ -27,7 +27,7 @@ import io.vertx.servicediscovery.spi.ServicePublisher
  *
  * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.spi.ServicePublisher] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use publish returning a future and chain with await()", replaceWith = ReplaceWith("publish(record).await()"))
+@Deprecated(message = "Instead use publish returning a future and chain with coAwait()", replaceWith = ReplaceWith("publish(record).coAwait()"))
 suspend fun ServicePublisher.publishAwait(record: Record): Record {
   return awaitResult {
     this.publish(record, it)
@@ -41,7 +41,7 @@ suspend fun ServicePublisher.publishAwait(record: Record): Record {
  *
  * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.spi.ServicePublisher] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use unpublish returning a future and chain with await()", replaceWith = ReplaceWith("unpublish(id).await()"))
+@Deprecated(message = "Instead use unpublish returning a future and chain with coAwait()", replaceWith = ReplaceWith("unpublish(id).coAwait()"))
 suspend fun ServicePublisher.unpublishAwait(id: String): Unit {
   return awaitResult {
     this.unpublish(id, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -56,7 +56,7 @@ suspend fun ServicePublisher.unpublishAwait(id: String): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.spi.ServicePublisher] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use update returning a future and chain with await()", replaceWith = ReplaceWith("update(record).await()"))
+@Deprecated(message = "Instead use update returning a future and chain with coAwait()", replaceWith = ReplaceWith("update(record).coAwait()"))
 suspend fun ServicePublisher.updateAwait(record: Record): Record {
   return awaitResult {
     this.update(record, it)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/servicediscovery/types/HttpEndpoint.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/servicediscovery/types/HttpEndpoint.kt
@@ -34,7 +34,7 @@ object HttpEndpoint {
    *
    * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.types.HttpEndpoint] using Vert.x codegen.
    */
-  @Deprecated(message = "Instead use getClient returning a future and chain with await()", replaceWith = ReplaceWith("getClient(discovery, filter).await()"))
+  @Deprecated(message = "Instead use getClient returning a future and chain with coAwait()", replaceWith = ReplaceWith("getClient(discovery, filter).coAwait()"))
   suspend fun getClientAwait(discovery: ServiceDiscovery, filter: JsonObject): HttpClient {
     return awaitResult {
       HttpEndpointVertxAlias.getClient(discovery, filter, it)
@@ -50,7 +50,7 @@ object HttpEndpoint {
    *
    * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.types.HttpEndpoint] using Vert.x codegen.
    */
-  @Deprecated(message = "Instead use getWebClient returning a future and chain with await()", replaceWith = ReplaceWith("getWebClient(discovery, filter).await()"))
+  @Deprecated(message = "Instead use getWebClient returning a future and chain with coAwait()", replaceWith = ReplaceWith("getWebClient(discovery, filter).coAwait()"))
   suspend fun getWebClientAwait(discovery: ServiceDiscovery, filter: JsonObject): WebClient {
     return awaitResult {
       HttpEndpointVertxAlias.getWebClient(discovery, filter, it)
@@ -67,7 +67,7 @@ object HttpEndpoint {
    *
    * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.types.HttpEndpoint] using Vert.x codegen.
    */
-  @Deprecated(message = "Instead use getClient returning a future and chain with await()", replaceWith = ReplaceWith("getClient(discovery, filter, conf).await()"))
+  @Deprecated(message = "Instead use getClient returning a future and chain with coAwait()", replaceWith = ReplaceWith("getClient(discovery, filter, conf).coAwait()"))
   suspend fun getClientAwait(discovery: ServiceDiscovery, filter: JsonObject, conf: JsonObject): HttpClient {
     return awaitResult {
       HttpEndpointVertxAlias.getClient(discovery, filter, conf, it)
@@ -84,7 +84,7 @@ object HttpEndpoint {
    *
    * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.types.HttpEndpoint] using Vert.x codegen.
    */
-  @Deprecated(message = "Instead use getWebClient returning a future and chain with await()", replaceWith = ReplaceWith("getWebClient(discovery, filter, conf).await()"))
+  @Deprecated(message = "Instead use getWebClient returning a future and chain with coAwait()", replaceWith = ReplaceWith("getWebClient(discovery, filter, conf).coAwait()"))
   suspend fun getWebClientAwait(discovery: ServiceDiscovery, filter: JsonObject, conf: JsonObject): WebClient {
     return awaitResult {
       HttpEndpointVertxAlias.getWebClient(discovery, filter, conf, it)
@@ -100,7 +100,7 @@ object HttpEndpoint {
    *
    * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.types.HttpEndpoint] using Vert.x codegen.
    */
-  @Deprecated(message = "Instead use getClient returning a future and chain with await()", replaceWith = ReplaceWith("getClient(discovery, filter).await()"))
+  @Deprecated(message = "Instead use getClient returning a future and chain with coAwait()", replaceWith = ReplaceWith("getClient(discovery, filter).coAwait()"))
   suspend fun getClientAwait(discovery: ServiceDiscovery, filter: (Record) -> Boolean): HttpClient {
     return awaitResult {
       HttpEndpointVertxAlias.getClient(discovery, filter, it::handle)
@@ -116,7 +116,7 @@ object HttpEndpoint {
    *
    * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.types.HttpEndpoint] using Vert.x codegen.
    */
-  @Deprecated(message = "Instead use getWebClient returning a future and chain with await()", replaceWith = ReplaceWith("getWebClient(discovery, filter).await()"))
+  @Deprecated(message = "Instead use getWebClient returning a future and chain with coAwait()", replaceWith = ReplaceWith("getWebClient(discovery, filter).coAwait()"))
   suspend fun getWebClientAwait(discovery: ServiceDiscovery, filter: (Record) -> Boolean): WebClient {
     return awaitResult {
       HttpEndpointVertxAlias.getWebClient(discovery, filter, it::handle)
@@ -133,7 +133,7 @@ object HttpEndpoint {
    *
    * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.types.HttpEndpoint] using Vert.x codegen.
    */
-  @Deprecated(message = "Instead use getClient returning a future and chain with await()", replaceWith = ReplaceWith("getClient(discovery, filter, conf).await()"))
+  @Deprecated(message = "Instead use getClient returning a future and chain with coAwait()", replaceWith = ReplaceWith("getClient(discovery, filter, conf).coAwait()"))
   suspend fun getClientAwait(discovery: ServiceDiscovery, filter: (Record) -> Boolean, conf: JsonObject): HttpClient {
     return awaitResult {
       HttpEndpointVertxAlias.getClient(discovery, filter, conf, it::handle)
@@ -150,7 +150,7 @@ object HttpEndpoint {
    *
    * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.types.HttpEndpoint] using Vert.x codegen.
    */
-  @Deprecated(message = "Instead use getWebClient returning a future and chain with await()", replaceWith = ReplaceWith("getWebClient(discovery, filter, conf).await()"))
+  @Deprecated(message = "Instead use getWebClient returning a future and chain with coAwait()", replaceWith = ReplaceWith("getWebClient(discovery, filter, conf).coAwait()"))
   suspend fun getWebClientAwait(discovery: ServiceDiscovery, filter: (Record) -> Boolean, conf: JsonObject): WebClient {
     return awaitResult {
       HttpEndpointVertxAlias.getWebClient(discovery, filter, conf, it::handle)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/servicediscovery/types/JDBCDataSource.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/servicediscovery/types/JDBCDataSource.kt
@@ -33,7 +33,7 @@ object JDBCDataSource {
    *
    * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.types.JDBCDataSource] using Vert.x codegen.
    */
-  @Deprecated(message = "Instead use getJDBCClient returning a future and chain with await()", replaceWith = ReplaceWith("getJDBCClient(discovery, filter).await()"))
+  @Deprecated(message = "Instead use getJDBCClient returning a future and chain with coAwait()", replaceWith = ReplaceWith("getJDBCClient(discovery, filter).coAwait()"))
   suspend fun getJDBCClientAwait(discovery: ServiceDiscovery, filter: JsonObject): JDBCClient {
     return awaitResult {
       JDBCDataSourceVertxAlias.getJDBCClient(discovery, filter, it)
@@ -49,7 +49,7 @@ object JDBCDataSource {
    *
    * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.types.JDBCDataSource] using Vert.x codegen.
    */
-  @Deprecated(message = "Instead use getJDBCClient returning a future and chain with await()", replaceWith = ReplaceWith("getJDBCClient(discovery, filter).await()"))
+  @Deprecated(message = "Instead use getJDBCClient returning a future and chain with coAwait()", replaceWith = ReplaceWith("getJDBCClient(discovery, filter).coAwait()"))
   suspend fun getJDBCClientAwait(discovery: ServiceDiscovery, filter: (Record) -> Boolean): JDBCClient {
     return awaitResult {
       JDBCDataSourceVertxAlias.getJDBCClient(discovery, filter, it::handle)
@@ -66,7 +66,7 @@ object JDBCDataSource {
    *
    * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.types.JDBCDataSource] using Vert.x codegen.
    */
-  @Deprecated(message = "Instead use getJDBCClient returning a future and chain with await()", replaceWith = ReplaceWith("getJDBCClient(discovery, filter, consumerConfiguration).await()"))
+  @Deprecated(message = "Instead use getJDBCClient returning a future and chain with coAwait()", replaceWith = ReplaceWith("getJDBCClient(discovery, filter, consumerConfiguration).coAwait()"))
   suspend fun getJDBCClientAwait(discovery: ServiceDiscovery, filter: JsonObject, consumerConfiguration: JsonObject): JDBCClient {
     return awaitResult {
       JDBCDataSourceVertxAlias.getJDBCClient(discovery, filter, consumerConfiguration, it)
@@ -83,7 +83,7 @@ object JDBCDataSource {
    *
    * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.types.JDBCDataSource] using Vert.x codegen.
    */
-  @Deprecated(message = "Instead use getJDBCClient returning a future and chain with await()", replaceWith = ReplaceWith("getJDBCClient(discovery, filter, consumerConfiguration).await()"))
+  @Deprecated(message = "Instead use getJDBCClient returning a future and chain with coAwait()", replaceWith = ReplaceWith("getJDBCClient(discovery, filter, consumerConfiguration).coAwait()"))
   suspend fun getJDBCClientAwait(discovery: ServiceDiscovery, filter: (Record) -> Boolean, consumerConfiguration: JsonObject): JDBCClient {
     return awaitResult {
       JDBCDataSourceVertxAlias.getJDBCClient(discovery, filter, consumerConfiguration, it::handle)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/servicediscovery/types/MessageSource.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/servicediscovery/types/MessageSource.kt
@@ -33,7 +33,7 @@ object MessageSource {
    *
    * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.types.MessageSource] using Vert.x codegen.
    */
-  @Deprecated(message = "Instead use getConsumer returning a future and chain with await()", replaceWith = ReplaceWith("getConsumer(discovery, filter).await()"))
+  @Deprecated(message = "Instead use getConsumer returning a future and chain with coAwait()", replaceWith = ReplaceWith("getConsumer(discovery, filter).coAwait()"))
   suspend fun <T> getConsumerAwait(discovery: ServiceDiscovery, filter: JsonObject): MessageConsumer<T> {
     return awaitResult {
       MessageSourceVertxAlias.getConsumer(discovery, filter, it)
@@ -49,7 +49,7 @@ object MessageSource {
    *
    * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.types.MessageSource] using Vert.x codegen.
    */
-  @Deprecated(message = "Instead use getConsumer returning a future and chain with await()", replaceWith = ReplaceWith("getConsumer(discovery, filter).await()"))
+  @Deprecated(message = "Instead use getConsumer returning a future and chain with coAwait()", replaceWith = ReplaceWith("getConsumer(discovery, filter).coAwait()"))
   suspend fun <T> getConsumerAwait(discovery: ServiceDiscovery, filter: (Record) -> Boolean): MessageConsumer<T> {
     return awaitResult {
       MessageSourceVertxAlias.getConsumer(discovery, filter, it::handle)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/servicediscovery/types/MongoDataSource.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/servicediscovery/types/MongoDataSource.kt
@@ -33,7 +33,7 @@ object MongoDataSource {
    *
    * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.types.MongoDataSource] using Vert.x codegen.
    */
-  @Deprecated(message = "Instead use getMongoClient returning a future and chain with await()", replaceWith = ReplaceWith("getMongoClient(discovery, filter).await()"))
+  @Deprecated(message = "Instead use getMongoClient returning a future and chain with coAwait()", replaceWith = ReplaceWith("getMongoClient(discovery, filter).coAwait()"))
   suspend fun getMongoClientAwait(discovery: ServiceDiscovery, filter: JsonObject): MongoClient {
     return awaitResult {
       MongoDataSourceVertxAlias.getMongoClient(discovery, filter, it)
@@ -49,7 +49,7 @@ object MongoDataSource {
    *
    * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.types.MongoDataSource] using Vert.x codegen.
    */
-  @Deprecated(message = "Instead use getMongoClient returning a future and chain with await()", replaceWith = ReplaceWith("getMongoClient(discovery, filter).await()"))
+  @Deprecated(message = "Instead use getMongoClient returning a future and chain with coAwait()", replaceWith = ReplaceWith("getMongoClient(discovery, filter).coAwait()"))
   suspend fun getMongoClientAwait(discovery: ServiceDiscovery, filter: (Record) -> Boolean): MongoClient {
     return awaitResult {
       MongoDataSourceVertxAlias.getMongoClient(discovery, filter, it::handle)
@@ -66,7 +66,7 @@ object MongoDataSource {
    *
    * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.types.MongoDataSource] using Vert.x codegen.
    */
-  @Deprecated(message = "Instead use getMongoClient returning a future and chain with await()", replaceWith = ReplaceWith("getMongoClient(discovery, filter, consumerConfiguration).await()"))
+  @Deprecated(message = "Instead use getMongoClient returning a future and chain with coAwait()", replaceWith = ReplaceWith("getMongoClient(discovery, filter, consumerConfiguration).coAwait()"))
   suspend fun getMongoClientAwait(discovery: ServiceDiscovery, filter: JsonObject, consumerConfiguration: JsonObject): MongoClient {
     return awaitResult {
       MongoDataSourceVertxAlias.getMongoClient(discovery, filter, consumerConfiguration, it)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/servicediscovery/types/RedisDataSource.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/servicediscovery/types/RedisDataSource.kt
@@ -33,7 +33,7 @@ object RedisDataSource {
    *
    * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.types.RedisDataSource] using Vert.x codegen.
    */
-  @Deprecated(message = "Instead use getRedisClient returning a future and chain with await()", replaceWith = ReplaceWith("getRedisClient(discovery, filter).await()"))
+  @Deprecated(message = "Instead use getRedisClient returning a future and chain with coAwait()", replaceWith = ReplaceWith("getRedisClient(discovery, filter).coAwait()"))
   suspend fun getRedisClientAwait(discovery: ServiceDiscovery, filter: JsonObject): Redis {
     return awaitResult {
       RedisDataSourceVertxAlias.getRedisClient(discovery, filter, it)
@@ -49,7 +49,7 @@ object RedisDataSource {
    *
    * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.types.RedisDataSource] using Vert.x codegen.
    */
-  @Deprecated(message = "Instead use getRedisClient returning a future and chain with await()", replaceWith = ReplaceWith("getRedisClient(discovery, filter).await()"))
+  @Deprecated(message = "Instead use getRedisClient returning a future and chain with coAwait()", replaceWith = ReplaceWith("getRedisClient(discovery, filter).coAwait()"))
   suspend fun getRedisClientAwait(discovery: ServiceDiscovery, filter: (Record) -> Boolean): Redis {
     return awaitResult {
       RedisDataSourceVertxAlias.getRedisClient(discovery, filter, it::handle)
@@ -66,7 +66,7 @@ object RedisDataSource {
    *
    * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.types.RedisDataSource] using Vert.x codegen.
    */
-  @Deprecated(message = "Instead use getRedisClient returning a future and chain with await()", replaceWith = ReplaceWith("getRedisClient(discovery, filter, consumerConfiguration).await()"))
+  @Deprecated(message = "Instead use getRedisClient returning a future and chain with coAwait()", replaceWith = ReplaceWith("getRedisClient(discovery, filter, consumerConfiguration).coAwait()"))
   suspend fun getRedisClientAwait(discovery: ServiceDiscovery, filter: JsonObject, consumerConfiguration: JsonObject): Redis {
     return awaitResult {
       RedisDataSourceVertxAlias.getRedisClient(discovery, filter, consumerConfiguration, it)
@@ -83,7 +83,7 @@ object RedisDataSource {
    *
    * NOTE: This function has been automatically generated from [io.vertx.servicediscovery.types.RedisDataSource] using Vert.x codegen.
    */
-  @Deprecated(message = "Instead use getRedisClient returning a future and chain with await()", replaceWith = ReplaceWith("getRedisClient(discovery, filter, consumerConfiguration).await()"))
+  @Deprecated(message = "Instead use getRedisClient returning a future and chain with coAwait()", replaceWith = ReplaceWith("getRedisClient(discovery, filter, consumerConfiguration).coAwait()"))
   suspend fun getRedisClientAwait(discovery: ServiceDiscovery, filter: (Record) -> Boolean, consumerConfiguration: JsonObject): Redis {
     return awaitResult {
       RedisDataSourceVertxAlias.getRedisClient(discovery, filter, consumerConfiguration, it::handle)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/sqlclient/Cursor.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/sqlclient/Cursor.kt
@@ -28,7 +28,7 @@ import io.vertx.sqlclient.RowSet
  *
  * NOTE: This function has been automatically generated from [io.vertx.sqlclient.Cursor] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use read returning a future and chain with await()", replaceWith = ReplaceWith("read(count).await()"))
+@Deprecated(message = "Instead use read returning a future and chain with coAwait()", replaceWith = ReplaceWith("read(count).coAwait()"))
 suspend fun Cursor.readAwait(count: Int): RowSet<Row> {
   return awaitResult {
     this.read(count, it)
@@ -41,7 +41,7 @@ suspend fun Cursor.readAwait(count: Int): RowSet<Row> {
  *
  * NOTE: This function has been automatically generated from [io.vertx.sqlclient.Cursor] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use close returning a future and chain with await()", replaceWith = ReplaceWith("close().await()"))
+@Deprecated(message = "Instead use close returning a future and chain with coAwait()", replaceWith = ReplaceWith("close().coAwait()"))
 suspend fun Cursor.closeAwait(): Unit {
   return awaitResult {
     this.close(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/sqlclient/Pool.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/sqlclient/Pool.kt
@@ -29,7 +29,7 @@ import java.util.function.Function
  *
  * NOTE: This function has been automatically generated from [io.vertx.sqlclient.Pool] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use getConnection returning a future and chain with await()", replaceWith = ReplaceWith("getConnection().await()"))
+@Deprecated(message = "Instead use getConnection returning a future and chain with coAwait()", replaceWith = ReplaceWith("getConnection().coAwait()"))
 suspend fun Pool.getConnectionAwait(): SqlConnection {
   return awaitResult {
     this.getConnection(it)
@@ -44,7 +44,7 @@ suspend fun Pool.getConnectionAwait(): SqlConnection {
  *
  * NOTE: This function has been automatically generated from [io.vertx.sqlclient.Pool] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use withTransaction returning a future and chain with await()", replaceWith = ReplaceWith("withTransaction(function).await()"))
+@Deprecated(message = "Instead use withTransaction returning a future and chain with coAwait()", replaceWith = ReplaceWith("withTransaction(function).coAwait()"))
 suspend fun <T> Pool.withTransactionAwait(function: (SqlConnection) -> Future<T?>): T? {
   return awaitResult {
     this.withTransaction(function, it::handle)
@@ -60,7 +60,7 @@ suspend fun <T> Pool.withTransactionAwait(function: (SqlConnection) -> Future<T?
  *
  * NOTE: This function has been automatically generated from [io.vertx.sqlclient.Pool] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use withTransaction returning a future and chain with await()", replaceWith = ReplaceWith("withTransaction(txPropagation, function).await()"))
+@Deprecated(message = "Instead use withTransaction returning a future and chain with coAwait()", replaceWith = ReplaceWith("withTransaction(txPropagation, function).coAwait()"))
 suspend fun <T> Pool.withTransactionAwait(txPropagation: TransactionPropagation, function: (SqlConnection) -> Future<T?>): T? {
   return awaitResult {
     this.withTransaction(txPropagation, function, it::handle)
@@ -75,7 +75,7 @@ suspend fun <T> Pool.withTransactionAwait(txPropagation: TransactionPropagation,
  *
  * NOTE: This function has been automatically generated from [io.vertx.sqlclient.Pool] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use withConnection returning a future and chain with await()", replaceWith = ReplaceWith("withConnection(function).await()"))
+@Deprecated(message = "Instead use withConnection returning a future and chain with coAwait()", replaceWith = ReplaceWith("withConnection(function).coAwait()"))
 suspend fun <T> Pool.withConnectionAwait(function: (SqlConnection) -> Future<T?>): T? {
   return awaitResult {
     this.withConnection(function, it::handle)
@@ -88,7 +88,7 @@ suspend fun <T> Pool.withConnectionAwait(function: (SqlConnection) -> Future<T?>
  *
  * NOTE: This function has been automatically generated from [io.vertx.sqlclient.Pool] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use close returning a future and chain with await()", replaceWith = ReplaceWith("close().await()"))
+@Deprecated(message = "Instead use close returning a future and chain with coAwait()", replaceWith = ReplaceWith("close().coAwait()"))
 suspend fun Pool.closeAwait(): Unit {
   return awaitResult {
     this.close(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/sqlclient/PreparedQuery.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/sqlclient/PreparedQuery.kt
@@ -26,7 +26,7 @@ import io.vertx.sqlclient.Tuple
  *
  * NOTE: This function has been automatically generated from [io.vertx.sqlclient.PreparedQuery] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use execute returning a future and chain with await()", replaceWith = ReplaceWith("execute().await()"))
+@Deprecated(message = "Instead use execute returning a future and chain with coAwait()", replaceWith = ReplaceWith("execute().coAwait()"))
 suspend fun <T> PreparedQuery<T>.executeAwait(): T {
   return awaitResult {
     this.execute(it)
@@ -41,7 +41,7 @@ suspend fun <T> PreparedQuery<T>.executeAwait(): T {
  *
  * NOTE: This function has been automatically generated from [io.vertx.sqlclient.PreparedQuery] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use execute returning a future and chain with await()", replaceWith = ReplaceWith("execute(tuple).await()"))
+@Deprecated(message = "Instead use execute returning a future and chain with coAwait()", replaceWith = ReplaceWith("execute(tuple).coAwait()"))
 suspend fun <T> PreparedQuery<T>.executeAwait(tuple: Tuple): T {
   return awaitResult {
     this.execute(tuple, it)
@@ -56,7 +56,7 @@ suspend fun <T> PreparedQuery<T>.executeAwait(tuple: Tuple): T {
  *
  * NOTE: This function has been automatically generated from [io.vertx.sqlclient.PreparedQuery] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use executeBatch returning a future and chain with await()", replaceWith = ReplaceWith("executeBatch(batch).await()"))
+@Deprecated(message = "Instead use executeBatch returning a future and chain with coAwait()", replaceWith = ReplaceWith("executeBatch(batch).coAwait()"))
 suspend fun <T> PreparedQuery<T>.executeBatchAwait(batch: List<Tuple>): T {
   return awaitResult {
     this.executeBatch(batch, it)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/sqlclient/PreparedStatement.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/sqlclient/PreparedStatement.kt
@@ -24,7 +24,7 @@ import io.vertx.sqlclient.PreparedStatement
  *
  * NOTE: This function has been automatically generated from [io.vertx.sqlclient.PreparedStatement] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use close returning a future and chain with await()", replaceWith = ReplaceWith("close().await()"))
+@Deprecated(message = "Instead use close returning a future and chain with coAwait()", replaceWith = ReplaceWith("close().coAwait()"))
 suspend fun PreparedStatement.closeAwait(): Unit {
   return awaitResult {
     this.close(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/sqlclient/Query.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/sqlclient/Query.kt
@@ -25,7 +25,7 @@ import io.vertx.sqlclient.Query
  *
  * NOTE: This function has been automatically generated from [io.vertx.sqlclient.Query] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use execute returning a future and chain with await()", replaceWith = ReplaceWith("execute().await()"))
+@Deprecated(message = "Instead use execute returning a future and chain with coAwait()", replaceWith = ReplaceWith("execute().coAwait()"))
 suspend fun <T> Query<T>.executeAwait(): T {
   return awaitResult {
     this.execute(it)

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/sqlclient/RowStream.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/sqlclient/RowStream.kt
@@ -26,7 +26,7 @@ import io.vertx.sqlclient.RowStream
  *
  * NOTE: This function has been automatically generated from [io.vertx.sqlclient.RowStream] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use pipeTo returning a future and chain with await()", replaceWith = ReplaceWith("pipeTo(dst).await()"))
+@Deprecated(message = "Instead use pipeTo returning a future and chain with coAwait()", replaceWith = ReplaceWith("pipeTo(dst).coAwait()"))
 suspend fun <T> RowStream<T>.pipeToAwait(dst: WriteStream<T>): Unit {
   return awaitResult {
     this.pipeTo(dst, io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -39,7 +39,7 @@ suspend fun <T> RowStream<T>.pipeToAwait(dst: WriteStream<T>): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.sqlclient.RowStream] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use close returning a future and chain with await()", replaceWith = ReplaceWith("close().await()"))
+@Deprecated(message = "Instead use close returning a future and chain with coAwait()", replaceWith = ReplaceWith("close().coAwait()"))
 suspend fun <T> RowStream<T>.closeAwait(): Unit {
   return awaitResult {
     this.close(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/sqlclient/SqlClient.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/sqlclient/SqlClient.kt
@@ -24,7 +24,7 @@ import io.vertx.sqlclient.SqlClient
  *
  * NOTE: This function has been automatically generated from [io.vertx.sqlclient.SqlClient] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use close returning a future and chain with await()", replaceWith = ReplaceWith("close().await()"))
+@Deprecated(message = "Instead use close returning a future and chain with coAwait()", replaceWith = ReplaceWith("close().coAwait()"))
 suspend fun SqlClient.closeAwait(): Unit {
   return awaitResult {
     this.close(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/sqlclient/SqlConnection.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/sqlclient/SqlConnection.kt
@@ -29,7 +29,7 @@ import io.vertx.sqlclient.Transaction
  *
  * NOTE: This function has been automatically generated from [io.vertx.sqlclient.SqlConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use prepare returning a future and chain with await()", replaceWith = ReplaceWith("prepare(sql).await()"))
+@Deprecated(message = "Instead use prepare returning a future and chain with coAwait()", replaceWith = ReplaceWith("prepare(sql).coAwait()"))
 suspend fun SqlConnection.prepareAwait(sql: String): PreparedStatement {
   return awaitResult {
     this.prepare(sql, it)
@@ -45,7 +45,7 @@ suspend fun SqlConnection.prepareAwait(sql: String): PreparedStatement {
  *
  * NOTE: This function has been automatically generated from [io.vertx.sqlclient.SqlConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use prepare returning a future and chain with await()", replaceWith = ReplaceWith("prepare(sql, options).await()"))
+@Deprecated(message = "Instead use prepare returning a future and chain with coAwait()", replaceWith = ReplaceWith("prepare(sql, options).coAwait()"))
 suspend fun SqlConnection.prepareAwait(sql: String, options: PrepareOptions): PreparedStatement {
   return awaitResult {
     this.prepare(sql, options, it)
@@ -59,7 +59,7 @@ suspend fun SqlConnection.prepareAwait(sql: String, options: PrepareOptions): Pr
  *
  * NOTE: This function has been automatically generated from [io.vertx.sqlclient.SqlConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use begin returning a future and chain with await()", replaceWith = ReplaceWith("begin().await()"))
+@Deprecated(message = "Instead use begin returning a future and chain with coAwait()", replaceWith = ReplaceWith("begin().coAwait()"))
 suspend fun SqlConnection.beginAwait(): Transaction {
   return awaitResult {
     this.begin(it)
@@ -72,7 +72,7 @@ suspend fun SqlConnection.beginAwait(): Transaction {
  *
  * NOTE: This function has been automatically generated from [io.vertx.sqlclient.SqlConnection] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use close returning a future and chain with await()", replaceWith = ReplaceWith("close().await()"))
+@Deprecated(message = "Instead use close returning a future and chain with coAwait()", replaceWith = ReplaceWith("close().coAwait()"))
 suspend fun SqlConnection.closeAwait(): Unit {
   return awaitResult {
     this.close(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/sqlclient/Transaction.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/sqlclient/Transaction.kt
@@ -24,7 +24,7 @@ import io.vertx.sqlclient.Transaction
  *
  * NOTE: This function has been automatically generated from [io.vertx.sqlclient.Transaction] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use commit returning a future and chain with await()", replaceWith = ReplaceWith("commit().await()"))
+@Deprecated(message = "Instead use commit returning a future and chain with coAwait()", replaceWith = ReplaceWith("commit().coAwait()"))
 suspend fun Transaction.commitAwait(): Unit {
   return awaitResult {
     this.commit(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -37,7 +37,7 @@ suspend fun Transaction.commitAwait(): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.sqlclient.Transaction] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use rollback returning a future and chain with await()", replaceWith = ReplaceWith("rollback().await()"))
+@Deprecated(message = "Instead use rollback returning a future and chain with coAwait()", replaceWith = ReplaceWith("rollback().coAwait()"))
 suspend fun Transaction.rollbackAwait(): Unit {
   return awaitResult {
     this.rollback(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })
@@ -50,7 +50,7 @@ suspend fun Transaction.rollbackAwait(): Unit {
  *
  * NOTE: This function has been automatically generated from [io.vertx.sqlclient.Transaction] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use completion returning a future and chain with await()", replaceWith = ReplaceWith("completion().await()"))
+@Deprecated(message = "Instead use completion returning a future and chain with coAwait()", replaceWith = ReplaceWith("completion().coAwait()"))
 suspend fun Transaction.completionAwait(): Unit {
   return awaitResult {
     this.completion(io.vertx.core.Handler { ar -> it.handle(ar.mapEmpty()) })

--- a/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/sqlclient/templates/SqlTemplate.kt
+++ b/vertx-lang-kotlin/src/main/kotlin/io/vertx/kotlin/sqlclient/templates/SqlTemplate.kt
@@ -26,7 +26,7 @@ import io.vertx.sqlclient.templates.SqlTemplate
  *
  * NOTE: This function has been automatically generated from [io.vertx.sqlclient.templates.SqlTemplate] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use execute returning a future and chain with await()", replaceWith = ReplaceWith("execute(parameters).await()"))
+@Deprecated(message = "Instead use execute returning a future and chain with coAwait()", replaceWith = ReplaceWith("execute(parameters).coAwait()"))
 suspend fun <I,R> SqlTemplate<I,R>.executeAwait(parameters: I): R {
   return awaitResult {
     this.execute(parameters, it)
@@ -41,7 +41,7 @@ suspend fun <I,R> SqlTemplate<I,R>.executeAwait(parameters: I): R {
  *
  * NOTE: This function has been automatically generated from [io.vertx.sqlclient.templates.SqlTemplate] using Vert.x codegen.
  */
-@Deprecated(message = "Instead use executeBatch returning a future and chain with await()", replaceWith = ReplaceWith("executeBatch(batch).await()"))
+@Deprecated(message = "Instead use executeBatch returning a future and chain with coAwait()", replaceWith = ReplaceWith("executeBatch(batch).coAwait()"))
 suspend fun <I,R> SqlTemplate<I,R>.executeBatchAwait(batch: List<I>): R {
   return awaitResult {
     this.executeBatch(batch, it)


### PR DESCRIPTION
Motivation:

The `Future.await` extension method has been deprecated and replaced by `coAwait` due to conflicts with Vert.x 5 `Future.await`. The Vert.x 4.x generates await extension methods which are deprecated, however the replacement still points to `Future.await`.

Changes:

Update the generated extension await methods to be replaced by `coAwait` instead of `await`.
