### PR TITLE
Remove Future.await extension method

### DIFF
--- a/vertx-lang-kotlin-coroutines/src/main/java/io/vertx/kotlin/coroutines/VertxCoroutine.kt
+++ b/vertx-lang-kotlin-coroutines/src/main/java/io/vertx/kotlin/coroutines/VertxCoroutine.kt
@@ -123,22 +123,6 @@ suspend fun <T> awaitBlocking(block: () -> T): T {
 /**
  * Awaits the completion of a future without blocking the event loop.
  */
-@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
-@Deprecated("As of 4.5, deprecated in favor of coAwait()", ReplaceWith("coAwait()"))
-suspend fun <T> Future<T>.await(): T = when {
-  succeeded() -> result()
-  failed() -> throw cause()
-  else -> suspendCancellableCoroutine { cont: CancellableContinuation<T> ->
-    onComplete { asyncResult ->
-      if (asyncResult.succeeded()) cont.resume(asyncResult.result() as T)
-      else cont.resumeWithException(asyncResult.cause())
-    }
-  }
-}
-
-/**
- * Awaits the completion of a future without blocking the event loop.
- */
 suspend fun <T> Future<T>.coAwait(): T = when {
   succeeded() -> result()
   failed() -> throw cause()


### PR DESCRIPTION
This method has been replaced with `Future.coAwait` since Vert.x core introduce a Java method with the same name in 4.5.