### PR TITLE
Upgrade to Kotlin 2.3.0

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -3,7 +3,7 @@
 image:https://github.com/vert-x3/vertx-lang-kotlin/actions/workflows/ci-5.x.yml/badge.svg["Build Status (5.x)",link="https://github.com/vert-x3/vertx-lang-kotlin/actions/workflows/ci-5.x.yml"]
 image:https://github.com/vert-x3/vertx-lang-kotlin/actions/workflows/ci-4.x.yml/badge.svg["Build Status (4.x)",link="https://github.com/vert-x3/vertx-lang-kotlin/actions/workflows/ci-4.x.yml"]
 image:https://img.shields.io/badge/license-Apache%20License%202.0-blue.svg?style=flat["GitHub license",link="http://www.apache.org/licenses/LICENSE-2.0"]
-image:https://img.shields.io/badge/kotlin-2.2.20-blue.svg["Kotlin version badge",link="https://kotlinlang.org"]
+image:https://img.shields.io/badge/kotlin-2.3.0-blue.svg["Kotlin version badge",link="https://kotlinlang.org"]
 image:https://img.shields.io/badge/kotlinx.coroutines-1.10.2-blue.svg["Coroutines version badge",link="https://github.com/Kotlin/kotlinx.coroutines#kotlinxcoroutines"]
 
 This is the repository for http://kotlinlang.org[Kotlin] language support for http://vertx.io/docs[Vert.x].

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <kotlin.coroutines.version>1.10.2</kotlin.coroutines.version>
-    <kotlin.version>2.2.20</kotlin.version>
+    <kotlin.version>2.3.0</kotlin.version>
     <junit.version>4.13.2</junit.version>
   </properties>
 


### PR DESCRIPTION
https://github.com/JetBrains/kotlin/releases/tag/v2.3.0

Latest stable release, that is compatible with Java 25