### PR TITLE
Remove Handlebars template engine from Kotlin gen

### DIFF
--- a/vertx-lang-kotlin/pom.xml
+++ b/vertx-lang-kotlin/pom.xml
@@ -146,11 +146,6 @@
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
-      <artifactId>vertx-web-templ-handlebars</artifactId>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
-      <groupId>io.vertx</groupId>
       <artifactId>vertx-web-templ-pug</artifactId>
       <optional>true</optional>
     </dependency>
@@ -438,7 +433,6 @@
             vertx-web-client,
             vertx-web,
             vertx-web-templ-freemarker,
-            vertx-web-templ-handlebars,
             vertx-web-templ-pug,
             vertx-web-templ-mvel,
             vertx-web-templ-pebble,


### PR DESCRIPTION
Similar to https://github.com/vert-x3/vertx-lang-kotlin/pull/278

After 5.1, vertx-web-templ-handlebars requires JDK17+ at runtime

The problem is that Kotlin Maven plugin:

- does not support Maven toolchains
- cannot be configured to disable classpath lookup for annotation processors

https://youtrack.jetbrains.com/issue/KT-79897/Maven-test-kapt-goal-does-not-respect-JDK-specified-by-maven-toolchains-plugin

https://youtrack.jetbrains.com/issue/KT-32743/Kapt-Maven-Do-not-include-compile-classpath-entries-in-the-annotation-processing-classpath